### PR TITLE
Add I2C bus drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ idf_component_register(
         DigitalOutput.cpp
         Esp32C6Adc.cpp
         FlexCan.cpp
+        I2cBus.cpp
         SfSpiBus.cpp
+        SfI2cBus.cpp
         SpiBus.cpp
     INCLUDE_DIRS "include"
 )

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ underlying RTOS implementation.
 
 ## Contents
 - Internal interface driver implementations located in the parent
-  directory (`BaseGpio`, `DigitalInput`, `SpiBus` ...).
+  directory (`BaseGpio`, `DigitalInput`, `SpiBus`, `I2cBus` ...).
+- Thread-safe variants such as `SfSpiBus` and `SfI2cBus` which rely on
+  the HF-RTOSW-ESPIDF mutex APIs.
 - Platform dependent utilities from `UTILITIES/common` (e.g.
   `BaseThread`, mutex helpers, timing utilities).
 

--- a/inc/I2cBus.h
+++ b/inc/I2cBus.h
@@ -1,0 +1,98 @@
+/**
+ * @file I2cBus.h
+ * @brief Declaration of the I2cBus class providing basic I2C master access on ESP32-C6.
+ *
+ * This driver wraps the ESP-IDF I2C master APIs and does not implement thread
+ * safety.  It follows the same design as SpiBus.
+ */
+#ifndef I2CBUS_H_
+#define I2CBUS_H_
+
+#include <driver/i2c.h>
+#include <cstdint>
+
+/**
+ * @class I2cBus
+ * @brief Non-thread-safe I2C master bus abstraction for ESP32-C6 (ESP-IDF).
+ */
+class I2cBus {
+public:
+    /**
+     * @brief Construct an I2cBus instance.
+     * @param port I2C port number (e.g. I2C_NUM_0)
+     * @param cfg I2C configuration structure (pins, mode, clock speed)
+     */
+    I2cBus(i2c_port_t port, const i2c_config_t &cfg) noexcept;
+
+    /**
+     * @brief Destructor closes the bus if open.
+     */
+    ~I2cBus() noexcept;
+
+    /**
+     * @brief Open and initialize the I2C port.
+     * @return true if open, false otherwise.
+     */
+    bool Open() noexcept;
+
+    /**
+     * @brief Close and de-initialize the I2C port.
+     * @return true if closed, false otherwise.
+     */
+    bool Close() noexcept;
+
+    /**
+     * @brief Write data to a slave device.
+     * @param addr 7-bit device address
+     * @param data Data buffer to transmit
+     * @param sizeBytes Number of bytes to write
+     * @param timeoutMsec Timeout in milliseconds
+     * @return true if transmission succeeded
+     */
+    bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+               uint32_t timeoutMsec = 1000) noexcept;
+
+    /**
+     * @brief Read data from a slave device.
+     * @param addr 7-bit device address
+     * @param data Buffer to store received data
+     * @param sizeBytes Number of bytes to read
+     * @param timeoutMsec Timeout in milliseconds
+     * @return true if read succeeded
+     */
+    bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+              uint32_t timeoutMsec = 1000) noexcept;
+
+    /**
+     * @brief Write then read from a slave device without releasing the bus.
+     * @param addr 7-bit device address
+     * @param txData Data buffer to send
+     * @param txSizeBytes Number of bytes to send
+     * @param rxData Buffer to store received data
+     * @param rxSizeBytes Number of bytes to read
+     * @param timeoutMsec Timeout in milliseconds
+     * @return true if transaction succeeded
+     */
+    bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
+                   uint8_t *rxData, uint16_t rxSizeBytes,
+                   uint32_t timeoutMsec = 1000) noexcept;
+
+    /**
+     * @brief Get the configured clock speed.
+     * @return Clock speed in Hz
+     */
+    uint32_t GetClockHz() const noexcept;
+
+    /**
+     * @brief Check if the bus is initialized.
+     */
+    bool IsInitialized() const noexcept { return initialized; }
+
+private:
+    i2c_port_t i2cPort;      ///< I2C port
+    i2c_config_t config;     ///< Configuration copy
+    bool initialized;        ///< Initialization flag
+};
+
+#endif // I2CBUS_H_
+

--- a/inc/SfI2cBus.h
+++ b/inc/SfI2cBus.h
@@ -1,0 +1,92 @@
+/**
+ * @file SfI2cBus.h
+ * @brief Thread-safe I2C master driver for ESP32-C6 with software mutex control.
+ *
+ * This class mirrors the SfSpiBus implementation and relies on a FreeRTOS
+ * mutex supplied from the HF-RTOSW-ESPIDF component.
+ */
+#ifndef SFI2CBUS_H_
+#define SFI2CBUS_H_
+
+#include <driver/i2c.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <cstdint>
+
+/**
+ * @class SfI2cBus
+ * @brief Thread-safe I2C master bus abstraction for ESP32-C6.
+ */
+class SfI2cBus {
+public:
+    /**
+     * @brief Construct an SfI2cBus instance.
+     * @param port I2C port number
+     * @param cfg I2C configuration structure
+     * @param mutexHandle Mutex used for locking during transfers
+     */
+    SfI2cBus(i2c_port_t port, const i2c_config_t &cfg, SemaphoreHandle_t mutexHandle) noexcept;
+
+    /**
+     * @brief Destructor closes the bus.
+     */
+    ~SfI2cBus() noexcept;
+
+    /**
+     * @brief Open and initialize the I2C port.
+     */
+    bool Open() noexcept;
+
+    /**
+     * @brief Close and de-initialize the I2C port.
+     */
+    bool Close() noexcept;
+
+    /**
+     * @brief Write to a device in a thread-safe manner.
+     */
+    bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+               uint32_t timeoutMsec) noexcept;
+
+    /**
+     * @brief Read from a device in a thread-safe manner.
+     */
+    bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+              uint32_t timeoutMsec) noexcept;
+
+    /**
+     * @brief Combined write then read operation.
+     */
+    bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
+                   uint8_t *rxData, uint16_t rxSizeBytes,
+                   uint32_t timeoutMsec) noexcept;
+
+    /**
+     * @brief Lock the bus for exclusive access.
+     */
+    bool LockBus(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
+
+    /**
+     * @brief Unlock the bus.
+     */
+    bool UnlockBus() noexcept;
+
+    /**
+     * @brief Get the clock speed in Hz.
+     */
+    uint32_t GetClockHz() const noexcept;
+
+    /**
+     * @brief Check initialization state.
+     */
+    bool IsInitialized() const noexcept { return initialized; }
+
+private:
+    i2c_port_t i2cPort;      ///< Port number
+    i2c_config_t config;     ///< Configuration copy
+    SemaphoreHandle_t busMutex; ///< Mutex for thread safety
+    bool initialized;        ///< Flag
+};
+
+#endif // SFI2CBUS_H_
+

--- a/src/I2cBus.cpp
+++ b/src/I2cBus.cpp
@@ -1,0 +1,78 @@
+/**
+ * @file I2cBus.cpp
+ * @brief Implementation of the I2cBus class for ESP32-C6.
+ */
+
+#include "I2cBus.h"
+#include <esp_log.h>
+
+static const char *TAG = "I2cBus";
+
+I2cBus::I2cBus(i2c_port_t port, const i2c_config_t &cfg) noexcept
+    : i2cPort(port), config(cfg), initialized(false) {}
+
+I2cBus::~I2cBus() noexcept {
+    if (initialized) {
+        Close();
+    }
+}
+
+bool I2cBus::Open() noexcept {
+    if (initialized)
+        return true;
+
+    esp_err_t ret = i2c_param_config(i2cPort, &config);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "param_config failed: %d", ret);
+        return false;
+    }
+    ret = i2c_driver_install(i2cPort, config.mode, 0, 0, 0);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "driver_install failed: %d", ret);
+        return false;
+    }
+    initialized = true;
+    return true;
+}
+
+bool I2cBus::Close() noexcept {
+    if (!initialized)
+        return true;
+    i2c_driver_delete(i2cPort);
+    initialized = false;
+    return true;
+}
+
+bool I2cBus::Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+                   uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    esp_err_t ret = i2c_master_write_to_device(
+        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
+    return ret == ESP_OK;
+}
+
+bool I2cBus::Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+                  uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    esp_err_t ret = i2c_master_read_from_device(
+        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
+    return ret == ESP_OK;
+}
+
+bool I2cBus::WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
+                       uint8_t *rxData, uint16_t rxSizeBytes,
+                       uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    esp_err_t ret = i2c_master_write_read_device(
+        i2cPort, addr, txData, txSizeBytes, rxData, rxSizeBytes,
+        pdMS_TO_TICKS(timeoutMsec));
+    return ret == ESP_OK;
+}
+
+uint32_t I2cBus::GetClockHz() const noexcept {
+    return config.master.clk_speed;
+}
+

--- a/src/SfI2cBus.cpp
+++ b/src/SfI2cBus.cpp
@@ -1,0 +1,98 @@
+/**
+ * @file SfI2cBus.cpp
+ * @brief Implementation of the SfI2cBus class.
+ */
+
+#include "SfI2cBus.h"
+#include <esp_log.h>
+
+static const char *TAG = "SfI2cBus";
+
+SfI2cBus::SfI2cBus(i2c_port_t port, const i2c_config_t &cfg, SemaphoreHandle_t mutexHandle) noexcept
+    : i2cPort(port), config(cfg), busMutex(mutexHandle), initialized(false) {}
+
+SfI2cBus::~SfI2cBus() noexcept {
+    if (initialized) {
+        Close();
+    }
+}
+
+bool SfI2cBus::Open() noexcept {
+    if (initialized)
+        return true;
+    esp_err_t ret = i2c_param_config(i2cPort, &config);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "param_config failed: %d", ret);
+        return false;
+    }
+    ret = i2c_driver_install(i2cPort, config.mode, 0, 0, 0);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "driver_install failed: %d", ret);
+        return false;
+    }
+    initialized = true;
+    return true;
+}
+
+bool SfI2cBus::Close() noexcept {
+    if (!initialized)
+        return true;
+    i2c_driver_delete(i2cPort);
+    initialized = false;
+    return true;
+}
+
+bool SfI2cBus::Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+                     uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+        return false;
+    esp_err_t ret = i2c_master_write_to_device(
+        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
+    xSemaphoreGive(busMutex);
+    return ret == ESP_OK;
+}
+
+bool SfI2cBus::Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+                    uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+        return false;
+    esp_err_t ret = i2c_master_read_from_device(
+        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
+    xSemaphoreGive(busMutex);
+    return ret == ESP_OK;
+}
+
+bool SfI2cBus::WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
+                         uint8_t *rxData, uint16_t rxSizeBytes,
+                         uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+        return false;
+    esp_err_t ret = i2c_master_write_read_device(
+        i2cPort, addr, txData, txSizeBytes, rxData, rxSizeBytes,
+        pdMS_TO_TICKS(timeoutMsec));
+    xSemaphoreGive(busMutex);
+    return ret == ESP_OK;
+}
+
+bool SfI2cBus::LockBus(uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    return xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE;
+}
+
+bool SfI2cBus::UnlockBus() noexcept {
+    if (!initialized)
+        return false;
+    return xSemaphoreGive(busMutex) == pdTRUE;
+}
+
+uint32_t SfI2cBus::GetClockHz() const noexcept {
+    return config.master.clk_speed;
+}
+


### PR DESCRIPTION
## Summary
- implement `I2cBus` for ESP-IDF I2C master access
- add thread-safe `SfI2cBus` using FreeRTOS mutexes provided by HF‑RTOSW‑ESPIDF
- update component build to compile new sources
- document new drivers in README