### PR TITLE
Fix includes and add ESP-IDF component manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 idf_component_register(
     SRCS
-        BaseGpio.cpp
-        DigitalExternalIRQ.cpp
-        DigitalGpio.cpp
-        DigitalInput.cpp
-        DigitalOutput.cpp
-        Esp32C6Adc.cpp
-        FlexCan.cpp
-        I2cBus.cpp
-        SfSpiBus.cpp
-        SfI2cBus.cpp
-        SpiBus.cpp
-    INCLUDE_DIRS "include"
+        src/BaseGpio.cpp
+        src/DigitalExternalIRQ.cpp
+        src/DigitalGpio.cpp
+        src/DigitalInput.cpp
+        src/DigitalOutput.cpp
+        src/Esp32C6Adc.cpp
+        src/FlexCan.cpp
+        src/I2cBus.cpp
+        src/SfSpiBus.cpp
+        src/SfI2cBus.cpp
+        src/SpiBus.cpp
+    INCLUDE_DIRS "inc"
 )

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,4 @@
+version: "0.1.0"
+description: "HardFOC Internal Interface Drivers for ESP-IDF"
+dependencies:
+  idf: "*"

--- a/inc/DigitalExternalIRQ.h
+++ b/inc/DigitalExternalIRQ.h
@@ -10,7 +10,7 @@
 #ifndef DIGITALEXTERNALIRQ_H
 #define DIGITALEXTERNALIRQ_H
 
-#include <internal_interface_drivers/DigitalInput.h>
+#include "DigitalInput.h"
 #include <driver/gpio.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>

--- a/inc/DigitalGpio.h
+++ b/inc/DigitalGpio.h
@@ -10,7 +10,7 @@
 #ifndef DIGITALGPIO_H
 #define DIGITALGPIO_H
 
-#include <internal_interface_drivers/BaseGpio.h>
+#include "BaseGpio.h"
 #include "driver/gpio.h"
 
 /**

--- a/inc/DigitalInput.h
+++ b/inc/DigitalInput.h
@@ -11,7 +11,7 @@
 #ifndef DIGITALINPUT_H
 #define DIGITALINPUT_H
 
-#include <internal_interface_drivers/DigitalGpio.h>
+#include "DigitalGpio.h"
 #include "driver/gpio.h"
 
 /**

--- a/inc/DigitalOutput.h
+++ b/inc/DigitalOutput.h
@@ -10,7 +10,7 @@
 #ifndef DIGITALOUTPUT_H
 #define DIGITALOUTPUT_H
 
-#include <internal_interface_drivers/DigitalGpio.h>
+#include "DigitalGpio.h"
 #include "driver/gpio.h"
 #include <string>
 

--- a/inc/Esp32C6Adc.h
+++ b/inc/Esp32C6Adc.h
@@ -9,7 +9,7 @@
 #ifndef HAL_INTERNAL_INTERFACE_DRIVERS_ESP32C6ADC_H_
 #define HAL_INTERNAL_INTERFACE_DRIVERS_ESP32C6ADC_H_
 
-#include <internal_interface_drivers/BaseAdc.h>
+#include "BaseAdc.h"
 #include "driver/adc.h"
 #include <cstdint>
 

--- a/src/BaseGpio.cpp
+++ b/src/BaseGpio.cpp
@@ -13,7 +13,7 @@
 // </summary>
 // -----------------------------------------------------------------------
 
-#include <internal_interface_drivers/BaseGpio.h>
+#include "BaseGpio.h"
 
 /**
  * @file BaseGpio.cpp

--- a/src/DigitalExternalIRQ.cpp
+++ b/src/DigitalExternalIRQ.cpp
@@ -1,4 +1,4 @@
-#include <internal_interface_drivers/DigitalExternalIRQ.h>
+#include "DigitalExternalIRQ.h"
 #include <driver/gpio.h>
 #include <esp_err.h>
 

--- a/src/DigitalGpio.cpp
+++ b/src/DigitalGpio.cpp
@@ -7,7 +7,7 @@
  * @note This implementation is intended for use with ESP-IDF. Pin configuration is expected
  *       to be handled by derived classes or via the PinCfg/gpio_config_esp32c6.hpp utilities.
  */
-#include <internal_interface_drivers/DigitalGpio.h>
+#include "DigitalGpio.h"
 #include "driver/gpio.h"
 
 const char* DigitalGpio::ToString(Mode mode) noexcept {

--- a/src/DigitalInput.cpp
+++ b/src/DigitalInput.cpp
@@ -12,7 +12,7 @@
 //     they are initialized the first time a pin in manipulated.
 // </summary>
 // -----------------------------------------------------------------------
-#include <internal_interface_drivers/DigitalInput.h>
+#include "DigitalInput.h"
 #include "driver/gpio.h"
 
 ///----------------------------------------------------------------

--- a/src/DigitalOutput.cpp
+++ b/src/DigitalOutput.cpp
@@ -6,7 +6,7 @@
  *
  * @note This implementation is intended for use with ESP-IDF. Pin configuration is handled via gpio_config().
  */
-#include <internal_interface_drivers/DigitalOutput.h>
+#include "DigitalOutput.h"
 #include "driver/gpio.h"
 
 DigitalOutput::DigitalOutput(gpio_num_t pinArg, ActiveState activeStateArg, State initialStateArg) noexcept :

--- a/src/DigitalOutputGuard.cpp
+++ b/src/DigitalOutputGuard.cpp
@@ -12,10 +12,10 @@
  * in its constructor and inactive in its destructor (RAII pattern).
  */
 
-#include "UTILITIES/common/DigitalOutputGuard.h"
+#include "DigitalOutputGuard.h"
 #include "UTILITIES/common/ThingsToString.h"
 
-#include "HAL/internal_interface_drivers/DigitalOutput.h"
+#include "DigitalOutput.h"
 #include "HAL/component_handlers/ConsolePort.h"
 
 //==============================================================//

--- a/src/Esp32C6Adc.cpp
+++ b/src/Esp32C6Adc.cpp
@@ -6,7 +6,7 @@
  *
  * @note This implementation is intended for use with ESP-IDF. Pin configuration is handled via gpio_config().
  */
-#include <internal_interface_drivers/Esp32C6Adc.h>
+#include "Esp32C6Adc.h"
 #include "driver/adc.h"
 #include "esp_adc_cal.h"
 #include <unistd.h>


### PR DESCRIPTION
## Summary
- fix include paths to use local headers
- update CMakeLists to use `src` and `inc` directories
- add `idf_component.yml` to mark repo as an ESP‑IDF component
