### PR TITLE
Add docs suite and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,16 @@
 # HF-IID-ESPIDF
-Internal Interface Drivers - wrappers for the espidf to be used in the HardFOC controller
 
-# IID-ESPIDF
+**HF-IID-ESPIDF** provides internal interface drivers and utilities for ESP-IDF targets used by the HardFOC controller.
 
-This component bundles the internal interface drivers and platform
-specific utilities used by the HardFOC project.
+## ✨ Features
 
-The drivers provide low level access to GPIO, ADC and bus interfaces for
-ESP-IDF targets.  Utility code such as the base thread framework and the
-ThreadX compatibility layer are also included here as they depend on the
-underlying RTOS implementation.
+- GPIO, SPI and I2C abstractions
+- Thread-safe bus drivers
+- Platform utilities including base threading and mutex helpers
 
-## Contents
-- Internal interface driver implementations located in the parent
-  directory (`BaseGpio`, `DigitalInput`, `SpiBus`, `I2cBus` ...).
-- Thread-safe variants such as `SfSpiBus` and `SfI2cBus` which rely on
-  the HF-RTOSW-ESPIDF mutex APIs.
-- Platform dependent utilities from `UTILITIES/common` (e.g.
-  `BaseThread`, mutex helpers, timing utilities).
+## 📦 Installation
 
-## Usage
-Add `iid-espidf` to your component requirements.  The component exports
-the include directories for both the driver headers and the utilities.
-It depends on the `hal` component and requires FreeRTOS.
+Add `iid-espidf` as a dependency in your component configuration:
 
 ```cmake
 idf_component_register(
@@ -30,6 +18,23 @@ idf_component_register(
 )
 ```
 
-## License
-This project is licensed under the GNU General Public License v3.0 or
-later.
+The component exports the required include directories and depends on FreeRTOS.
+
+## 🚀 Usage
+
+Include the headers you need and initialize the drivers as shown in the documentation. Example:
+
+```cpp
+#include "DigitalOutput.h"
+DigitalOutput led(GPIO_NUM_2);
+led.init();
+led.set(true);
+```
+
+## 📖 Documentation
+
+Extensive documentation is available in the [docs](docs/index.md) folder.
+
+## 📝 License
+
+This project is licensed under the GNU General Public License v3.0 or later.

--- a/docs/buses.md
+++ b/docs/buses.md
@@ -1,0 +1,21 @@
+[⬅️ Prev](gpio.md) | [🔙 Index](index.md) | [Next ➡️](utilities.md)
+
+# 📡 Bus Interfaces
+
+HF-IID-ESPIDF contains drivers for common communication buses on ESP32 targets.
+
+## SPI Bus
+
+`SpiBus` provides master mode communication. A thread-safe version `SfSpiBus` is available when used with the HF-RTOSW mutex APIs.
+
+## I2C Bus
+
+The `I2cBus` class exposes standard master transactions. Use `SfI2cBus` for thread-safe access in multi-tasking environments.
+
+```cpp
+#include "SfI2cBus.h"
+SfI2cBus bus(I2C_NUM_0);
+bus.init();
+```
+
+[⬅️ Prev](gpio.md) | [🔙 Index](index.md) | [Next ➡️](utilities.md)

--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -1,0 +1,25 @@
+[⬅️ Back to Index](index.md) | [Next ➡️](buses.md)
+
+# 🔌 GPIO Basics
+
+This section covers the general purpose I/O abstractions provided by HF-IID-ESPIDF.
+
+## Overview
+
+The drivers wrap ESP-IDF GPIO functionality, providing a clean object-oriented interface for digital inputs and outputs. Lazy initialization keeps resource usage minimal until the pin is needed.
+
+- **BaseGpio** – common functionality for GPIO pins.
+- **DigitalInput / DigitalOutput** – simple input/output helpers.
+- **DigitalExternalIRQ** – configure interrupts on GPIO pins.
+
+## Usage Tips
+
+```cpp
+#include "DigitalOutput.h"
+
+DigitalOutput led(GPIO_NUM_2);
+led.init();
+led.set(true);
+```
+
+[⬅️ Back to Index](index.md) | [Next ➡️](buses.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# 📚 HF-IID-ESPIDF Documentation Index
+
+Welcome to the documentation suite for **HF-IID-ESPIDF** – a collection of drivers and utilities for ESP-IDF targets used by the HardFOC project.
+
+## Table of Contents
+
+- [🔌 GPIO Basics](gpio.md)
+- [📡 Bus Interfaces](buses.md)
+- [🛠️ Utilities](utilities.md)
+- [🧵 Threading Concepts](threads.md)
+
+Navigate through the sections using the links above. Each page contains navigation links for easy browsing.

--- a/docs/threads.md
+++ b/docs/threads.md
@@ -1,0 +1,15 @@
+[⬅️ Prev](utilities.md) | [🔙 Index](index.md) | [Next ➡️](index.md)
+
+# 🧵 Threading Concepts
+
+HF-IID-ESPIDF optionally integrates with FreeRTOS to provide lightweight thread wrappers and synchronization utilities.
+
+## BaseThread
+
+`BaseThread` offers a simple interface for creating tasks that integrate with HardFOC components.
+
+## Mutex Guards
+
+Utilities ensure safe access to shared resources when using the thread-safe bus drivers.
+
+[⬅️ Prev](utilities.md) | [🔙 Index](index.md) | [Next ➡️](index.md)

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1,0 +1,13 @@
+[⬅️ Prev](buses.md) | [🔙 Index](index.md) | [Next ➡️](threads.md)
+
+# 🛠️ Utilities
+
+A selection of helper classes simplifies timing, mutex management and other chores when working with ESP-IDF.
+
+- **BaseThread** – abstract thread wrapper used by HardFOC.
+- **Mutex Helpers** – RAII wrappers for thread safety.
+- **Timing Utilities** – delay and time measurement helpers.
+
+These utilities are automatically exported when you depend on `iid-espidf` from your component.
+
+[⬅️ Prev](buses.md) | [🔙 Index](index.md) | [Next ➡️](threads.md)


### PR DESCRIPTION
## Summary
- expand the README
- create a new `docs` folder with navigation between pages
- document GPIO, bus interfaces, utilities and threading concepts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846888b6e18832897758a7e8a1a9c44