### PR TITLE
Add navigation and examples to driver docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Internal Interface Drivers - wrappers for the ESP-IDF to be used in the HardFOC controller.
 
+For detailed API guides see [docs/index.md](docs/index.md).
+
 ## IID‑ESPIDF Overview
 
 This component bundles the internal interface drivers and platform specific utilities used by the HardFOC project. The drivers provide low level access to GPIO, ADC and bus interfaces for ESP‑IDF targets. Utility code such as the base thread framework and the ThreadX compatibility layer are also included here as they depend on the underlying RTOS implementation.

--- a/docs/BaseAdc.md
+++ b/docs/BaseAdc.md
@@ -1,0 +1,23 @@
+# BaseAdc Class Guide
+
+Lightweight abstract base class for ADC peripherals. Derived drivers implement `Initialize()` and the channel read functions.
+
+## Features ✨
+- Lazy initialization via `EnsureInitialized()`
+- Standardized `AdcErr` codes for error handling
+- Pure virtual methods to read channels in volts or raw counts
+- Designed for easy extension by MCU specific drivers
+
+## Usage Example
+```cpp
+class MyAdc : public BaseAdc {
+    bool Initialize() noexcept override { /* configure hardware */ return true; }
+    AdcErr ReadChannelV(uint8_t ch, float& v, uint8_t n=1, uint32_t t=0) noexcept override { /* read */ }
+    AdcErr ReadChannelCount(uint8_t ch, uint32_t& c, uint8_t n=1, uint32_t t=0) noexcept override { /* read */ }
+    AdcErr ReadChannel(uint8_t ch, uint32_t& c, float& v, uint8_t n=1, uint32_t t=0) noexcept override { /* read */ }
+};
+```
+
+---
+
+[Documentation Index](index.md) | [Next →](Esp32C6Adc.md)

--- a/docs/BaseGpio.md
+++ b/docs/BaseGpio.md
@@ -1,0 +1,20 @@
+# BaseGpio Class Guide
+
+Abstract helper for GPIO based classes. Provides lazy initialization and pin configuration retrieval.
+
+## Key Points
+- Stores the target pin number
+- `EnsureInitialized()` calls protected `Initialize()` implemented by subclasses
+- `GetPin()` returns the ESP‑IDF `gpio_num_t`
+- Used by `DigitalInput`, `DigitalOutput` and `PwmOutput`
+
+## Example Subclass
+```cpp
+class SimpleGpio : public BaseGpio {
+    bool Initialize() noexcept override { /* configure pin */ return true; }
+};
+```
+
+---
+
+[← Previous](Esp32C6Adc.md) | [Documentation Index](index.md) | [Next →](DigitalGpio.md)

--- a/docs/DigitalExternalIRQ.md
+++ b/docs/DigitalExternalIRQ.md
@@ -1,0 +1,21 @@
+# DigitalExternalIRQ Class Guide
+
+Interrupt capable input pin built on `DigitalInput`. Handles enabling, disabling and waiting for a GPIO interrupt using ESP‑IDF.
+
+## Highlights
+- Configurable interrupt type (rising, falling, etc.)
+- Wait for an event with optional timeout
+- Ideal for motion sensors or other GPIO IRQ sources
+
+## Example
+```cpp
+DigitalExternalIRQ irq(GPIO_NUM_13, GPIO_INTR_NEGEDGE);
+irq.Enable();
+if (irq.Wait(1000)) {
+    // interrupt received
+}
+```
+
+---
+
+[← Previous](DigitalOutputGuard.md) | [Documentation Index](index.md) | [Next →](I2cBus.md)

--- a/docs/DigitalGpio.md
+++ b/docs/DigitalGpio.md
@@ -1,0 +1,18 @@
+# DigitalGpio Class Guide
+
+Abstract GPIO helper inherited by most pin classes. Defines enums for mode, state and resistance and converts them to strings.
+
+## Highlights
+- Supports active-high or active-low pins
+- Enumeration helpers for mode, state and pull resistors
+- Designed for extension by `DigitalInput`, `DigitalOutput` and similar classes
+
+## Example
+```cpp
+DigitalOutput led(GPIO_NUM_5, DigitalGpio::ActiveState::High);
+led.SetActive();
+```
+
+---
+
+[← Previous](BaseGpio.md) | [Documentation Index](index.md) | [Next →](DigitalInput.md)

--- a/docs/DigitalInput.md
+++ b/docs/DigitalInput.md
@@ -1,0 +1,21 @@
+# DigitalInput Class Guide
+
+GPIO input wrapper. Extends `DigitalGpio` and configures the pin as an input on demand.
+
+## Features
+- Lazy initialization when first read
+- `IsActive()` helper to check the logical state
+- Optional `GetState()` method to read without translating to active level
+- Ideal for buttons or external interrupt sources
+
+## Example
+```cpp
+DigitalInput button(GPIO_NUM_0, DigitalGpio::ActiveState::Low);
+if (button.IsActive()) {
+    // button pressed
+}
+```
+
+---
+
+[← Previous](DigitalGpio.md) | [Documentation Index](index.md) | [Next →](DigitalOutput.md)

--- a/docs/DigitalOutput.md
+++ b/docs/DigitalOutput.md
@@ -1,0 +1,20 @@
+# DigitalOutput Class Guide
+
+Configurable GPIO output pin. Supports push‑pull or open‑drain modes and provides simple state helpers.
+
+## Capabilities
+- Lazy initialization and optional initial state
+- `SetActive()`, `SetInactive()` and `Toggle()` helpers
+- Query the configured mode with `OutputMode()`
+- Use `IsActive()` to check the logical level
+
+## Example
+```cpp
+DigitalOutput led(GPIO_NUM_2, DigitalGpio::ActiveState::High);
+led.SetActive();       // LED on
+led.Toggle();          // LED off
+```
+
+---
+
+[← Previous](DigitalInput.md) | [Documentation Index](index.md) | [Next →](DigitalOutputGuard.md)

--- a/docs/DigitalOutputGuard.md
+++ b/docs/DigitalOutputGuard.md
@@ -1,0 +1,18 @@
+# DigitalOutputGuard Class Guide
+
+RAII helper that activates a `DigitalOutput` on creation and deactivates it on destruction.
+
+Useful for toggling chip select lines or other temporary enables.
+
+## Example
+```cpp
+{
+    DigitalOutputGuard guard(myOutput);
+    // myOutput is active within this scope
+}
+// automatically inactive here
+```
+
+---
+
+[← Previous](DigitalOutput.md) | [Documentation Index](index.md) | [Next →](DigitalExternalIRQ.md)

--- a/docs/Esp32C6Adc.md
+++ b/docs/Esp32C6Adc.md
@@ -1,0 +1,22 @@
+# Esp32C6Adc Class Guide
+
+Concrete ADC driver built on ESP‑IDF for the ESP32‑C6. Implements `BaseAdc` and exposes simple channel reads in counts or volts.
+
+## Features ✨
+- Configurable ADC unit, attenuation and width
+- Lazy initialization on first use
+- Helper methods to read channels with optional averaging
+- Returns raw counts or converted voltages
+
+## Example
+```cpp
+Esp32C6Adc adc(ADC_UNIT_1, ADC_ATTEN_DB_11);
+float v;
+if (adc.ReadChannelV(ADC_CHANNEL_0, v) == BaseAdc::AdcErr::ADC_SUCCESS) {
+    // use voltage value
+}
+```
+
+---
+
+[← Previous](BaseAdc.md) | [Documentation Index](index.md) | [Next →](BaseGpio.md)

--- a/docs/FlexCan.md
+++ b/docs/FlexCan.md
@@ -1,0 +1,20 @@
+# FlexCan Class Guide
+
+Minimal CAN controller abstraction built around the ESP‑IDF TWAI driver.
+
+## Features
+- Simple `Frame` struct for TX/RX
+- Open, close, read and write helpers
+- Suitable for basic CAN communication
+
+## Example
+```cpp
+FlexCan can(0, 500000); // CAN0 at 500 kbit/s
+can.Open();
+FlexCan::Frame f{0x123, {0x01,0x02}, 2, false, false};
+can.Write(f);
+```
+
+---
+
+[← Previous](SfSpiBus.md) | [Documentation Index](index.md) | [Next →](PwmOutput.md)

--- a/docs/I2cBus.md
+++ b/docs/I2cBus.md
@@ -1,0 +1,23 @@
+# I2cBus Class Guide
+
+Non‑thread‑safe I²C master wrapper around ESP‑IDF APIs.
+
+## Features
+- Configurable port and bus parameters
+- Blocking read, write and write‑read helpers
+- Simple `Open()` / `Close()` lifecycle
+
+## Example
+```cpp
+i2c_config_t cfg = {};
+cfg.sda_io_num = 21;
+cfg.scl_io_num = 22;
+I2cBus bus(I2C_NUM_0, cfg);
+bus.Open();
+uint8_t id;
+bus.WriteRead(0x50, &reg, 1, &id, 1);
+```
+
+---
+
+[← Previous](DigitalExternalIRQ.md) | [Documentation Index](index.md) | [Next →](SfI2cBus.md)

--- a/docs/PwmOutput.md
+++ b/docs/PwmOutput.md
@@ -1,0 +1,19 @@
+# PwmOutput Class Guide
+
+Wrapper around the ESP‑IDF LEDC driver for generating PWM on a single pin.
+
+## Features
+- Configurable channel, timer, frequency and resolution
+- `Start()`, `Stop()` and `SetDuty()` helpers
+- Integrates with `DigitalGpio` for active state handling
+
+## Example
+```cpp
+PwmOutput pwm(GPIO_NUM_4, LEDC_CHANNEL_0, LEDC_TIMER_0, 5000, LEDC_TIMER_13_BIT);
+pwm.Start();
+pwm.SetDuty(0.5f);
+```
+
+---
+
+[← Previous](FlexCan.md) | [Documentation Index](index.md)

--- a/docs/SfI2cBus.md
+++ b/docs/SfI2cBus.md
@@ -1,0 +1,22 @@
+# SfI2cBus Class Guide
+
+Thread‑safe I²C master using a FreeRTOS mutex. Mirror of `I2cBus` with locking helpers.
+
+## Benefits
+- Safe access from multiple tasks
+- `LockBus()` and `UnlockBus()` for manual control
+- Identical API to `I2cBus`
+
+## Example
+```cpp
+SemaphoreHandle_t m = xSemaphoreCreateMutex();
+SfI2cBus bus(I2C_NUM_0, cfg, m);
+bus.Open();
+bus.LockBus();
+bus.Write(addr, data, 2, 100);
+bus.UnlockBus();
+```
+
+---
+
+[← Previous](I2cBus.md) | [Documentation Index](index.md) | [Next →](SpiBus.md)

--- a/docs/SfSpiBus.md
+++ b/docs/SfSpiBus.md
@@ -1,0 +1,20 @@
+# SfSpiBus Class Guide
+
+Thread‑safe SPI master with software controlled CS. Wraps ESP‑IDF SPI driver and guards transfers with a mutex.
+
+## Highlights
+- Software CS pin toggling
+- Mutex protected transactions
+- Same API as `SpiBus` plus `LockBus()` and `UnlockBus()`
+
+## Example
+```cpp
+SemaphoreHandle_t m = xSemaphoreCreateMutex();
+SfSpiBus bus(SPI2_HOST, busCfg, devCfg, m);
+bus.Open();
+bus.Write(txBuf, 4, 100);
+```
+
+---
+
+[← Previous](SpiBus.md) | [Documentation Index](index.md) | [Next →](FlexCan.md)

--- a/docs/SpiBus.md
+++ b/docs/SpiBus.md
@@ -1,0 +1,21 @@
+# SpiBus Class Guide
+
+Basic SPI master driver using ESP‑IDF. No thread safety is provided.
+
+## Capabilities
+- Blocking read, write and write‑read operations
+- Host/device configuration supplied by the user
+- Query the configured clock frequency
+
+## Example
+```cpp
+SpiBus bus(SPI2_HOST, busCfg, devCfg);
+if (bus.Open()) {
+    bus.Write(txBuf, 4);
+    bus.Read(rxBuf, 4);
+}
+```
+
+---
+
+[← Previous](SfI2cBus.md) | [Documentation Index](index.md) | [Next →](SfSpiBus.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# IID-ESPIDF Documentation Index
+
+This directory contains short guides for each internal interface class. Use the links below or the navigation footer on each page to browse the documentation.
+
+- [BaseAdc](BaseAdc.md)
+- [Esp32C6Adc](Esp32C6Adc.md)
+- [BaseGpio](BaseGpio.md)
+- [DigitalGpio](DigitalGpio.md)
+- [DigitalInput](DigitalInput.md)
+- [DigitalOutput](DigitalOutput.md)
+- [DigitalOutputGuard](DigitalOutputGuard.md)
+- [DigitalExternalIRQ](DigitalExternalIRQ.md)
+- [I2cBus](I2cBus.md)
+- [SfI2cBus](SfI2cBus.md)
+- [SpiBus](SpiBus.md)
+- [SfSpiBus](SfSpiBus.md)
+- [FlexCan](FlexCan.md)
+- [PwmOutput](PwmOutput.md)
+
+Return to the [project README](../README.md).


### PR DESCRIPTION
## Summary
- expand each driver guide with features and code snippets
- add prev/next links for easy navigation between pages
- explain doc index and link back to README