### PR TITLE
Add PeriodicTimer abstraction and update docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,6 @@ idf_component_register(
         src/SfI2cBus.cpp
         src/SpiBus.cpp
         src/PwmOutput.cpp
+        src/PeriodicTimer.cpp
     INCLUDE_DIRS "inc"
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HF-IID-ESPIDF
 
-Internal Interface Drivers - wrappers for the ESP-IDF to be used in the HardFOC controller.
+Internal Interface Drivers - wrappers for the ESP-IDF to be used in the HardFOC controller. 🏎️
 
 For detailed API guides see [docs/index.md](docs/index.md).
 
@@ -8,11 +8,14 @@ For detailed API guides see [docs/index.md](docs/index.md).
 
 This component bundles the internal interface drivers and platform specific utilities used by the HardFOC project. The drivers provide low level access to GPIO, ADC and bus interfaces for ESP‑IDF targets. Utility code such as the base thread framework and the ThreadX compatibility layer are also included here as they depend on the underlying RTOS implementation.
 
+Each abstraction aims to hide the verbose ESP‑IDF APIs behind a tiny C++ class while still exposing all the necessary flexibility.  Add the component to your project and you can easily reuse these drivers across boards and applications.
+
 ### Contents
 - `BaseGpio`, `DigitalInput`, `DigitalOutput` ⚙️
 - Bus drivers like `SpiBus`, `I2cBus` and their thread safe versions 🚌
 - Platform utilities from `UTILITIES/common` (timers, mutex helpers, base threads) 🧰
-- New `PwmOutput` abstraction for LEDC based PWM generation 🎛️
+- `PwmOutput` abstraction for LEDC based PWM generation 🎛️
+- `PeriodicTimer` helper built on `esp_timer` ⏲️
 
 ### Usage
 Add `iid-espidf` to your component requirements. The component exports the include directories for both the driver headers and the utilities and depends on FreeRTOS.
@@ -34,6 +37,21 @@ PwmOutput pwm(GPIO_NUM_4, LEDC_CHANNEL_0, LEDC_TIMER_0, 5000,
 void app_main() {
     pwm.Start();
     pwm.SetDuty(0.5f); // 50% duty cycle
+}
+```
+
+### PeriodicTimer example
+```cpp
+#include "PeriodicTimer.h"
+
+static void Blink(void*) {
+    // toggle LED
+}
+
+PeriodicTimer timer(&Blink);
+
+void app_main() {
+    timer.Start(500000); // 0.5 second period
 }
 ```
 

--- a/docs/PeriodicTimer.md
+++ b/docs/PeriodicTimer.md
@@ -1,0 +1,26 @@
+# PeriodicTimer Class Guide
+
+Simple wrapper around the `esp_timer` API that repeatedly invokes a callback.
+Useful for scheduling periodic tasks without dealing with the raw driver.
+
+## Features ⏲️
+- Create timers with any period in microseconds
+- `Start()` and `Stop()` helpers
+- Works from tasks or ISRs via the ESP-IDF timer service
+
+## Example
+```cpp
+#include "PeriodicTimer.h"
+
+static void Blink(void*) {
+    // toggle an LED
+}
+
+PeriodicTimer timer(&Blink);
+
+timer.Start(1000000); // call every second
+```
+
+---
+
+[← Previous](PwmOutput.md) | [Documentation Index](index.md)

--- a/docs/PwmOutput.md
+++ b/docs/PwmOutput.md
@@ -16,4 +16,4 @@ pwm.SetDuty(0.5f);
 
 ---
 
-[← Previous](FlexCan.md) | [Documentation Index](index.md)
+[← Previous](FlexCan.md) | [Documentation Index](index.md) | [Next →](PeriodicTimer.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,5 +16,6 @@ This directory contains short guides for each internal interface class. Use the 
 - [SfSpiBus](SfSpiBus.md)
 - [FlexCan](FlexCan.md)
 - [PwmOutput](PwmOutput.md)
+- [PeriodicTimer](PeriodicTimer.md)
 
 Return to the [project README](../README.md).

--- a/inc/PeriodicTimer.h
+++ b/inc/PeriodicTimer.h
@@ -1,0 +1,57 @@
+#ifndef PERIODIC_TIMER_H
+#define PERIODIC_TIMER_H
+
+#include "esp_timer.h"
+#include <cstdint>
+
+/**
+ * @file PeriodicTimer.h
+ * @brief Lightweight wrapper around esp_timer for periodic callbacks.
+ *
+ * This class creates an esp_timer that repeatedly invokes a user provided
+ * callback function. It follows the lazy initialization approach used by
+ * the other abstractions in this component.
+ */
+class PeriodicTimer {
+public:
+    using Callback = void (*)(void*); //!< Callback type used by the timer
+
+    /**
+     * @brief Construct a PeriodicTimer.
+     * @param cb   Callback function to invoke on timer expiry
+     * @param arg  User argument passed to the callback
+     */
+    explicit PeriodicTimer(Callback cb, void* arg = nullptr) noexcept;
+    PeriodicTimer(const PeriodicTimer&) = delete;
+    PeriodicTimer& operator=(const PeriodicTimer&) = delete;
+    ~PeriodicTimer() noexcept;
+
+    /**
+     * @brief Start the timer with the given period.
+     * @param periodUs Period in microseconds
+     * @return true if the timer was started
+     */
+    bool Start(uint64_t periodUs) noexcept;
+
+    /**
+     * @brief Stop the timer if running.
+     * @return true if stopped successfully
+     */
+    bool Stop() noexcept;
+
+    /**
+     * @brief Check if the timer is currently running.
+     */
+    bool IsRunning() const noexcept { return running; }
+
+private:
+    static void Dispatch(void* arg);
+    bool CreateHandle() noexcept;
+
+    esp_timer_handle_t handle;
+    Callback userCb;
+    void* userArg;
+    bool running;
+};
+
+#endif // PERIODIC_TIMER_H

--- a/src/PeriodicTimer.cpp
+++ b/src/PeriodicTimer.cpp
@@ -1,0 +1,59 @@
+#include "PeriodicTimer.h"
+#include <esp_log.h>
+
+static const char* TAG = "PeriodicTimer";
+
+PeriodicTimer::PeriodicTimer(Callback cb, void* arg) noexcept
+    : handle(nullptr), userCb(cb), userArg(arg), running(false) {}
+
+PeriodicTimer::~PeriodicTimer() noexcept {
+    Stop();
+    if (handle) {
+        esp_timer_delete(handle);
+        handle = nullptr;
+    }
+}
+
+bool PeriodicTimer::CreateHandle() noexcept {
+    if (handle)
+        return true;
+    esp_timer_create_args_t args = {};
+    args.callback = &PeriodicTimer::Dispatch;
+    args.arg = this;
+    args.dispatch_method = ESP_TIMER_TASK;
+    esp_err_t ret = esp_timer_create(&args, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "esp_timer_create failed: %d", ret);
+        return false;
+    }
+    return true;
+}
+
+bool PeriodicTimer::Start(uint64_t periodUs) noexcept {
+    if (!CreateHandle())
+        return false;
+    esp_err_t ret = esp_timer_start_periodic(handle, periodUs);
+    if (ret == ESP_OK)
+        running = true;
+    else
+        ESP_LOGE(TAG, "esp_timer_start_periodic failed: %d", ret);
+    return ret == ESP_OK;
+}
+
+bool PeriodicTimer::Stop() noexcept {
+    if (!handle || !running)
+        return true;
+    esp_err_t ret = esp_timer_stop(handle);
+    if (ret == ESP_OK)
+        running = false;
+    else
+        ESP_LOGE(TAG, "esp_timer_stop failed: %d", ret);
+    return ret == ESP_OK;
+}
+
+void PeriodicTimer::Dispatch(void* arg) {
+    auto self = static_cast<PeriodicTimer*>(arg);
+    if (self && self->userCb)
+        self->userCb(self->userArg);
+}
+


### PR DESCRIPTION
## Summary
- add new `PeriodicTimer` wrapper for esp_timer
- document new class and link in docs index
- update PwmOutput doc navigation
- expand README with new section and example
- register new source in CMakeLists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dd3a99e88328b027aca12127f8f4