### PR TITLE
Add UART and DAC abstractions with docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,5 +13,7 @@ idf_component_register(
         src/SpiBus.cpp
         src/PwmOutput.cpp
         src/PeriodicTimer.cpp
+        src/UartDriver.cpp
+        src/DacOutput.cpp
     INCLUDE_DIRS "inc"
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HF-IID-ESPIDF
 
-Internal Interface Drivers - wrappers for the ESP-IDF to be used in the HardFOC controller. 🏎️
+Internal Interface Drivers – wrappers for the ESP‑IDF to be used in the HardFOC controller. 🏎️
 
 For detailed API guides see [docs/index.md](docs/index.md).
 
@@ -8,14 +8,19 @@ For detailed API guides see [docs/index.md](docs/index.md).
 
 This component bundles the internal interface drivers and platform specific utilities used by the HardFOC project. The drivers provide low level access to GPIO, ADC and bus interfaces for ESP‑IDF targets. Utility code such as the base thread framework and the ThreadX compatibility layer are also included here as they depend on the underlying RTOS implementation.
 
-Each abstraction aims to hide the verbose ESP‑IDF APIs behind a tiny C++ class while still exposing all the necessary flexibility.  Add the component to your project and you can easily reuse these drivers across boards and applications.
+Each abstraction is intentionally tiny and header only where possible. You simply create the object and call `Open()` or `Start()` when ready. Behind the scenes the verbose ESP‑IDF calls are made for you. This means you can write compact applications that remain portable between boards and even other MCU families that reuse the same interface layer.
+
 
 ### Contents
 - `BaseGpio`, `DigitalInput`, `DigitalOutput` ⚙️
 - Bus drivers like `SpiBus`, `I2cBus` and their thread safe versions 🚌
-- Platform utilities from `UTILITIES/common` (timers, mutex helpers, base threads) 🧰
+- Thread aware versions `SfSpiBus` and `SfI2cBus` 🧵
+- `FlexCan` for CAN peripherals 🚐
 - `PwmOutput` abstraction for LEDC based PWM generation 🎛️
 - `PeriodicTimer` helper built on `esp_timer` ⏲️
+- `UartDriver` serial helper 📡
+- `DacOutput` for analog voltages 🎚️
+- Platform utilities from `UTILITIES/common` (timers, mutex helpers, base threads) 🧰
 
 ### Usage
 Add `iid-espidf` to your component requirements. The component exports the include directories for both the driver headers and the utilities and depends on FreeRTOS.

--- a/docs/DacOutput.md
+++ b/docs/DacOutput.md
@@ -1,0 +1,18 @@
+# DacOutput Class Guide
+
+Tiny helper around the ESP‑IDF DAC functions for generating analog voltages.
+
+## Highlights
+- Enable/disable a DAC channel
+- Write 8‑bit values with `SetValue()`
+
+## Example
+```cpp
+DacOutput dac(DAC_CHANNEL_1);
+dac.Enable();
+dac.SetValue(128); // mid‑scale output
+```
+
+---
+
+[← Previous](UartDriver.md) | [Documentation Index](index.md)

--- a/docs/UartDriver.md
+++ b/docs/UartDriver.md
@@ -1,0 +1,27 @@
+# UartDriver Class Guide
+
+Simple wrapper around the ESP‑IDF UART driver providing blocking read and write.
+
+## Features
+- Configure port, pins and parameters
+- `Open()`, `Close()` lifecycle helpers
+- `Write()` and `Read()` methods for byte streams
+
+## Example
+```cpp
+uart_config_t cfg = {
+    .baud_rate = 115200,
+    .data_bits = UART_DATA_8_BITS,
+    .parity = UART_PARITY_DISABLE,
+    .stop_bits = UART_STOP_BITS_1,
+    .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+};
+UartDriver serial(UART_NUM_0, cfg, GPIO_NUM_1, GPIO_NUM_3);
+serial.Open();
+const char msg[] = "hi";
+serial.Write(reinterpret_cast<const uint8_t*>(msg), sizeof(msg));
+```
+
+---
+
+[← Previous](PeriodicTimer.md) | [Documentation Index](index.md) | [Next →](DacOutput.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,5 +17,7 @@ This directory contains short guides for each internal interface class. Use the 
 - [FlexCan](FlexCan.md)
 - [PwmOutput](PwmOutput.md)
 - [PeriodicTimer](PeriodicTimer.md)
+- [UartDriver](UartDriver.md)
+- [DacOutput](DacOutput.md)
 
 Return to the [project README](../README.md).

--- a/inc/DacOutput.h
+++ b/inc/DacOutput.h
@@ -1,0 +1,29 @@
+#ifndef DACOUTPUT_H
+#define DACOUTPUT_H
+
+#include <driver/dac_common.h>
+#include <cstdint>
+
+/**
+ * @file DacOutput.h
+ * @brief Thin wrapper for the ESP-IDF DAC driver.
+ */
+class DacOutput {
+public:
+    explicit DacOutput(dac_channel_t channel) noexcept;
+    ~DacOutput() noexcept;
+    DacOutput(const DacOutput&) = delete;
+    DacOutput& operator=(const DacOutput&) = delete;
+
+    bool Enable() noexcept;   ///< Enable the channel
+    bool Disable() noexcept;  ///< Disable the channel
+    bool SetValue(uint8_t value) noexcept; ///< Output 8-bit value
+
+    bool IsEnabled() const noexcept { return enabled; }
+
+private:
+    dac_channel_t channel;
+    bool enabled;
+};
+
+#endif // DACOUTPUT_H

--- a/inc/UartDriver.h
+++ b/inc/UartDriver.h
@@ -1,0 +1,45 @@
+#ifndef UARTDRIVER_H
+#define UARTDRIVER_H
+
+#include <driver/uart.h>
+#include <cstdint>
+
+/**
+ * @file UartDriver.h
+ * @brief Simple UART driver wrapper for ESP-IDF.
+ *
+ * Provides minimal helpers for opening, closing and
+ * blocking read/write over a UART port.
+ */
+class UartDriver {
+public:
+    /**
+     * @brief Construct a UartDriver.
+     * @param port UART port number
+     * @param config UART configuration structure
+     * @param txPin GPIO used for TX
+     * @param rxPin GPIO used for RX
+     */
+    UartDriver(uart_port_t port, const uart_config_t& config,
+               int txPin, int rxPin) noexcept;
+    ~UartDriver() noexcept;
+    UartDriver(const UartDriver&) = delete;
+    UartDriver& operator=(const UartDriver&) = delete;
+
+    bool Open() noexcept;   ///< Install and configure the driver
+    bool Close() noexcept;  ///< Delete the driver
+    bool Write(const uint8_t* data, uint16_t length) noexcept; ///< Blocking write
+    bool Read(uint8_t* data, uint16_t length,
+              TickType_t ticksToWait = portMAX_DELAY) noexcept; ///< Blocking read
+
+    bool IsInitialized() const noexcept { return initialized; }
+
+private:
+    uart_port_t port;
+    uart_config_t config;
+    int txPin;
+    int rxPin;
+    bool initialized;
+};
+
+#endif // UARTDRIVER_H

--- a/src/DacOutput.cpp
+++ b/src/DacOutput.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file DacOutput.cpp
+ * @brief Implementation of the DacOutput class.
+ */
+
+#include "DacOutput.h"
+#include <driver/dac_oneshot.h>
+#include <esp_log.h>
+
+static const char* TAG = "DacOutput";
+
+DacOutput::DacOutput(dac_channel_t ch) noexcept : channel(ch), enabled(false) {}
+
+DacOutput::~DacOutput() noexcept {
+    if (enabled) {
+        Disable();
+    }
+}
+
+bool DacOutput::Enable() noexcept {
+    if (enabled) return true;
+    esp_err_t err = dac_output_enable(channel);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "enable failed: %d", err);
+        return false;
+    }
+    enabled = true;
+    return true;
+}
+
+bool DacOutput::Disable() noexcept {
+    if (!enabled) return true;
+    esp_err_t err = dac_output_disable(channel);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "disable failed: %d", err);
+        return false;
+    }
+    enabled = false;
+    return true;
+}
+
+bool DacOutput::SetValue(uint8_t value) noexcept {
+    if (!enabled) return false;
+    esp_err_t err = dac_output_voltage(channel, value);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "set value failed: %d", err);
+        return false;
+    }
+    return true;
+}

--- a/src/UartDriver.cpp
+++ b/src/UartDriver.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file UartDriver.cpp
+ * @brief Implementation of the UartDriver class.
+ */
+
+#include "UartDriver.h"
+#include <esp_log.h>
+
+static const char* TAG = "UartDriver";
+
+UartDriver::UartDriver(uart_port_t p, const uart_config_t& cfg, int tx, int rx) noexcept
+    : port(p), config(cfg), txPin(tx), rxPin(rx), initialized(false) {}
+
+UartDriver::~UartDriver() noexcept {
+    if (initialized) {
+        Close();
+    }
+}
+
+bool UartDriver::Open() noexcept {
+    if (initialized) return true;
+    esp_err_t err = uart_param_config(port, &config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "param config failed: %d", err);
+        return false;
+    }
+    err = uart_set_pin(port, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "set pin failed: %d", err);
+        return false;
+    }
+    err = uart_driver_install(port, config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
+                              config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
+                              0, nullptr, 0);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "driver install failed: %d", err);
+        return false;
+    }
+    initialized = true;
+    return true;
+}
+
+bool UartDriver::Close() noexcept {
+    if (!initialized) return true;
+    uart_driver_delete(port);
+    initialized = false;
+    return true;
+}
+
+bool UartDriver::Write(const uint8_t* data, uint16_t length) noexcept {
+    if (!initialized) return false;
+    int ret = uart_write_bytes(port, data, length);
+    return (ret == length);
+}
+
+bool UartDriver::Read(uint8_t* data, uint16_t length, TickType_t ticksToWait) noexcept {
+    if (!initialized) return false;
+    int ret = uart_read_bytes(port, data, length, ticksToWait);
+    return (ret == length);
+}


### PR DESCRIPTION
## Summary
- implement `UartDriver` and `DacOutput` helpers
- document new classes and reference them in documentation index
- extend README with additional explanations and emojis
- add sources to build system