### PR TITLE
Add thread-safe UART driver and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ idf_component_register(
         src/PwmOutput.cpp
         src/PeriodicTimer.cpp
         src/UartDriver.cpp
+        src/SfUartDriver.cpp
         src/DacOutput.cpp
     INCLUDE_DIRS "inc"
 )

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # HF-IID-ESPIDF
 
-Internal Interface Drivers – wrappers for the ESP‑IDF to be used in the HardFOC controller. 🏎️
+Internal Interface Drivers – handy wrappers for ESP‑IDF used by the HardFOC controller. 🏎️ These abstractions keep your code tidy and portable across ESP32 variants.
 
 For detailed API guides see [docs/index.md](docs/index.md).
 
 ## IID‑ESPIDF Overview
 
-This component bundles the internal interface drivers and platform specific utilities used by the HardFOC project. The drivers provide low level access to GPIO, ADC and bus interfaces for ESP‑IDF targets. Utility code such as the base thread framework and the ThreadX compatibility layer are also included here as they depend on the underlying RTOS implementation.
+This component bundles a growing collection of interface drivers and utilities. They hide verbose ESP‑IDF boilerplate while staying small and reusable. Alongside the hardware helpers you will also find base thread frameworks and RTOS utilities used across the HardFOC ecosystem.
 
-Each abstraction is intentionally tiny and header only where possible. You simply create the object and call `Open()` or `Start()` when ready. Behind the scenes the verbose ESP‑IDF calls are made for you. This means you can write compact applications that remain portable between boards and even other MCU families that reuse the same interface layer.
+Each abstraction is intentionally tiny and header only where possible. Create an object, call `Open()` or `Start()` and off you go. All the ESP‑IDF ceremony is performed behind the scenes so your code stays compact and portable between boards – and even other MCU families that reuse the same interface layer.
 
 
 ### Contents
 - `BaseGpio`, `DigitalInput`, `DigitalOutput` ⚙️
-- Bus drivers like `SpiBus`, `I2cBus` and their thread safe versions 🚌
-- Thread aware versions `SfSpiBus` and `SfI2cBus` 🧵
+- Bus drivers `SpiBus` and `I2cBus` 🚌
+- Thread‑safe variants `SfSpiBus`, `SfI2cBus` and `SfUartDriver` 🧵
 - `FlexCan` for CAN peripherals 🚐
-- `PwmOutput` abstraction for LEDC based PWM generation 🎛️
+- `PwmOutput` abstraction for LEDC PWM generation 🎛️
 - `PeriodicTimer` helper built on `esp_timer` ⏲️
-- `UartDriver` serial helper 📡
+- `UartDriver` and `SfUartDriver` serial helpers 📡
 - `DacOutput` for analog voltages 🎚️
 - Platform utilities from `UTILITIES/common` (timers, mutex helpers, base threads) 🧰
 
@@ -58,6 +58,21 @@ PeriodicTimer timer(&Blink);
 void app_main() {
     timer.Start(500000); // 0.5 second period
 }
+```
+
+### SfUartDriver example
+```cpp
+SemaphoreHandle_t m = xSemaphoreCreateMutex();
+uart_config_t cfg = {
+    .baud_rate = 115200,
+    .data_bits = UART_DATA_8_BITS,
+    .parity = UART_PARITY_DISABLE,
+    .stop_bits = UART_STOP_BITS_1,
+    .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+};
+SfUartDriver serial(UART_NUM_1, cfg, GPIO_NUM_1, GPIO_NUM_3, m);
+serial.Open();
+serial.Write(reinterpret_cast<const uint8_t*>("hi"), 2);
 ```
 
 ### License

--- a/docs/DacOutput.md
+++ b/docs/DacOutput.md
@@ -15,4 +15,4 @@ dac.SetValue(128); // mid‑scale output
 
 ---
 
-[← Previous](UartDriver.md) | [Documentation Index](index.md)
+[← Previous](SfUartDriver.md) | [Documentation Index](index.md)

--- a/docs/SfUartDriver.md
+++ b/docs/SfUartDriver.md
@@ -1,0 +1,19 @@
+# SfUartDriver Class Guide
+
+Thread‑safe UART driver using a FreeRTOS mutex. Wraps the ESP‑IDF UART driver and mirrors the `UartDriver` API.
+
+## Highlights
+- Mutex protected read and write operations
+- Identical usage to `UartDriver` with extra `Lock()` and `Unlock()` helpers
+
+## Example
+```cpp
+SemaphoreHandle_t m = xSemaphoreCreateMutex();
+SfUartDriver serial(UART_NUM_0, cfg, GPIO_NUM_1, GPIO_NUM_3, m);
+serial.Open();
+serial.Write(reinterpret_cast<const uint8_t*>("hi"), 2);
+```
+
+---
+
+[← Previous](UartDriver.md) | [Documentation Index](index.md) | [Next →](DacOutput.md)

--- a/docs/UartDriver.md
+++ b/docs/UartDriver.md
@@ -24,4 +24,4 @@ serial.Write(reinterpret_cast<const uint8_t*>(msg), sizeof(msg));
 
 ---
 
-[← Previous](PeriodicTimer.md) | [Documentation Index](index.md) | [Next →](DacOutput.md)
+[← Previous](PeriodicTimer.md) | [Documentation Index](index.md) | [Next →](SfUartDriver.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ This directory contains short guides for each internal interface class. Use the 
 - [PwmOutput](PwmOutput.md)
 - [PeriodicTimer](PeriodicTimer.md)
 - [UartDriver](UartDriver.md)
+- [SfUartDriver](SfUartDriver.md)
 - [DacOutput](DacOutput.md)
 
 Return to the [project README](../README.md).

--- a/inc/SfUartDriver.h
+++ b/inc/SfUartDriver.h
@@ -1,0 +1,52 @@
+#ifndef SFUARTDRIVER_H
+#define SFUARTDRIVER_H
+
+#include <driver/uart.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <cstdint>
+
+/**
+ * @file SfUartDriver.h
+ * @brief Thread-safe UART driver wrapper for ESP-IDF.
+ *
+ * Mirrors the API of UartDriver but guards read and write
+ * operations using a FreeRTOS mutex.
+ */
+class SfUartDriver {
+public:
+    /**
+     * @brief Construct a thread-safe UART driver.
+     * @param port UART port number
+     * @param config UART configuration structure
+     * @param txPin GPIO used for TX
+     * @param rxPin GPIO used for RX
+     * @param mutexHandle Mutex used for locking during transfers
+     */
+    SfUartDriver(uart_port_t port, const uart_config_t& config,
+                 int txPin, int rxPin, SemaphoreHandle_t mutexHandle) noexcept;
+    ~SfUartDriver() noexcept;
+    SfUartDriver(const SfUartDriver&) = delete;
+    SfUartDriver& operator=(const SfUartDriver&) = delete;
+
+    bool Open() noexcept;   ///< Install and configure the driver
+    bool Close() noexcept;  ///< Delete the driver
+    bool Write(const uint8_t* data, uint16_t length, uint32_t timeoutMsec = 1000) noexcept; ///< Blocking write
+    bool Read(uint8_t* data, uint16_t length,
+              TickType_t ticksToWait = portMAX_DELAY) noexcept; ///< Blocking read
+
+    bool Lock() noexcept;   ///< Manually lock the mutex
+    bool Unlock() noexcept; ///< Unlock the mutex
+
+    bool IsInitialized() const noexcept { return initialized; }
+
+private:
+    uart_port_t port;
+    uart_config_t config;
+    int txPin;
+    int rxPin;
+    SemaphoreHandle_t mutex;
+    bool initialized;
+};
+
+#endif // SFUARTDRIVER_H

--- a/src/SfUartDriver.cpp
+++ b/src/SfUartDriver.cpp
@@ -1,0 +1,84 @@
+/**
+ * @file SfUartDriver.cpp
+ * @brief Implementation of the SfUartDriver class.
+ */
+
+#include "SfUartDriver.h"
+#include <esp_log.h>
+
+static const char* TAG = "SfUartDriver";
+
+SfUartDriver::SfUartDriver(uart_port_t p, const uart_config_t& cfg,
+                           int tx, int rx, SemaphoreHandle_t mtx) noexcept
+    : port(p), config(cfg), txPin(tx), rxPin(rx), mutex(mtx), initialized(false) {}
+
+SfUartDriver::~SfUartDriver() noexcept {
+    if (initialized) {
+        Close();
+    }
+}
+
+bool SfUartDriver::Open() noexcept {
+    if (initialized)
+        return true;
+    esp_err_t err = uart_param_config(port, &config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "param config failed: %d", err);
+        return false;
+    }
+    err = uart_set_pin(port, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "set pin failed: %d", err);
+        return false;
+    }
+    err = uart_driver_install(port,
+                              config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
+                              config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
+                              0, nullptr, 0);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "driver install failed: %d", err);
+        return false;
+    }
+    initialized = true;
+    return true;
+}
+
+bool SfUartDriver::Close() noexcept {
+    if (!initialized)
+        return true;
+    uart_driver_delete(port);
+    initialized = false;
+    return true;
+}
+
+bool SfUartDriver::Write(const uint8_t* data, uint16_t length, uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+        return false;
+    int ret = uart_write_bytes(port, data, length);
+    xSemaphoreGive(mutex);
+    return ret == length;
+}
+
+bool SfUartDriver::Read(uint8_t* data, uint16_t length, TickType_t ticksToWait) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(mutex, ticksToWait) != pdTRUE)
+        return false;
+    int ret = uart_read_bytes(port, data, length, ticksToWait);
+    xSemaphoreGive(mutex);
+    return ret == length;
+}
+
+bool SfUartDriver::Lock() noexcept {
+    if (!initialized)
+        return false;
+    return xSemaphoreTake(mutex, portMAX_DELAY) == pdTRUE;
+}
+
+bool SfUartDriver::Unlock() noexcept {
+    if (!initialized)
+        return false;
+    return xSemaphoreGive(mutex) == pdTRUE;
+}


### PR DESCRIPTION
## Summary
- add `SfUartDriver` class for mutex-protected UART communication
- register the new source file in `CMakeLists.txt`
- document `SfUartDriver` and link it in the docs
- update `UartDriver` and `DacOutput` pages to maintain navigation
- enhance README with more details, emojis and an `SfUartDriver` example

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command `idf_component_register`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e125cf2c83289e843780fa61b8f9