### PR TITLE
Add RMT output and prune extra helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,6 @@ idf_component_register(
         src/UartDriver.cpp
         src/SfUartDriver.cpp
         src/DacOutput.cpp
+        src/RmtOutput.cpp
     INCLUDE_DIRS "inc"
 )

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Each abstraction is intentionally tiny and header only where possible. Create an
 - `PeriodicTimer` helper built on `esp_timer` ⏲️
 - `UartDriver` and `SfUartDriver` serial helpers 📡
 - `DacOutput` for analog voltages 🎚️
+- `RmtOutput` wrapper for the RMT peripheral 📡
 - Platform utilities from `UTILITIES/common` (timers, mutex helpers, base threads) 🧰
 
 ### Usage
@@ -73,6 +74,19 @@ uart_config_t cfg = {
 SfUartDriver serial(UART_NUM_1, cfg, GPIO_NUM_1, GPIO_NUM_3, m);
 serial.Open();
 serial.Write(reinterpret_cast<const uint8_t*>("hi"), 2);
+```
+
+
+### RmtOutput example
+```cpp
+RmtOutput rmt(RMT_CHANNEL_0, GPIO_NUM_18, 80);
+rmt.Open();
+rmt_item32_t item = {};
+item.level0 = 1;
+item.duration0 = 500;
+item.level1 = 0;
+item.duration1 = 500;
+rmt.Write(&item, 1);
 ```
 
 ### License

--- a/docs/DacOutput.md
+++ b/docs/DacOutput.md
@@ -15,4 +15,4 @@ dac.SetValue(128); // mid‑scale output
 
 ---
 
-[← Previous](SfUartDriver.md) | [Documentation Index](index.md)
+[← Previous](SfUartDriver.md) | [Documentation Index](index.md) | [Next →](RmtOutput.md)

--- a/docs/RmtOutput.md
+++ b/docs/RmtOutput.md
@@ -1,0 +1,24 @@
+# RmtOutput Class Guide
+
+Wrapper around the ESP‑IDF RMT API for transmitting pulse sequences. 📡
+
+## Features
+- Install and configure a TX channel
+- Send arrays of `rmt_item32_t`
+- RAII cleanup of the driver
+
+## Example
+```cpp
+RmtOutput rmt(RMT_CHANNEL_0, GPIO_NUM_18, 80);
+rmt.Open();
+rmt_item32_t item = {};
+item.level0 = 1;
+item.duration0 = 500;
+item.level1 = 0;
+item.duration1 = 500;
+rmt.Write(&item, 1);
+```
+
+---
+
+[← Previous](DacOutput.md) | [Documentation Index](index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,5 +20,6 @@ This directory contains short guides for each internal interface class. Use the 
 - [UartDriver](UartDriver.md)
 - [SfUartDriver](SfUartDriver.md)
 - [DacOutput](DacOutput.md)
+- [RmtOutput](RmtOutput.md)
 
 Return to the [project README](../README.md).

--- a/inc/RmtOutput.h
+++ b/inc/RmtOutput.h
@@ -1,0 +1,32 @@
+#ifndef RMT_OUTPUT_H
+#define RMT_OUTPUT_H
+
+#include "driver/rmt.h"
+#include "driver/gpio.h"
+
+/**
+ * @file RmtOutput.h
+ * @brief Simple wrapper around the ESP-IDF RMT API for TX channels.
+ */
+class RmtOutput {
+public:
+    RmtOutput(rmt_channel_t channel, gpio_num_t pin, uint32_t clk_div = 80) noexcept;
+    ~RmtOutput() noexcept;
+    RmtOutput(const RmtOutput&) = delete;
+    RmtOutput& operator=(const RmtOutput&) = delete;
+
+    bool Open() noexcept;
+    void Close() noexcept;
+
+    bool Write(const rmt_item32_t* items, size_t len, bool wait_tx_done = true) noexcept;
+
+    bool IsOpen() const noexcept { return installed; }
+
+private:
+    rmt_channel_t chan;
+    gpio_num_t gpio;
+    uint32_t div;
+    bool installed;
+};
+
+#endif // RMT_OUTPUT_H

--- a/src/RmtOutput.cpp
+++ b/src/RmtOutput.cpp
@@ -1,0 +1,39 @@
+#include "RmtOutput.h"
+
+RmtOutput::RmtOutput(rmt_channel_t channel, gpio_num_t pin, uint32_t clk_div) noexcept
+    : chan(channel), gpio(pin), div(clk_div), installed(false) {}
+
+RmtOutput::~RmtOutput() noexcept {
+    Close();
+}
+
+bool RmtOutput::Open() noexcept {
+    if (installed) return true;
+    rmt_config_t cfg = {};
+    cfg.rmt_mode = RMT_MODE_TX;
+    cfg.channel = chan;
+    cfg.gpio_num = gpio;
+    cfg.clk_div = div;
+    cfg.mem_block_num = 1;
+    if (rmt_config(&cfg) != ESP_OK) {
+        return false;
+    }
+    if (rmt_driver_install(chan, 0, 0) != ESP_OK) {
+        return false;
+    }
+    installed = true;
+    return true;
+}
+
+void RmtOutput::Close() noexcept {
+    if (installed) {
+        rmt_driver_uninstall(chan);
+        installed = false;
+    }
+}
+
+bool RmtOutput::Write(const rmt_item32_t* items, size_t len, bool wait_tx_done) noexcept {
+    if (!installed) return false;
+    return rmt_write_items(chan, items, len, wait_tx_done) == ESP_OK;
+}
+


### PR DESCRIPTION
## Summary
- add `RmtOutput` wrapper around ESP-IDF RMT TX driver
- drop `RtosTask` and `NvsStorage` helpers
- document new class and update index
- clean README examples
- compile sources in CMakeLists

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command)*

------
https://chatgpt.com/codex/tasks/task_e_6846e2ca8d748328814cebb69dea8632