### PR TITLE
Add NVS storage and thread-safe CAN wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ idf_component_register(
         src/DigitalOutput.cpp
         src/Esp32C6Adc.cpp
         src/FlexCan.cpp
+        src/SfFlexCan.cpp
         src/I2cBus.cpp
         src/SfSpiBus.cpp
         src/SfI2cBus.cpp
@@ -16,5 +17,7 @@ idf_component_register(
         src/UartDriver.cpp
         src/SfUartDriver.cpp
         src/DacOutput.cpp
+        src/RmtOutput.cpp
+        src/NvsStorage.cpp
     INCLUDE_DIRS "inc"
 )

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Each abstraction is intentionally tiny and header only where possible. Create an
 - Bus drivers `SpiBus` and `I2cBus` 🚌
 - Thread‑safe variants `SfSpiBus`, `SfI2cBus` and `SfUartDriver` 🧵
 - `FlexCan` for CAN peripherals 🚐
+- `SfFlexCan` thread-safe CAN driver 🛡️
 - `PwmOutput` abstraction for LEDC PWM generation 🎛️
 - `PeriodicTimer` helper built on `esp_timer` ⏲️
 - `UartDriver` and `SfUartDriver` serial helpers 📡
 - `DacOutput` for analog voltages 🎚️
+- `RmtOutput` wrapper for the RMT peripheral 📡
+- `NvsStorage` for saving settings 💾
 - Platform utilities from `UTILITIES/common` (timers, mutex helpers, base threads) 🧰
 
 ### Usage
@@ -73,6 +76,37 @@ uart_config_t cfg = {
 SfUartDriver serial(UART_NUM_1, cfg, GPIO_NUM_1, GPIO_NUM_3, m);
 serial.Open();
 serial.Write(reinterpret_cast<const uint8_t*>("hi"), 2);
+```
+
+
+### RmtOutput example
+```cpp
+RmtOutput rmt(RMT_CHANNEL_0, GPIO_NUM_18, 80);
+rmt.Open();
+rmt_item32_t item = {};
+item.level0 = 1;
+item.duration0 = 500;
+item.level1 = 0;
+item.duration1 = 500;
+rmt.Write(&item, 1);
+```
+
+### NvsStorage example
+```cpp
+NvsStorage storage("app");
+storage.Open();
+storage.SetU32("count", 42);
+uint32_t v;
+storage.GetU32("count", v);
+```
+
+### SfFlexCan example
+```cpp
+SemaphoreHandle_t cm = xSemaphoreCreateMutex();
+SfFlexCan can(0, 500000, cm);
+can.Open();
+FlexCan::Frame f{0x100, {0x01}, 1, false, false};
+can.Write(f);
 ```
 
 ### License

--- a/docs/DacOutput.md
+++ b/docs/DacOutput.md
@@ -15,4 +15,4 @@ dac.SetValue(128); // mid‑scale output
 
 ---
 
-[← Previous](SfUartDriver.md) | [Documentation Index](index.md)
+[← Previous](SfUartDriver.md) | [Documentation Index](index.md) | [Next →](RmtOutput.md)

--- a/docs/FlexCan.md
+++ b/docs/FlexCan.md
@@ -17,4 +17,4 @@ can.Write(f);
 
 ---
 
-[← Previous](SfSpiBus.md) | [Documentation Index](index.md) | [Next →](PwmOutput.md)
+[← Previous](SfSpiBus.md) | [Documentation Index](index.md) | [Next →](SfFlexCan.md)

--- a/docs/NvsStorage.md
+++ b/docs/NvsStorage.md
@@ -1,0 +1,21 @@
+# NvsStorage Class Guide
+
+Small helper for non-volatile key-value pairs using the ESP‑IDF NVS API. 💾
+
+## Highlights
+- Initializes NVS flash on first use
+- Opens a namespace given at construction
+- Get/Set 32‑bit values with commit on write
+
+## Example
+```cpp
+NvsStorage store("app");
+store.Open();
+store.SetU32("boot_count", 1);
+uint32_t val;
+store.GetU32("boot_count", val);
+```
+
+---
+
+[← Previous](RmtOutput.md) | [Documentation Index](index.md)

--- a/docs/PwmOutput.md
+++ b/docs/PwmOutput.md
@@ -16,4 +16,4 @@ pwm.SetDuty(0.5f);
 
 ---
 
-[← Previous](FlexCan.md) | [Documentation Index](index.md) | [Next →](PeriodicTimer.md)
+[← Previous](SfFlexCan.md) | [Documentation Index](index.md) | [Next →](PeriodicTimer.md)

--- a/docs/RmtOutput.md
+++ b/docs/RmtOutput.md
@@ -1,0 +1,24 @@
+# RmtOutput Class Guide
+
+Wrapper around the ESP‑IDF RMT API for transmitting pulse sequences. 📡
+
+## Features
+- Install and configure a TX channel
+- Send arrays of `rmt_item32_t`
+- RAII cleanup of the driver
+
+## Example
+```cpp
+RmtOutput rmt(RMT_CHANNEL_0, GPIO_NUM_18, 80);
+rmt.Open();
+rmt_item32_t item = {};
+item.level0 = 1;
+item.duration0 = 500;
+item.level1 = 0;
+item.duration1 = 500;
+rmt.Write(&item, 1);
+```
+
+---
+
+[← Previous](DacOutput.md) | [Documentation Index](index.md) | [Next →](NvsStorage.md)

--- a/docs/SfFlexCan.md
+++ b/docs/SfFlexCan.md
@@ -1,0 +1,20 @@
+# SfFlexCan Class Guide
+
+Thread‑safe CAN controller built on `FlexCan` and a FreeRTOS mutex. 🛡️
+
+## Highlights
+- Same API as `FlexCan` but guarded by a mutex
+- `Lock()`/`Unlock()` helpers for manual control
+
+## Example
+```cpp
+SemaphoreHandle_t m = xSemaphoreCreateMutex();
+SfFlexCan can(0, 500000, m);
+can.Open();
+FlexCan::Frame f{0x123, {0x01}, 1, false, false};
+can.Write(f);
+```
+
+---
+
+[← Previous](FlexCan.md) | [Documentation Index](index.md) | [Next →](PwmOutput.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,13 @@ This directory contains short guides for each internal interface class. Use the 
 - [SpiBus](SpiBus.md)
 - [SfSpiBus](SfSpiBus.md)
 - [FlexCan](FlexCan.md)
+- [SfFlexCan](SfFlexCan.md)
 - [PwmOutput](PwmOutput.md)
 - [PeriodicTimer](PeriodicTimer.md)
 - [UartDriver](UartDriver.md)
 - [SfUartDriver](SfUartDriver.md)
 - [DacOutput](DacOutput.md)
+- [RmtOutput](RmtOutput.md)
+- [NvsStorage](NvsStorage.md)
 
 Return to the [project README](../README.md).

--- a/inc/NvsStorage.h
+++ b/inc/NvsStorage.h
@@ -1,0 +1,49 @@
+/**
+ * @file NvsStorage.h
+ * @brief Lightweight NVS helper for key-value storage.
+ */
+#ifndef NVSSTORAGE_H_
+#define NVSSTORAGE_H_
+
+#include <nvs.h>
+#include <nvs_flash.h>
+#include <cstdint>
+
+/**
+ * @class NvsStorage
+ * @brief Minimal RAII wrapper for an NVS namespace.
+ */
+class NvsStorage {
+public:
+    /**
+     * @brief Construct storage bound to a namespace.
+     * @param ns Namespace string
+     */
+    explicit NvsStorage(const char* ns) noexcept;
+    ~NvsStorage() noexcept;
+    NvsStorage(const NvsStorage&) = delete;
+    NvsStorage& operator=(const NvsStorage&) = delete;
+
+    /** Open the namespace creating it if needed. */
+    bool Open() noexcept;
+    /** Close the handle if open. */
+    void Close() noexcept;
+
+    /** Store a 32-bit value under a key. */
+    bool SetU32(const char* key, uint32_t value) noexcept;
+    /** Retrieve a 32-bit value. */
+    bool GetU32(const char* key, uint32_t& value) noexcept;
+    /** Remove a key from storage. */
+    bool EraseKey(const char* key) noexcept;
+    /** Commit any pending writes. */
+    bool Commit() noexcept;
+
+    /** Check if the handle is valid. */
+    bool IsOpened() const noexcept { return handle != 0; }
+
+private:
+    const char* nsName;   ///< Namespace string
+    nvs_handle_t handle;  ///< Open handle or 0
+};
+
+#endif // NVSSTORAGE_H_

--- a/inc/RmtOutput.h
+++ b/inc/RmtOutput.h
@@ -1,0 +1,32 @@
+#ifndef RMT_OUTPUT_H
+#define RMT_OUTPUT_H
+
+#include "driver/rmt.h"
+#include "driver/gpio.h"
+
+/**
+ * @file RmtOutput.h
+ * @brief Simple wrapper around the ESP-IDF RMT API for TX channels.
+ */
+class RmtOutput {
+public:
+    RmtOutput(rmt_channel_t channel, gpio_num_t pin, uint32_t clk_div = 80) noexcept;
+    ~RmtOutput() noexcept;
+    RmtOutput(const RmtOutput&) = delete;
+    RmtOutput& operator=(const RmtOutput&) = delete;
+
+    bool Open() noexcept;
+    void Close() noexcept;
+
+    bool Write(const rmt_item32_t* items, size_t len, bool wait_tx_done = true) noexcept;
+
+    bool IsOpen() const noexcept { return installed; }
+
+private:
+    rmt_channel_t chan;
+    gpio_num_t gpio;
+    uint32_t div;
+    bool installed;
+};
+
+#endif // RMT_OUTPUT_H

--- a/inc/SfFlexCan.h
+++ b/inc/SfFlexCan.h
@@ -1,0 +1,47 @@
+/**
+ * @file SfFlexCan.h
+ * @brief Thread-safe wrapper around FlexCan using a FreeRTOS mutex.
+ */
+#ifndef SFFLEXCAN_H_
+#define SFFLEXCAN_H_
+
+#include "FlexCan.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+/**
+ * @class SfFlexCan
+ * @brief Adds mutex protection to FlexCan operations.
+ */
+class SfFlexCan {
+public:
+    /**
+     * @brief Construct a thread-safe CAN driver.
+     * @param port CAN controller port
+     * @param baudRate Bus bitrate in bit/s
+     * @param mutexHandle Mutex used for locking
+     */
+    SfFlexCan(uint8_t port, uint32_t baudRate, SemaphoreHandle_t mutexHandle) noexcept;
+    ~SfFlexCan() noexcept;
+    SfFlexCan(const SfFlexCan&) = delete;
+    SfFlexCan& operator=(const SfFlexCan&) = delete;
+
+    bool Open() noexcept;  ///< Initialize the underlying driver
+    bool Close() noexcept; ///< Stop and uninstall
+
+    bool Write(const FlexCan::Frame& frame, uint32_t timeoutMsec = 1000) noexcept;
+    bool Read(FlexCan::Frame& frame, uint32_t timeoutMsec = 0) noexcept;
+
+    bool Lock(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
+    bool Unlock() noexcept;
+
+    bool IsInitialized() const noexcept { return initialized; }
+    uint32_t GetBaudRate() const noexcept { return base.GetBaudRate(); }
+
+private:
+    FlexCan base;
+    SemaphoreHandle_t mutex;
+    bool initialized;
+};
+
+#endif // SFFLEXCAN_H_

--- a/src/NvsStorage.cpp
+++ b/src/NvsStorage.cpp
@@ -1,0 +1,71 @@
+/**
+ * @file NvsStorage.cpp
+ * @brief Implementation of the NvsStorage class.
+ */
+
+#include "NvsStorage.h"
+#include <cstring>
+
+NvsStorage::NvsStorage(const char* ns) noexcept
+    : nsName(ns), handle(0) {}
+
+NvsStorage::~NvsStorage() noexcept {
+    if (handle) {
+        Close();
+    }
+}
+
+bool NvsStorage::Open() noexcept {
+    if (handle)
+        return true;
+    esp_err_t err = nvs_flash_init();
+    if (err != ESP_OK && err != ESP_ERR_NVS_NO_FREE_PAGES &&
+        err != ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        return false;
+    }
+    if (err != ESP_OK) {
+        nvs_flash_erase();
+        if (nvs_flash_init() != ESP_OK)
+            return false;
+    }
+    err = nvs_open(nsName, NVS_READWRITE, &handle);
+    return err == ESP_OK;
+}
+
+void NvsStorage::Close() noexcept {
+    if (handle) {
+        nvs_close(handle);
+        handle = 0;
+    }
+}
+
+bool NvsStorage::SetU32(const char* key, uint32_t value) noexcept {
+    if (!handle)
+        return false;
+    esp_err_t err = nvs_set_u32(handle, key, value);
+    if (err != ESP_OK)
+        return false;
+    return Commit();
+}
+
+bool NvsStorage::GetU32(const char* key, uint32_t& value) noexcept {
+    if (!handle)
+        return false;
+    esp_err_t err = nvs_get_u32(handle, key, &value);
+    return err == ESP_OK;
+}
+
+bool NvsStorage::EraseKey(const char* key) noexcept {
+    if (!handle)
+        return false;
+    esp_err_t err = nvs_erase_key(handle, key);
+    if (err != ESP_OK)
+        return false;
+    return Commit();
+}
+
+bool NvsStorage::Commit() noexcept {
+    if (!handle)
+        return false;
+    return nvs_commit(handle) == ESP_OK;
+}

--- a/src/RmtOutput.cpp
+++ b/src/RmtOutput.cpp
@@ -1,0 +1,39 @@
+#include "RmtOutput.h"
+
+RmtOutput::RmtOutput(rmt_channel_t channel, gpio_num_t pin, uint32_t clk_div) noexcept
+    : chan(channel), gpio(pin), div(clk_div), installed(false) {}
+
+RmtOutput::~RmtOutput() noexcept {
+    Close();
+}
+
+bool RmtOutput::Open() noexcept {
+    if (installed) return true;
+    rmt_config_t cfg = {};
+    cfg.rmt_mode = RMT_MODE_TX;
+    cfg.channel = chan;
+    cfg.gpio_num = gpio;
+    cfg.clk_div = div;
+    cfg.mem_block_num = 1;
+    if (rmt_config(&cfg) != ESP_OK) {
+        return false;
+    }
+    if (rmt_driver_install(chan, 0, 0) != ESP_OK) {
+        return false;
+    }
+    installed = true;
+    return true;
+}
+
+void RmtOutput::Close() noexcept {
+    if (installed) {
+        rmt_driver_uninstall(chan);
+        installed = false;
+    }
+}
+
+bool RmtOutput::Write(const rmt_item32_t* items, size_t len, bool wait_tx_done) noexcept {
+    if (!installed) return false;
+    return rmt_write_items(chan, items, len, wait_tx_done) == ESP_OK;
+}
+

--- a/src/SfFlexCan.cpp
+++ b/src/SfFlexCan.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file SfFlexCan.cpp
+ * @brief Implementation of SfFlexCan.
+ */
+
+#include "SfFlexCan.h"
+
+SfFlexCan::SfFlexCan(uint8_t port, uint32_t baudRate, SemaphoreHandle_t mtx) noexcept
+    : base(port, baudRate), mutex(mtx), initialized(false) {}
+
+SfFlexCan::~SfFlexCan() noexcept {
+    if (initialized)
+        Close();
+}
+
+bool SfFlexCan::Open() noexcept {
+    if (initialized)
+        return true;
+    if (!base.Open())
+        return false;
+    initialized = true;
+    return true;
+}
+
+bool SfFlexCan::Close() noexcept {
+    if (!initialized)
+        return true;
+    base.Close();
+    initialized = false;
+    return true;
+}
+
+bool SfFlexCan::Write(const FlexCan::Frame& frame, uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+        return false;
+    bool ok = base.Write(frame);
+    xSemaphoreGive(mutex);
+    return ok;
+}
+
+bool SfFlexCan::Read(FlexCan::Frame& frame, uint32_t timeoutMsec) noexcept {
+    if (!initialized)
+        return false;
+    if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+        return false;
+    bool ok = base.Read(frame, timeoutMsec);
+    xSemaphoreGive(mutex);
+    return ok;
+}
+
+bool SfFlexCan::Lock(uint32_t timeoutMsec) noexcept {
+    return xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE;
+}
+
+bool SfFlexCan::Unlock() noexcept {
+    return xSemaphoreGive(mutex) == pdTRUE;
+}


### PR DESCRIPTION
## Summary
- implement `NvsStorage` helper for NVS key-value pairs
- implement `SfFlexCan` thread-safe wrapper around `FlexCan`
- document the new classes and update the navigation index
- list the new abstractions and usage examples in the README
- compile the new sources via CMakeLists
