### PR TITLE
Add CI build and example

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-*,clang-analyzer-*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI • Build · Size · Static Analyse
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IDF_TARGET: esp32c6
+  BUILD_PATH: ci_project
+  ESP_IDF_VERSIONS: '["release-v5.5"]'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build ➜ ${{ matrix.idf_version }} · ${{ matrix.build_type }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_version: [release-v5.5]
+        build_type: [Release, Debug]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Format check
+        run: clang-format --dry-run --Werror inc/*.h src/*.cpp examples/esp32/main/*.cpp
+
+      - name: ESP-IDF build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: ${{ matrix.idf_version }}
+          target: ${{ env.IDF_TARGET }}
+          path: .
+          command: |
+            idf.py create-project ${{ env.BUILD_PATH }}
+            cp examples/esp32/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
+            sed -i "s|../../|../|" ${{ env.BUILD_PATH }}/CMakeLists.txt
+            rm -rf ${{ env.BUILD_PATH }}/main
+            cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
+            idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
+            idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt
+            idf.py -C ${{ env.BUILD_PATH }} size --format json > ${{ env.BUILD_PATH }}/build/size.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: fw-${{ matrix.idf_version }}-${{ matrix.build_type }}
+          retention-days: 14
+          path: |
+            ${{ env.BUILD_PATH }}/build/*.bin
+            ${{ env.BUILD_PATH }}/build/*.elf
+            ${{ env.BUILD_PATH }}/build/*.map
+            ${{ env.BUILD_PATH }}/build/size.*
+
+  static-analysis:
+    if: github.event_name == 'pull_request'
+    name: Static analyse (cppcheck + clang-tidy)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: deep5050/cppcheck-action@v3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable: all
+          inconclusive: true
+          std: c99
+          include: main
+
+      - uses: ZedThree/clang-tidy-review@v0.21.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .clang-tidy
+
+  workflow-lint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.6.25

--- a/examples/esp32/CMakeLists.txt
+++ b/examples/esp32/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
+    set(EXTRA_COMPONENT_DIRS "../../")
+
+        include($ENV{IDF_PATH} / tools / cmake / project.cmake) project(iid_example)

--- a/examples/esp32/main/CMakeLists.txt
+++ b/examples/esp32/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "main.cpp"
+                            "DummyTransport.cpp" INCLUDE_DIRS "." REQUIRES hf -
+                       internal - interface - wrap)

--- a/examples/esp32/main/DummyTransport.cpp
+++ b/examples/esp32/main/DummyTransport.cpp
@@ -1,0 +1,10 @@
+#include "DummyTransport.h"
+
+bool DummyTransport::WriteReg(uint8_t reg, uint8_t val) {
+    uint8_t buf[2] = {reg, val};
+    return bus.Write(0x50, buf, 2);
+}
+
+bool DummyTransport::ReadReg(uint8_t reg, uint8_t &val) {
+    return bus.WriteRead(0x50, &reg, 1, &val, 1);
+}

--- a/examples/esp32/main/DummyTransport.h
+++ b/examples/esp32/main/DummyTransport.h
@@ -1,0 +1,16 @@
+#ifndef DUMMY_TRANSPORT_H
+#define DUMMY_TRANSPORT_H
+
+#include "I2cBus.h"
+
+class DummyTransport {
+  public:
+    explicit DummyTransport(I2cBus &b) : bus(b) {}
+    bool WriteReg(uint8_t reg, uint8_t val);
+    bool ReadReg(uint8_t reg, uint8_t &val);
+
+  private:
+    I2cBus &bus;
+};
+
+#endif // DUMMY_TRANSPORT_H

--- a/examples/esp32/main/main.cpp
+++ b/examples/esp32/main/main.cpp
@@ -1,0 +1,30 @@
+#include "DigitalOutput.h"
+#include "DummyTransport.h"
+#include "I2cBus.h"
+#include "PeriodicTimer.h"
+
+static void ToggleCb(void *arg) {
+    auto led = static_cast<DigitalOutput *>(arg);
+    led->Toggle();
+}
+
+extern "C" void app_main() {
+    i2c_config_t cfg = {};
+    cfg.mode = I2C_MODE_MASTER;
+    cfg.sda_io_num = GPIO_NUM_8;
+    cfg.scl_io_num = GPIO_NUM_9;
+    cfg.master.clk_speed = 100000;
+
+    I2cBus bus(I2C_NUM_0, cfg);
+    bus.Open();
+
+    DummyTransport transport(bus);
+    uint8_t value = 0;
+    transport.ReadReg(0x00, value);
+
+    DigitalOutput led(GPIO_NUM_2, DigitalGpio::ActiveState::High);
+    PeriodicTimer timer(&ToggleCb, &led);
+    timer.Start(1000000);
+
+    (void)value;
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to compile with ESP-IDF
- provide ESP32 example with component CMake files
- add dummy transport layer used in example
- add minimal clang-format and clang-tidy configs
