### PR TITLE
Fix clang-format issues in interface drivers

### DIFF
--- a/inc/BaseAdc.h
+++ b/inc/BaseAdc.h
@@ -1,11 +1,15 @@
 /**
 
-  *  Contains the declaration of the abstract Adc class, which provides features common to
-  *    ADC classes.  Adc's derived classes are intended to employ lazy initialization;
+  *  Contains the declaration of the abstract Adc class, which provides features
+  common to
+  *    ADC classes.  Adc's derived classes are intended to employ lazy
+  initialization;
   *    they are initialized the first time the pin in manipulated.
   *
-  *  Note:  These functions are not thread or interrupt-safe and should be called
-  *          called with appropriate guards if used within an ISR or shared between tasks.
+  *  Note:  These functions are not thread or interrupt-safe and should be
+  called
+  *          called with appropriate guards if used within an ISR or shared
+  between tasks.
   -------------------------------------------------------------------------------------**/
 
 #ifndef HAL_INTERNAL_INTERFACE_DRIVERS_BASEADC_H_
@@ -20,58 +24,68 @@
  */
 class BaseAdc {
 public:
-    /**
-     * @brief ADC error codes
-     */
-    enum class AdcErr {
-        ADC_SUCCESS,
-        ADC_ERR_FAILURE,
-        ADC_ERR_CHANNEL_NOT_FOUND,
-        ADC_ERR_CHANNEL_NOT_ENABLED,
-        ADC_ERR_CHANNEL_READ_ERR,
-        ADC_ERR_INVALID_SAMPLE_COUNT,
-    };
+  /**
+   * @brief ADC error codes
+   */
+  enum class AdcErr {
+    ADC_SUCCESS,
+    ADC_ERR_FAILURE,
+    ADC_ERR_CHANNEL_NOT_FOUND,
+    ADC_ERR_CHANNEL_NOT_ENABLED,
+    ADC_ERR_CHANNEL_READ_ERR,
+    ADC_ERR_INVALID_SAMPLE_COUNT,
+  };
 
-    /**
-     * @brief Constructor
-     */
-    BaseAdc() : initialized(false) {}
+  /**
+   * @brief Constructor
+   */
+  BaseAdc() : initialized(false) {}
 
-    /**
-     * @brief Virtual destructor
-     */
-    virtual ~BaseAdc() {}
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~BaseAdc() {}
 
-    /**
-     * @brief Ensures that the ADC is initialized (lazy initialization).
-     * @return true if the ADC is initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized) {
-            initialized = Initialize();
-        }
-        return initialized;
+  /**
+   * @brief Ensures that the ADC is initialized (lazy initialization).
+   * @return true if the ADC is initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized) {
+      initialized = Initialize();
     }
+    return initialized;
+  }
 
-    /**
-     * @brief Checks if the class is initialized.
-     * @return true if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept { return initialized; }
+  /**
+   * @brief Checks if the class is initialized.
+   * @return true if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept { return initialized; }
 
-    /**
-     * @brief Initializes the ADC peripheral (must be implemented by derived classes).
-     * @return True if the initialization is successful, false otherwise.
-     */
-    virtual bool Initialize() noexcept = 0;
+  /**
+   * @brief Initializes the ADC peripheral (must be implemented by derived
+   * classes).
+   * @return True if the initialization is successful, false otherwise.
+   */
+  virtual bool Initialize() noexcept = 0;
 
-    // PURE VIRTUAL FUNCTIONS, MUST BE OVERRIDDEN
-    virtual AdcErr ReadChannelV(uint8_t channel_num, float& channel_reading_v, uint8_t numOfSamplesToAvg = 1, uint32_t timeBetweenSamples = 0) noexcept = 0;
-    virtual AdcErr ReadChannelCount(uint8_t channel_num, uint32_t& channel_reading_count, uint8_t numOfSamplesToAvg = 1, uint32_t timeBetweenSamples = 0) noexcept = 0;
-    virtual AdcErr ReadChannel(uint8_t channel_num, uint32_t& channel_reading_count, float& channel_reading_v, uint8_t numOfSamplesToAvg = 1, uint32_t timeBetweenSamples = 0) noexcept = 0;
+  // PURE VIRTUAL FUNCTIONS, MUST BE OVERRIDDEN
+  virtual AdcErr ReadChannelV(uint8_t channel_num, float &channel_reading_v,
+                              uint8_t numOfSamplesToAvg = 1,
+                              uint32_t timeBetweenSamples = 0) noexcept = 0;
+  virtual AdcErr ReadChannelCount(uint8_t channel_num,
+                                  uint32_t &channel_reading_count,
+                                  uint8_t numOfSamplesToAvg = 1,
+                                  uint32_t timeBetweenSamples = 0) noexcept = 0;
+  virtual AdcErr ReadChannel(uint8_t channel_num,
+                             uint32_t &channel_reading_count,
+                             float &channel_reading_v,
+                             uint8_t numOfSamplesToAvg = 1,
+                             uint32_t timeBetweenSamples = 0) noexcept = 0;
 
 protected:
-    bool initialized;
+  bool initialized;
 };
 
 #endif /* HAL_INTERNAL_INTERFACE_DRIVERS_BASEADC_H_ */

--- a/inc/BaseGpio.h
+++ b/inc/BaseGpio.h
@@ -2,10 +2,12 @@
  * @file BaseGpio.h
  * @brief Abstract base class for GPIO pin abstraction using ESP-IDF (ESP32-C6).
  *
- * This class provides a hardware abstraction for GPIO pins, supporting lazy initialization and
- * ESP-IDF configuration. It is designed to be inherited by digital input/output classes.
+ * This class provides a hardware abstraction for GPIO pins, supporting lazy
+ * initialization and ESP-IDF configuration. It is designed to be inherited by
+ * digital input/output classes.
  *
- * @note This class is not thread-safe. Use appropriate synchronization if accessed from multiple contexts.
+ * @note This class is not thread-safe. Use appropriate synchronization if
+ * accessed from multiple contexts.
  */
 #ifndef BASEGPIO_H
 #define BASEGPIO_H
@@ -19,69 +21,69 @@
  */
 class BaseGpio {
 public:
-    /**
-     * @brief Constructor allocates an instance of the class with a specified pin.
-     * @param pinArg GPIO pin number (gpio_num_t)
-     */
-    explicit BaseGpio(gpio_num_t pinArg) noexcept :
-        pin(pinArg),
-        initialized(false)
-    {
-        // No code at this time
+  /**
+   * @brief Constructor allocates an instance of the class with a specified pin.
+   * @param pinArg GPIO pin number (gpio_num_t)
+   */
+  explicit BaseGpio(gpio_num_t pinArg) noexcept
+      : pin(pinArg), initialized(false) {
+    // No code at this time
+  }
+
+  /**
+   * @brief Copy constructor is deleted to avoid copying instances.
+   */
+  BaseGpio(const BaseGpio &copy) = delete;
+
+  /**
+   * @brief Assignment operator is deleted to avoid copying instances.
+   */
+  BaseGpio &operator=(const BaseGpio &copy) = delete;
+
+  /**
+   * @brief Virtual destructor.
+   */
+  virtual ~BaseGpio() = default;
+
+  /**
+   * @brief Returns true if the pin is initialized.
+   */
+  bool IsInitialized() const noexcept { return initialized; }
+
+  /**
+   * @brief Ensures the pin is initialized (lazy initialization).
+   * @return true if initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized) {
+      initialized = Initialize();
     }
+    return initialized;
+  }
 
-    /**
-     * @brief Copy constructor is deleted to avoid copying instances.
-     */
-    BaseGpio(const BaseGpio& copy) = delete;
+  /**
+   * @brief Virtual function to initialize the GPIO pin (must be implemented by
+   * derived classes).
+   * @return true if able to initialize, false otherwise.
+   */
+  virtual bool Initialize() noexcept = 0;
 
-    /**
-     * @brief Assignment operator is deleted to avoid copying instances.
-     */
-    BaseGpio& operator=(const BaseGpio& copy) = delete;
+  /**
+   * @brief Returns the GPIO pin number.
+   * @return gpio_num_t pin number.
+   */
+  gpio_num_t GetPin() const noexcept { return pin; }
 
-    /**
-     * @brief Virtual destructor.
-     */
-    virtual ~BaseGpio() = default;
-
-    /**
-     * @brief Returns true if the pin is initialized.
-     */
-    bool IsInitialized() const noexcept { return initialized; }
-
-    /**
-     * @brief Ensures the pin is initialized (lazy initialization).
-     * @return true if initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized) {
-            initialized = Initialize();
-        }
-        return initialized;
-    }
-
-    /**
-     * @brief Virtual function to initialize the GPIO pin (must be implemented by derived classes).
-     * @return true if able to initialize, false otherwise.
-     */
-    virtual bool Initialize() noexcept = 0;
-
-    /**
-     * @brief Returns the GPIO pin number.
-     * @return gpio_num_t pin number.
-     */
-    gpio_num_t GetPin() const noexcept { return pin; }
-
-    /**
-     * @brief Returns the ESP-IDF pin configuration flags (to be implemented by derived classes if needed).
-     * @return uint32_t pin configuration flags.
-     */
-    virtual uint32_t GetPinConfiguration() const noexcept { return 0; }
+  /**
+   * @brief Returns the ESP-IDF pin configuration flags (to be implemented by
+   * derived classes if needed).
+   * @return uint32_t pin configuration flags.
+   */
+  virtual uint32_t GetPinConfiguration() const noexcept { return 0; }
 
 protected:
-    const gpio_num_t pin;   ///< ESP32-C6 GPIO pin number
-    bool initialized;       ///< Initialization state
+  const gpio_num_t pin; ///< ESP32-C6 GPIO pin number
+  bool initialized;     ///< Initialization state
 };
 
 #endif // BASEGPIO_H

--- a/inc/DacOutput.h
+++ b/inc/DacOutput.h
@@ -1,8 +1,8 @@
 #ifndef DACOUTPUT_H
 #define DACOUTPUT_H
 
-#include <driver/dac_common.h>
 #include <cstdint>
+#include <driver/dac_common.h>
 
 /**
  * @file DacOutput.h
@@ -10,20 +10,20 @@
  */
 class DacOutput {
 public:
-    explicit DacOutput(dac_channel_t channel) noexcept;
-    ~DacOutput() noexcept;
-    DacOutput(const DacOutput&) = delete;
-    DacOutput& operator=(const DacOutput&) = delete;
+  explicit DacOutput(dac_channel_t channel) noexcept;
+  ~DacOutput() noexcept;
+  DacOutput(const DacOutput &) = delete;
+  DacOutput &operator=(const DacOutput &) = delete;
 
-    bool Enable() noexcept;   ///< Enable the channel
-    bool Disable() noexcept;  ///< Disable the channel
-    bool SetValue(uint8_t value) noexcept; ///< Output 8-bit value
+  bool Enable() noexcept;                ///< Enable the channel
+  bool Disable() noexcept;               ///< Disable the channel
+  bool SetValue(uint8_t value) noexcept; ///< Output 8-bit value
 
-    bool IsEnabled() const noexcept { return enabled; }
+  bool IsEnabled() const noexcept { return enabled; }
 
 private:
-    dac_channel_t channel;
-    bool enabled;
+  dac_channel_t channel;
+  bool enabled;
 };
 
 #endif // DACOUTPUT_H

--- a/inc/DigitalExternalIRQ.h
+++ b/inc/DigitalExternalIRQ.h
@@ -17,40 +17,40 @@
 
 class DigitalExternalIRQ : public DigitalInput {
 public:
-    /**
-     * @brief Construct an external interrupt on the given pin.
-     *
-     * @param pin           GPIO pin number.
-     * @param interruptType ESP-IDF interrupt type (e.g. GPIO_INTR_POSEDGE).
-     * @param activeState   Logical active level of the pin.
-     */
-    DigitalExternalIRQ(gpio_num_t pin,
-                       gpio_int_type_t interruptType = GPIO_INTR_POSEDGE,
-                       ActiveState activeState = ActiveState::High) noexcept;
+  /**
+   * @brief Construct an external interrupt on the given pin.
+   *
+   * @param pin           GPIO pin number.
+   * @param interruptType ESP-IDF interrupt type (e.g. GPIO_INTR_POSEDGE).
+   * @param activeState   Logical active level of the pin.
+   */
+  DigitalExternalIRQ(gpio_num_t pin,
+                     gpio_int_type_t interruptType = GPIO_INTR_POSEDGE,
+                     ActiveState activeState = ActiveState::High) noexcept;
 
-    DigitalExternalIRQ(const DigitalExternalIRQ&) = delete;
-    DigitalExternalIRQ& operator=(const DigitalExternalIRQ&) = delete;
-    virtual ~DigitalExternalIRQ();
+  DigitalExternalIRQ(const DigitalExternalIRQ &) = delete;
+  DigitalExternalIRQ &operator=(const DigitalExternalIRQ &) = delete;
+  virtual ~DigitalExternalIRQ();
 
-    /** Enable external interrupt handling. */
-    bool Enable();
-    /** Disable external interrupt handling. */
-    bool Disable();
+  /** Enable external interrupt handling. */
+  bool Enable();
+  /** Disable external interrupt handling. */
+  bool Disable();
 
-    /**
-     * @brief Block until the interrupt occurs or the timeout expires.
-     * @param timeoutMs Timeout in milliseconds (defaults to indefinite).
-     * @return true if the interrupt was received, false on timeout or error.
-     */
-    bool Wait(uint32_t timeoutMs = portMAX_DELAY);
+  /**
+   * @brief Block until the interrupt occurs or the timeout expires.
+   * @param timeoutMs Timeout in milliseconds (defaults to indefinite).
+   * @return true if the interrupt was received, false on timeout or error.
+   */
+  bool Wait(uint32_t timeoutMs = portMAX_DELAY);
 
 private:
-    virtual bool Initialize() noexcept override;
-    static void IRAM_ATTR IsrHandler(void* arg);
+  virtual bool Initialize() noexcept override;
+  static void IRAM_ATTR IsrHandler(void *arg);
 
-    gpio_int_type_t intrType;
-    SemaphoreHandle_t binSem;
-    bool enabled;
+  gpio_int_type_t intrType;
+  SemaphoreHandle_t binSem;
+  bool enabled;
 };
 
 #endif // DIGITALEXTERNALIRQ_H

--- a/inc/DigitalGpio.h
+++ b/inc/DigitalGpio.h
@@ -1,11 +1,14 @@
 /**
  * @file DigitalGpio.h
- * @brief Abstract base class DigitalGpio for handling GPIO pins on ESP32-C6 (ESP-IDF).
+ * @brief Abstract base class DigitalGpio for handling GPIO pins on ESP32-C6
+ * (ESP-IDF).
  *
- * The DigitalGpio class provides common features for handling digital GPIO pins using ESP-IDF.
- * It is designed with lazy initialization; pins are initialized when first manipulated.
+ * The DigitalGpio class provides common features for handling digital GPIO pins
+ * using ESP-IDF. It is designed with lazy initialization; pins are initialized
+ * when first manipulated.
  *
- * @note These functions are not thread-safe. Use appropriate guards in ISR or multi-threaded contexts.
+ * @note These functions are not thread-safe. Use appropriate guards in ISR or
+ * multi-threaded contexts.
  */
 #ifndef DIGITALGPIO_H
 #define DIGITALGPIO_H
@@ -19,101 +22,100 @@
  */
 class DigitalGpio : public BaseGpio {
 public:
-    /**
-     * @brief Enumeration for setting the mode of the GPIO pin.
-     */
-    enum class Mode : uint8_t {
-        OpenDrain,   ///< Open-drain output
-        PushPull     ///< Push-pull output
-    };
+  /**
+   * @brief Enumeration for setting the mode of the GPIO pin.
+   */
+  enum class Mode : uint8_t {
+    OpenDrain, ///< Open-drain output
+    PushPull   ///< Push-pull output
+  };
 
-    /**
-     * @brief Enumeration for describing the state of the GPIO pin.
-     */
-    enum class State : uint8_t {
-        Active,
-        Inactive
-    };
+  /**
+   * @brief Enumeration for describing the state of the GPIO pin.
+   */
+  enum class State : uint8_t { Active, Inactive };
 
-    /**
-     * @brief Enumeration for describing the active state of the GPIO pin.
-     */
-    enum class ActiveState : uint8_t {
-        High,   ///< Active when logic high
-        Low     ///< Active when logic low
-    };
+  /**
+   * @brief Enumeration for describing the active state of the GPIO pin.
+   */
+  enum class ActiveState : uint8_t {
+    High, ///< Active when logic high
+    Low   ///< Active when logic low
+  };
 
-    /**
-     * @brief Enumeration for describing the resistance configuration of the GPIO pin.
-     */
-    enum class Resistance : uint8_t {
-        Floating,   ///< No pull-up or pull-down
-        PullUp,     ///< Pull-up enabled
-        PullDown    ///< Pull-down enabled
-    };
+  /**
+   * @brief Enumeration for describing the resistance configuration of the GPIO
+   * pin.
+   */
+  enum class Resistance : uint8_t {
+    Floating, ///< No pull-up or pull-down
+    PullUp,   ///< Pull-up enabled
+    PullDown  ///< Pull-down enabled
+  };
 
-    /**
-     * @brief Converts Mode enum to string.
-     */
-    static const char* ToString(Mode mode) noexcept;
-    /**
-     * @brief Converts State enum to string.
-     */
-    static const char* ToString(State state) noexcept;
-    /**
-     * @brief Converts ActiveState enum to string.
-     */
-    static const char* ToString(ActiveState activeState) noexcept;
-    /**
-     * @brief Converts Resistance enum to string.
-     */
-    static const char* ToString(Resistance resistance) noexcept;
+  /**
+   * @brief Converts Mode enum to string.
+   */
+  static const char *ToString(Mode mode) noexcept;
+  /**
+   * @brief Converts State enum to string.
+   */
+  static const char *ToString(State state) noexcept;
+  /**
+   * @brief Converts ActiveState enum to string.
+   */
+  static const char *ToString(ActiveState activeState) noexcept;
+  /**
+   * @brief Converts Resistance enum to string.
+   */
+  static const char *ToString(Resistance resistance) noexcept;
 
 protected:
-    /**
-     * @brief Constructor that initializes an instance with a pin and active state.
-     * @param pinArg GPIO pin number (gpio_num_t)
-     * @param activeStateArg Defines the active state of the pin.
-     */
-    DigitalGpio(gpio_num_t pinArg, ActiveState activeStateArg) noexcept :
-        BaseGpio(pinArg),
-        activeState(activeStateArg)
-    {
-        // No code at this time
-    }
+  /**
+   * @brief Constructor that initializes an instance with a pin and active
+   * state.
+   * @param pinArg GPIO pin number (gpio_num_t)
+   * @param activeStateArg Defines the active state of the pin.
+   */
+  DigitalGpio(gpio_num_t pinArg, ActiveState activeStateArg) noexcept
+      : BaseGpio(pinArg), activeState(activeStateArg) {
+    // No code at this time
+  }
 
-    /**
-     * @brief Copy constructor is deleted to prevent instance copying.
-     */
-    DigitalGpio(const DigitalGpio& copy) = delete;
-    /**
-     * @brief Assignment operator is deleted to prevent instance copying.
-     */
-    DigitalGpio& operator=(const DigitalGpio& copy) = delete;
-    /**
-     * @brief Default destructor.
-     */
-    virtual ~DigitalGpio() = default;
+  /**
+   * @brief Copy constructor is deleted to prevent instance copying.
+   */
+  DigitalGpio(const DigitalGpio &copy) = delete;
+  /**
+   * @brief Assignment operator is deleted to prevent instance copying.
+   */
+  DigitalGpio &operator=(const DigitalGpio &copy) = delete;
+  /**
+   * @brief Default destructor.
+   */
+  virtual ~DigitalGpio() = default;
 
-    /**
-     * @brief Checks if the pin is active high.
-     * @return True if the pin is active high, false otherwise.
-     */
-    bool IsActiveHigh() const noexcept { return activeState == ActiveState::High; }
-    /**
-     * @brief Checks if the pin is active low.
-     * @return True if the pin is active low, false otherwise.
-     */
-    bool IsActiveLow() const noexcept { return activeState == ActiveState::Low; }
+  /**
+   * @brief Checks if the pin is active high.
+   * @return True if the pin is active high, false otherwise.
+   */
+  bool IsActiveHigh() const noexcept {
+    return activeState == ActiveState::High;
+  }
+  /**
+   * @brief Checks if the pin is active low.
+   * @return True if the pin is active low, false otherwise.
+   */
+  bool IsActiveLow() const noexcept { return activeState == ActiveState::Low; }
 
-    /**
-     * @brief Fetches the resistance configuration of the pin (ESP-IDF style).
-     * @return The resistance configuration of the pin.
-     */
-    Resistance GetResistance() const noexcept;
+  /**
+   * @brief Fetches the resistance configuration of the pin (ESP-IDF style).
+   * @return The resistance configuration of the pin.
+   */
+  Resistance GetResistance() const noexcept;
 
 private:
-    const ActiveState activeState; ///< Pin active state (high or low)
+  const ActiveState activeState; ///< Pin active state (high or low)
 };
 
 #endif // DIGITALGPIO_H

--- a/inc/DigitalInput.h
+++ b/inc/DigitalInput.h
@@ -1,12 +1,15 @@
 /**
  * @file DigitalInput.h
- * @brief DigitalInput class for describing GPIO input pins on ESP32-C6 (ESP-IDF).
+ * @brief DigitalInput class for describing GPIO input pins on ESP32-C6
+ * (ESP-IDF).
  *
  * The DigitalInput class is part of a hardware abstraction layer (HAL)
- * and provides an interface for manipulating GPIO input pins. The class is designed
- * with lazy initialization, i.e., pins are initialized when first manipulated.
+ * and provides an interface for manipulating GPIO input pins. The class is
+ * designed with lazy initialization, i.e., pins are initialized when first
+ * manipulated.
  *
- * @note These functions are not thread-safe. Use appropriate guards in ISR or multi-threaded contexts.
+ * @note These functions are not thread-safe. Use appropriate guards in ISR or
+ * multi-threaded contexts.
  */
 #ifndef DIGITALINPUT_H
 #define DIGITALINPUT_H
@@ -20,44 +23,46 @@
  */
 class DigitalInput : public DigitalGpio {
 public:
-    /**
-     * @brief Constructor creates an instance of DigitalInput with a pin and active state.
-     * @param pin GPIO pin number (gpio_num_t)
-     * @param activeState Defines the active state of the pin.
-     */
-    DigitalInput(gpio_num_t pin, ActiveState activeState) noexcept;
+  /**
+   * @brief Constructor creates an instance of DigitalInput with a pin and
+   * active state.
+   * @param pin GPIO pin number (gpio_num_t)
+   * @param activeState Defines the active state of the pin.
+   */
+  DigitalInput(gpio_num_t pin, ActiveState activeState) noexcept;
 
-    /**
-     * @brief Copy constructor is deleted to prevent instance copying.
-     */
-    DigitalInput(const DigitalInput&) = delete;
-    /**
-     * @brief Assignment operator is deleted to prevent instance copying.
-     */
-    DigitalInput& operator=(const DigitalInput&) = delete;
-    /**
-     * @brief Default destructor.
-     */
-    virtual ~DigitalInput() override = default;
+  /**
+   * @brief Copy constructor is deleted to prevent instance copying.
+   */
+  DigitalInput(const DigitalInput &) = delete;
+  /**
+   * @brief Assignment operator is deleted to prevent instance copying.
+   */
+  DigitalInput &operator=(const DigitalInput &) = delete;
+  /**
+   * @brief Default destructor.
+   */
+  virtual ~DigitalInput() override = default;
 
-    /**
-     * @brief Checks if the logical pin state is active.
-     * @return True if the pin is active, false otherwise.
-     */
-    bool IsActive() noexcept;
+  /**
+   * @brief Checks if the logical pin state is active.
+   * @return True if the pin is active, false otherwise.
+   */
+  bool IsActive() noexcept;
 
-    /**
-     * @brief Fetches the current state of the pin.
-     * @return The current state of the pin.
-     */
-    State GetState() noexcept;
+  /**
+   * @brief Fetches the current state of the pin.
+   * @return The current state of the pin.
+   */
+  State GetState() noexcept;
 
 private:
-    /**
-     * @brief Virtual function to initialize the peripheral (configures pin as input).
-     * @return True if initialization is successful, false otherwise.
-     */
-    virtual bool Initialize() noexcept override;
+  /**
+   * @brief Virtual function to initialize the peripheral (configures pin as
+   * input).
+   * @return True if initialization is successful, false otherwise.
+   */
+  virtual bool Initialize() noexcept override;
 };
 
 #endif // DIGITALINPUT_H

--- a/inc/DigitalOutput.h
+++ b/inc/DigitalOutput.h
@@ -1,11 +1,14 @@
 /**
  * @file DigitalOutput.h
- * @brief Contains the definition of the DigitalOutput class for ESP32-C6 (ESP-IDF).
+ * @brief Contains the definition of the DigitalOutput class for ESP32-C6
+ * (ESP-IDF).
  *
- * Provides facilities to describe and control GPIO output pins using ESP-IDF. Supports push-pull and open-drain modes,
- * as well as lazy initialization and thread safety (if Mutex is implemented for ESP32).
+ * Provides facilities to describe and control GPIO output pins using ESP-IDF.
+ * Supports push-pull and open-drain modes, as well as lazy initialization and
+ * thread safety (if Mutex is implemented for ESP32).
  *
- * @note These functions are not thread-safe unless protected externally. Use appropriate guards in ISR or multi-threaded contexts.
+ * @note These functions are not thread-safe unless protected externally. Use
+ * appropriate guards in ISR or multi-threaded contexts.
  */
 #ifndef DIGITALOUTPUT_H
 #define DIGITALOUTPUT_H
@@ -16,69 +19,74 @@
 
 /**
  * @class DigitalOutput
- * @brief Provides facilities to describe and control GPIO output pins on ESP32-C6.
+ * @brief Provides facilities to describe and control GPIO output pins on
+ * ESP32-C6.
  */
 class DigitalOutput : public DigitalGpio {
 public:
-    /**
-     * @brief Constructor allocates an instance of the class with a pin, active state, and initial state.
-     * @param pinArg GPIO pin number (gpio_num_t)
-     * @param activeStateArg Indicates whether the set bit is active.
-     * @param initialStateArg The initial state of the pin (default: State::Inactive).
-     */
-    DigitalOutput(gpio_num_t pinArg, ActiveState activeStateArg, State initialStateArg = State::Inactive) noexcept;
+  /**
+   * @brief Constructor allocates an instance of the class with a pin, active
+   * state, and initial state.
+   * @param pinArg GPIO pin number (gpio_num_t)
+   * @param activeStateArg Indicates whether the set bit is active.
+   * @param initialStateArg The initial state of the pin (default:
+   * State::Inactive).
+   */
+  DigitalOutput(gpio_num_t pinArg, ActiveState activeStateArg,
+                State initialStateArg = State::Inactive) noexcept;
 
-    /**
-     * @brief Copy constructor is deleted to avoid copying instances.
-     */
-    DigitalOutput(const DigitalOutput& copy) = delete;
-    /**
-     * @brief Assignment operator is deleted to avoid copying instances.
-     */
-    DigitalOutput& operator=(const DigitalOutput& copy) = delete;
-    /**
-     * @brief Destructor.
-     */
-    virtual ~DigitalOutput() override;
+  /**
+   * @brief Copy constructor is deleted to avoid copying instances.
+   */
+  DigitalOutput(const DigitalOutput &copy) = delete;
+  /**
+   * @brief Assignment operator is deleted to avoid copying instances.
+   */
+  DigitalOutput &operator=(const DigitalOutput &copy) = delete;
+  /**
+   * @brief Destructor.
+   */
+  virtual ~DigitalOutput() override;
 
-    /**
-     * @brief Helper function to return the output mode (PushPull/OpenDrain).
-     * @returns The output mode.
-     */
-    Mode OutputMode() const noexcept;
+  /**
+   * @brief Helper function to return the output mode (PushPull/OpenDrain).
+   * @returns The output mode.
+   */
+  Mode OutputMode() const noexcept;
 
-    /**
-     * @brief Helper function to return the logical state of the pin.
-     * @returns True if the pin is logically active, false otherwise.
-     */
-    bool IsActive() noexcept;
+  /**
+   * @brief Helper function to return the logical state of the pin.
+   * @returns True if the pin is logically active, false otherwise.
+   */
+  bool IsActive() noexcept;
 
-    /**
-     * @brief Function to set the logical active state.
-     * @returns True if the operation was successful, false otherwise.
-     */
-    bool SetActive() noexcept;
+  /**
+   * @brief Function to set the logical active state.
+   * @returns True if the operation was successful, false otherwise.
+   */
+  bool SetActive() noexcept;
 
-    /**
-     * @brief Function to reset the pin to the logical inactive state.
-     * @returns True if the operation was successful, false otherwise.
-     */
-    bool SetInactive() noexcept;
+  /**
+   * @brief Function to reset the pin to the logical inactive state.
+   * @returns True if the operation was successful, false otherwise.
+   */
+  bool SetInactive() noexcept;
 
-    /**
-     * @brief Function to toggle the pin state.
-     * @returns True if the operation was successful, false otherwise.
-     */
-    bool Toggle() noexcept;
+  /**
+   * @brief Function to toggle the pin state.
+   * @returns True if the operation was successful, false otherwise.
+   */
+  bool Toggle() noexcept;
 
 private:
-    const State initialState; ///< The initial state of the pin.
+  const State initialState; ///< The initial state of the pin.
 
-    /**
-     * @brief Virtual function to initialize the peripheral (configures pin as output).
-     * @returns True if able to initialize, false otherwise.
-     */
-    virtual bool Initialize() noexcept override;
+  /**
+   * @brief Virtual function to initialize the peripheral (configures pin as
+   * output).
+   * @returns True if able to initialize, false otherwise.
+   */
+  virtual bool Initialize() noexcept override;
 };
 
 #endif // DIGITALOUTPUT_H

--- a/inc/DigitalOutputGuard.h
+++ b/inc/DigitalOutputGuard.h
@@ -2,13 +2,15 @@
  * Nebula Tech Corporation
  *
  * Copyright © 2023 Nebula Tech Corporation.   All Rights Reserved.
- * This file is part of HardFOC and is licensed under the GNU General Public License v3.0 or later.
+ * This file is part of HardFOC and is licensed under the GNU General Public
+License v3.0 or later.
 
 /**
  * @file DigitalOutputGuard.h
  * @brief Header file for the DigitalOutputGuard class.
  *
- * The DigitalOutputGuard class ensures that a DigitalOutput instance is set active
+ * The DigitalOutputGuard class ensures that a DigitalOutput instance is set
+active
  * in its constructor and inactive in its destructor (RAII pattern).
  */
 
@@ -22,36 +24,38 @@
  * @class DigitalOutputGuard
  * @brief Guard class for managing the state of a DigitalOutput instance.
  *
- * The DigitalOutputGuard sets the associated DigitalOutput instance active in its constructor
- * and inactive in its destructor. This ensures proper resource management and consistent behavior.
+ * The DigitalOutputGuard sets the associated DigitalOutput instance active in
+ * its constructor and inactive in its destructor. This ensures proper resource
+ * management and consistent behavior.
  */
 class DigitalOutputGuard {
 public:
-    /**
-     * @brief Constructor.
-     * @param output Reference to the DigitalOutput instance to manage.
-     *
-     * The constructor sets the associated DigitalOutput instance active.
-     */
-    DigitalOutputGuard(DigitalOutput& output);
+  /**
+   * @brief Constructor.
+   * @param output Reference to the DigitalOutput instance to manage.
+   *
+   * The constructor sets the associated DigitalOutput instance active.
+   */
+  DigitalOutputGuard(DigitalOutput &output);
 
-    /**
-     * @brief Constructor.
-     * @param output Reference to the DigitalOutput instance to manage.
-     *
-     * The constructor sets the associated DigitalOutput instance active.
-     */
-    DigitalOutputGuard(DigitalOutput* output);
+  /**
+   * @brief Constructor.
+   * @param output Reference to the DigitalOutput instance to manage.
+   *
+   * The constructor sets the associated DigitalOutput instance active.
+   */
+  DigitalOutputGuard(DigitalOutput *output);
 
-    /**
-     * @brief Destructor.
-     *
-     * The destructor sets the associated DigitalOutput instance inactive.
-     */
-    ~DigitalOutputGuard();
+  /**
+   * @brief Destructor.
+   *
+   * The destructor sets the associated DigitalOutput instance inactive.
+   */
+  ~DigitalOutputGuard();
 
 private:
-    DigitalOutput* p_output_; ///< Reference to the managed DigitalOutput instance.
+  DigitalOutput
+      *p_output_; ///< Reference to the managed DigitalOutput instance.
 };
 
 #endif /* HAL_INTERNAL_INTERFACE_DRIVERS_DIGITALOUTPUTGUARD_H_ */

--- a/inc/Esp32C6Adc.h
+++ b/inc/Esp32C6Adc.h
@@ -2,9 +2,11 @@
  * @file Esp32C6Adc.h
  * @brief ADC driver class for ESP32-C6 using ESP-IDF.
  *
- * This class provides an implementation of BaseAdc for the ESP32-C6, using ESP-IDF's ADC APIs.
+ * This class provides an implementation of BaseAdc for the ESP32-C6, using
+ * ESP-IDF's ADC APIs.
  *
- * @note This class is not thread-safe. Use appropriate synchronization if accessed from multiple contexts.
+ * @note This class is not thread-safe. Use appropriate synchronization if
+ * accessed from multiple contexts.
  */
 #ifndef HAL_INTERNAL_INTERFACE_DRIVERS_ESP32C6ADC_H_
 #define HAL_INTERNAL_INTERFACE_DRIVERS_ESP32C6ADC_H_
@@ -15,61 +17,75 @@
 
 class Esp32C6Adc : public BaseAdc {
 public:
-    /**
-     * @brief Constructor for ESP32-C6 ADC driver.
-     * @param adc_unit ADC unit (ADC_UNIT_1 or ADC_UNIT_2)
-     * @param attenuation ADC attenuation (ADC_ATTEN_DB_0, etc.)
-     * @param width ADC width (ADC_WIDTH_BIT_12, etc.)
-     */
-    Esp32C6Adc(adc_unit_t adc_unit, adc_atten_t attenuation, adc_bits_width_t width = ADC_WIDTH_BIT_12);
+  /**
+   * @brief Constructor for ESP32-C6 ADC driver.
+   * @param adc_unit ADC unit (ADC_UNIT_1 or ADC_UNIT_2)
+   * @param attenuation ADC attenuation (ADC_ATTEN_DB_0, etc.)
+   * @param width ADC width (ADC_WIDTH_BIT_12, etc.)
+   */
+  Esp32C6Adc(adc_unit_t adc_unit, adc_atten_t attenuation,
+             adc_bits_width_t width = ADC_WIDTH_BIT_12);
 
-    /**
-     * @brief Destructor.
-     */
-    ~Esp32C6Adc() noexcept;
+  /**
+   * @brief Destructor.
+   */
+  ~Esp32C6Adc() noexcept;
 
-    /**
-     * @brief Initializes the ADC peripheral.
-     * @return True if initialization is successful, false otherwise.
-     */
-    virtual bool Initialize() noexcept override;
+  /**
+   * @brief Initializes the ADC peripheral.
+   * @return True if initialization is successful, false otherwise.
+   */
+  virtual bool Initialize() noexcept override;
 
-    /**
-     * @brief Reads the specified channel and returns the reading in volts.
-     * @param channel_num Channel number to read (ADC1_CHANNEL_0, etc.)
-     * @param channel_reading_v Variable to store the channel voltage reading.
-     * @param numOfSamplesToAvg Number of samples to average (default is 1).
-     * @param timeBetweenSamples Time between consecutive samples in ms (default is 0).
-     * @return Error status indicating the success or failure of the operation.
-     */
-    virtual AdcErr ReadChannelV(uint8_t channel_num, float& channel_reading_v, uint8_t numOfSamplesToAvg = 1, uint32_t timeBetweenSamples = 0) noexcept override;
+  /**
+   * @brief Reads the specified channel and returns the reading in volts.
+   * @param channel_num Channel number to read (ADC1_CHANNEL_0, etc.)
+   * @param channel_reading_v Variable to store the channel voltage reading.
+   * @param numOfSamplesToAvg Number of samples to average (default is 1).
+   * @param timeBetweenSamples Time between consecutive samples in ms (default
+   * is 0).
+   * @return Error status indicating the success or failure of the operation.
+   */
+  virtual AdcErr
+  ReadChannelV(uint8_t channel_num, float &channel_reading_v,
+               uint8_t numOfSamplesToAvg = 1,
+               uint32_t timeBetweenSamples = 0) noexcept override;
 
-    /**
-     * @brief Reads the specified channel and returns the raw ADC count.
-     * @param channel_num Channel number to read.
-     * @param channel_reading_count Variable to store the raw ADC count.
-     * @param numOfSamplesToAvg Number of samples to average (default is 1).
-     * @param timeBetweenSamples Time between consecutive samples in ms (default is 0).
-     * @return Error status indicating the success or failure of the operation.
-     */
-    virtual AdcErr ReadChannelCount(uint8_t channel_num, uint32_t& channel_reading_count, uint8_t numOfSamplesToAvg = 1, uint32_t timeBetweenSamples = 0) noexcept override;
+  /**
+   * @brief Reads the specified channel and returns the raw ADC count.
+   * @param channel_num Channel number to read.
+   * @param channel_reading_count Variable to store the raw ADC count.
+   * @param numOfSamplesToAvg Number of samples to average (default is 1).
+   * @param timeBetweenSamples Time between consecutive samples in ms (default
+   * is 0).
+   * @return Error status indicating the success or failure of the operation.
+   */
+  virtual AdcErr
+  ReadChannelCount(uint8_t channel_num, uint32_t &channel_reading_count,
+                   uint8_t numOfSamplesToAvg = 1,
+                   uint32_t timeBetweenSamples = 0) noexcept override;
 
-    /**
-     * @brief Reads the specified channel and returns both raw count and voltage.
-     * @param channel_num Channel number to read.
-     * @param channel_reading_count Variable to store the raw ADC count.
-     * @param channel_reading_v Variable to store the channel voltage reading.
-     * @param numOfSamplesToAvg Number of samples to average (default is 1).
-     * @param timeBetweenSamples Time between consecutive samples in ms (default is 0).
-     * @return Error status indicating the success or failure of the operation.
-     */
-    virtual AdcErr ReadChannel(uint8_t channel_num, uint32_t& channel_reading_count, float& channel_reading_v, uint8_t numOfSamplesToAvg = 1, uint32_t timeBetweenSamples = 0) noexcept override;
+  /**
+   * @brief Reads the specified channel and returns both raw count and voltage.
+   * @param channel_num Channel number to read.
+   * @param channel_reading_count Variable to store the raw ADC count.
+   * @param channel_reading_v Variable to store the channel voltage reading.
+   * @param numOfSamplesToAvg Number of samples to average (default is 1).
+   * @param timeBetweenSamples Time between consecutive samples in ms (default
+   * is 0).
+   * @return Error status indicating the success or failure of the operation.
+   */
+  virtual AdcErr ReadChannel(uint8_t channel_num,
+                             uint32_t &channel_reading_count,
+                             float &channel_reading_v,
+                             uint8_t numOfSamplesToAvg = 1,
+                             uint32_t timeBetweenSamples = 0) noexcept override;
 
 private:
-    adc_unit_t adcUnit;
-    adc_atten_t attenuation;
-    adc_bits_width_t width;
-    bool initialized;
+  adc_unit_t adcUnit;
+  adc_atten_t attenuation;
+  adc_bits_width_t width;
+  bool initialized;
 };
 
 #endif /* HAL_INTERNAL_INTERFACE_DRIVERS_ESP32C6ADC_H_ */

--- a/inc/I2cBus.h
+++ b/inc/I2cBus.h
@@ -1,6 +1,7 @@
 /**
  * @file I2cBus.h
- * @brief Declaration of the I2cBus class providing basic I2C master access on ESP32-C6.
+ * @brief Declaration of the I2cBus class providing basic I2C master access on
+ * ESP32-C6.
  *
  * This driver wraps the ESP-IDF I2C master APIs and does not implement thread
  * safety.  It follows the same design as SpiBus.
@@ -8,8 +9,8 @@
 #ifndef I2CBUS_H_
 #define I2CBUS_H_
 
-#include <driver/i2c.h>
 #include <cstdint>
+#include <driver/i2c.h>
 
 /**
  * @class I2cBus
@@ -17,82 +18,81 @@
  */
 class I2cBus {
 public:
-    /**
-     * @brief Construct an I2cBus instance.
-     * @param port I2C port number (e.g. I2C_NUM_0)
-     * @param cfg I2C configuration structure (pins, mode, clock speed)
-     */
-    I2cBus(i2c_port_t port, const i2c_config_t &cfg) noexcept;
+  /**
+   * @brief Construct an I2cBus instance.
+   * @param port I2C port number (e.g. I2C_NUM_0)
+   * @param cfg I2C configuration structure (pins, mode, clock speed)
+   */
+  I2cBus(i2c_port_t port, const i2c_config_t &cfg) noexcept;
 
-    /**
-     * @brief Destructor closes the bus if open.
-     */
-    ~I2cBus() noexcept;
+  /**
+   * @brief Destructor closes the bus if open.
+   */
+  ~I2cBus() noexcept;
 
-    /**
-     * @brief Open and initialize the I2C port.
-     * @return true if open, false otherwise.
-     */
-    bool Open() noexcept;
+  /**
+   * @brief Open and initialize the I2C port.
+   * @return true if open, false otherwise.
+   */
+  bool Open() noexcept;
 
-    /**
-     * @brief Close and de-initialize the I2C port.
-     * @return true if closed, false otherwise.
-     */
-    bool Close() noexcept;
+  /**
+   * @brief Close and de-initialize the I2C port.
+   * @return true if closed, false otherwise.
+   */
+  bool Close() noexcept;
 
-    /**
-     * @brief Write data to a slave device.
-     * @param addr 7-bit device address
-     * @param data Data buffer to transmit
-     * @param sizeBytes Number of bytes to write
-     * @param timeoutMsec Timeout in milliseconds
-     * @return true if transmission succeeded
-     */
-    bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
-               uint32_t timeoutMsec = 1000) noexcept;
+  /**
+   * @brief Write data to a slave device.
+   * @param addr 7-bit device address
+   * @param data Data buffer to transmit
+   * @param sizeBytes Number of bytes to write
+   * @param timeoutMsec Timeout in milliseconds
+   * @return true if transmission succeeded
+   */
+  bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+             uint32_t timeoutMsec = 1000) noexcept;
 
-    /**
-     * @brief Read data from a slave device.
-     * @param addr 7-bit device address
-     * @param data Buffer to store received data
-     * @param sizeBytes Number of bytes to read
-     * @param timeoutMsec Timeout in milliseconds
-     * @return true if read succeeded
-     */
-    bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
-              uint32_t timeoutMsec = 1000) noexcept;
+  /**
+   * @brief Read data from a slave device.
+   * @param addr 7-bit device address
+   * @param data Buffer to store received data
+   * @param sizeBytes Number of bytes to read
+   * @param timeoutMsec Timeout in milliseconds
+   * @return true if read succeeded
+   */
+  bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+            uint32_t timeoutMsec = 1000) noexcept;
 
-    /**
-     * @brief Write then read from a slave device without releasing the bus.
-     * @param addr 7-bit device address
-     * @param txData Data buffer to send
-     * @param txSizeBytes Number of bytes to send
-     * @param rxData Buffer to store received data
-     * @param rxSizeBytes Number of bytes to read
-     * @param timeoutMsec Timeout in milliseconds
-     * @return true if transaction succeeded
-     */
-    bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
-                   uint8_t *rxData, uint16_t rxSizeBytes,
-                   uint32_t timeoutMsec = 1000) noexcept;
+  /**
+   * @brief Write then read from a slave device without releasing the bus.
+   * @param addr 7-bit device address
+   * @param txData Data buffer to send
+   * @param txSizeBytes Number of bytes to send
+   * @param rxData Buffer to store received data
+   * @param rxSizeBytes Number of bytes to read
+   * @param timeoutMsec Timeout in milliseconds
+   * @return true if transaction succeeded
+   */
+  bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
+                 uint8_t *rxData, uint16_t rxSizeBytes,
+                 uint32_t timeoutMsec = 1000) noexcept;
 
-    /**
-     * @brief Get the configured clock speed.
-     * @return Clock speed in Hz
-     */
-    uint32_t GetClockHz() const noexcept;
+  /**
+   * @brief Get the configured clock speed.
+   * @return Clock speed in Hz
+   */
+  uint32_t GetClockHz() const noexcept;
 
-    /**
-     * @brief Check if the bus is initialized.
-     */
-    bool IsInitialized() const noexcept { return initialized; }
+  /**
+   * @brief Check if the bus is initialized.
+   */
+  bool IsInitialized() const noexcept { return initialized; }
 
 private:
-    i2c_port_t i2cPort;      ///< I2C port
-    i2c_config_t config;     ///< Configuration copy
-    bool initialized;        ///< Initialization flag
+  i2c_port_t i2cPort;  ///< I2C port
+  i2c_config_t config; ///< Configuration copy
+  bool initialized;    ///< Initialization flag
 };
 
 #endif // I2CBUS_H_
-

--- a/inc/NvsStorage.h
+++ b/inc/NvsStorage.h
@@ -5,9 +5,9 @@
 #ifndef NVSSTORAGE_H_
 #define NVSSTORAGE_H_
 
+#include <cstdint>
 #include <nvs.h>
 #include <nvs_flash.h>
-#include <cstdint>
 
 /**
  * @class NvsStorage
@@ -15,35 +15,35 @@
  */
 class NvsStorage {
 public:
-    /**
-     * @brief Construct storage bound to a namespace.
-     * @param ns Namespace string
-     */
-    explicit NvsStorage(const char* ns) noexcept;
-    ~NvsStorage() noexcept;
-    NvsStorage(const NvsStorage&) = delete;
-    NvsStorage& operator=(const NvsStorage&) = delete;
+  /**
+   * @brief Construct storage bound to a namespace.
+   * @param ns Namespace string
+   */
+  explicit NvsStorage(const char *ns) noexcept;
+  ~NvsStorage() noexcept;
+  NvsStorage(const NvsStorage &) = delete;
+  NvsStorage &operator=(const NvsStorage &) = delete;
 
-    /** Open the namespace creating it if needed. */
-    bool Open() noexcept;
-    /** Close the handle if open. */
-    void Close() noexcept;
+  /** Open the namespace creating it if needed. */
+  bool Open() noexcept;
+  /** Close the handle if open. */
+  void Close() noexcept;
 
-    /** Store a 32-bit value under a key. */
-    bool SetU32(const char* key, uint32_t value) noexcept;
-    /** Retrieve a 32-bit value. */
-    bool GetU32(const char* key, uint32_t& value) noexcept;
-    /** Remove a key from storage. */
-    bool EraseKey(const char* key) noexcept;
-    /** Commit any pending writes. */
-    bool Commit() noexcept;
+  /** Store a 32-bit value under a key. */
+  bool SetU32(const char *key, uint32_t value) noexcept;
+  /** Retrieve a 32-bit value. */
+  bool GetU32(const char *key, uint32_t &value) noexcept;
+  /** Remove a key from storage. */
+  bool EraseKey(const char *key) noexcept;
+  /** Commit any pending writes. */
+  bool Commit() noexcept;
 
-    /** Check if the handle is valid. */
-    bool IsOpened() const noexcept { return handle != 0; }
+  /** Check if the handle is valid. */
+  bool IsOpened() const noexcept { return handle != 0; }
 
 private:
-    const char* nsName;   ///< Namespace string
-    nvs_handle_t handle;  ///< Open handle or 0
+  const char *nsName;  ///< Namespace string
+  nvs_handle_t handle; ///< Open handle or 0
 };
 
 #endif // NVSSTORAGE_H_

--- a/inc/PeriodicTimer.h
+++ b/inc/PeriodicTimer.h
@@ -14,44 +14,44 @@
  */
 class PeriodicTimer {
 public:
-    using Callback = void (*)(void*); //!< Callback type used by the timer
+  using Callback = void (*)(void *); //!< Callback type used by the timer
 
-    /**
-     * @brief Construct a PeriodicTimer.
-     * @param cb   Callback function to invoke on timer expiry
-     * @param arg  User argument passed to the callback
-     */
-    explicit PeriodicTimer(Callback cb, void* arg = nullptr) noexcept;
-    PeriodicTimer(const PeriodicTimer&) = delete;
-    PeriodicTimer& operator=(const PeriodicTimer&) = delete;
-    ~PeriodicTimer() noexcept;
+  /**
+   * @brief Construct a PeriodicTimer.
+   * @param cb   Callback function to invoke on timer expiry
+   * @param arg  User argument passed to the callback
+   */
+  explicit PeriodicTimer(Callback cb, void *arg = nullptr) noexcept;
+  PeriodicTimer(const PeriodicTimer &) = delete;
+  PeriodicTimer &operator=(const PeriodicTimer &) = delete;
+  ~PeriodicTimer() noexcept;
 
-    /**
-     * @brief Start the timer with the given period.
-     * @param periodUs Period in microseconds
-     * @return true if the timer was started
-     */
-    bool Start(uint64_t periodUs) noexcept;
+  /**
+   * @brief Start the timer with the given period.
+   * @param periodUs Period in microseconds
+   * @return true if the timer was started
+   */
+  bool Start(uint64_t periodUs) noexcept;
 
-    /**
-     * @brief Stop the timer if running.
-     * @return true if stopped successfully
-     */
-    bool Stop() noexcept;
+  /**
+   * @brief Stop the timer if running.
+   * @return true if stopped successfully
+   */
+  bool Stop() noexcept;
 
-    /**
-     * @brief Check if the timer is currently running.
-     */
-    bool IsRunning() const noexcept { return running; }
+  /**
+   * @brief Check if the timer is currently running.
+   */
+  bool IsRunning() const noexcept { return running; }
 
 private:
-    static void Dispatch(void* arg);
-    bool CreateHandle() noexcept;
+  static void Dispatch(void *arg);
+  bool CreateHandle() noexcept;
 
-    esp_timer_handle_t handle;
-    Callback userCb;
-    void* userArg;
-    bool running;
+  esp_timer_handle_t handle;
+  Callback userCb;
+  void *userArg;
+  bool running;
 };
 
 #endif // PERIODIC_TIMER_H

--- a/inc/PwmOutput.h
+++ b/inc/PwmOutput.h
@@ -18,57 +18,56 @@
  */
 class PwmOutput : public DigitalGpio {
 public:
-    /**
-     * @brief Construct a PwmOutput.
-     * @param pin GPIO pin to output PWM
-     * @param channel LEDC channel (LEDC_CHANNEL_0..)
-     * @param timer LEDC timer index (LEDC_TIMER_0..)
-     * @param freqHz PWM frequency in Hz
-     * @param resolution Timer resolution (e.g. LEDC_TIMER_13_BIT)
-     * @param activeState Signal active state
-     */
-    PwmOutput(gpio_num_t pin, ledc_channel_t channel,
-              ledc_timer_t timer, uint32_t freqHz,
-              ledc_timer_bit_t resolution,
-              ActiveState activeState = ActiveState::High) noexcept;
+  /**
+   * @brief Construct a PwmOutput.
+   * @param pin GPIO pin to output PWM
+   * @param channel LEDC channel (LEDC_CHANNEL_0..)
+   * @param timer LEDC timer index (LEDC_TIMER_0..)
+   * @param freqHz PWM frequency in Hz
+   * @param resolution Timer resolution (e.g. LEDC_TIMER_13_BIT)
+   * @param activeState Signal active state
+   */
+  PwmOutput(gpio_num_t pin, ledc_channel_t channel, ledc_timer_t timer,
+            uint32_t freqHz, ledc_timer_bit_t resolution,
+            ActiveState activeState = ActiveState::High) noexcept;
 
-    PwmOutput(const PwmOutput&) = delete;
-    PwmOutput& operator=(const PwmOutput&) = delete;
-    virtual ~PwmOutput() override;
+  PwmOutput(const PwmOutput &) = delete;
+  PwmOutput &operator=(const PwmOutput &) = delete;
+  virtual ~PwmOutput() override;
 
-    /**
-     * @brief Start PWM generation.
-     * @return true if started
-     */
-    bool Start() noexcept;
+  /**
+   * @brief Start PWM generation.
+   * @return true if started
+   */
+  bool Start() noexcept;
 
-    /**
-     * @brief Stop PWM output and set pin inactive.
-     * @return true if stopped
-     */
-    bool Stop() noexcept;
+  /**
+   * @brief Stop PWM output and set pin inactive.
+   * @return true if stopped
+   */
+  bool Stop() noexcept;
 
-    /**
-     * @brief Set duty cycle as fraction from 0.0 to 1.0.
-     */
-    bool SetDuty(float duty) noexcept;
+  /**
+   * @brief Set duty cycle as fraction from 0.0 to 1.0.
+   */
+  bool SetDuty(float duty) noexcept;
 
-    /**
-     * @brief Update the output frequency.
-     */
-    bool SetFrequency(uint32_t freqHz) noexcept;
+  /**
+   * @brief Update the output frequency.
+   */
+  bool SetFrequency(uint32_t freqHz) noexcept;
 
-    /**
-     * @brief Get the configured frequency in Hz.
-     */
-    uint32_t GetFrequency() const noexcept { return frequency; }
+  /**
+   * @brief Get the configured frequency in Hz.
+   */
+  uint32_t GetFrequency() const noexcept { return frequency; }
 
 private:
-    virtual bool Initialize() noexcept override;
-    ledc_channel_t channel;
-    ledc_timer_t timer;
-    uint32_t frequency;
-    ledc_timer_bit_t resolution;
+  virtual bool Initialize() noexcept override;
+  ledc_channel_t channel;
+  ledc_timer_t timer;
+  uint32_t frequency;
+  ledc_timer_bit_t resolution;
 };
 
 #endif // PWMOUTPUT_H

--- a/inc/RmtOutput.h
+++ b/inc/RmtOutput.h
@@ -1,8 +1,8 @@
 #ifndef RMT_OUTPUT_H
 #define RMT_OUTPUT_H
 
-#include "driver/rmt.h"
 #include "driver/gpio.h"
+#include "driver/rmt.h"
 
 /**
  * @file RmtOutput.h
@@ -10,23 +10,25 @@
  */
 class RmtOutput {
 public:
-    RmtOutput(rmt_channel_t channel, gpio_num_t pin, uint32_t clk_div = 80) noexcept;
-    ~RmtOutput() noexcept;
-    RmtOutput(const RmtOutput&) = delete;
-    RmtOutput& operator=(const RmtOutput&) = delete;
+  RmtOutput(rmt_channel_t channel, gpio_num_t pin,
+            uint32_t clk_div = 80) noexcept;
+  ~RmtOutput() noexcept;
+  RmtOutput(const RmtOutput &) = delete;
+  RmtOutput &operator=(const RmtOutput &) = delete;
 
-    bool Open() noexcept;
-    void Close() noexcept;
+  bool Open() noexcept;
+  void Close() noexcept;
 
-    bool Write(const rmt_item32_t* items, size_t len, bool wait_tx_done = true) noexcept;
+  bool Write(const rmt_item32_t *items, size_t len,
+             bool wait_tx_done = true) noexcept;
 
-    bool IsOpen() const noexcept { return installed; }
+  bool IsOpen() const noexcept { return installed; }
 
 private:
-    rmt_channel_t chan;
-    gpio_num_t gpio;
-    uint32_t div;
-    bool installed;
+  rmt_channel_t chan;
+  gpio_num_t gpio;
+  uint32_t div;
+  bool installed;
 };
 
 #endif // RMT_OUTPUT_H

--- a/inc/SfFlexCan.h
+++ b/inc/SfFlexCan.h
@@ -15,33 +15,34 @@
  */
 class SfFlexCan {
 public:
-    /**
-     * @brief Construct a thread-safe CAN driver.
-     * @param port CAN controller port
-     * @param baudRate Bus bitrate in bit/s
-     * @param mutexHandle Mutex used for locking
-     */
-    SfFlexCan(uint8_t port, uint32_t baudRate, SemaphoreHandle_t mutexHandle) noexcept;
-    ~SfFlexCan() noexcept;
-    SfFlexCan(const SfFlexCan&) = delete;
-    SfFlexCan& operator=(const SfFlexCan&) = delete;
+  /**
+   * @brief Construct a thread-safe CAN driver.
+   * @param port CAN controller port
+   * @param baudRate Bus bitrate in bit/s
+   * @param mutexHandle Mutex used for locking
+   */
+  SfFlexCan(uint8_t port, uint32_t baudRate,
+            SemaphoreHandle_t mutexHandle) noexcept;
+  ~SfFlexCan() noexcept;
+  SfFlexCan(const SfFlexCan &) = delete;
+  SfFlexCan &operator=(const SfFlexCan &) = delete;
 
-    bool Open() noexcept;  ///< Initialize the underlying driver
-    bool Close() noexcept; ///< Stop and uninstall
+  bool Open() noexcept;  ///< Initialize the underlying driver
+  bool Close() noexcept; ///< Stop and uninstall
 
-    bool Write(const FlexCan::Frame& frame, uint32_t timeoutMsec = 1000) noexcept;
-    bool Read(FlexCan::Frame& frame, uint32_t timeoutMsec = 0) noexcept;
+  bool Write(const FlexCan::Frame &frame, uint32_t timeoutMsec = 1000) noexcept;
+  bool Read(FlexCan::Frame &frame, uint32_t timeoutMsec = 0) noexcept;
 
-    bool Lock(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
-    bool Unlock() noexcept;
+  bool Lock(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
+  bool Unlock() noexcept;
 
-    bool IsInitialized() const noexcept { return initialized; }
-    uint32_t GetBaudRate() const noexcept { return base.GetBaudRate(); }
+  bool IsInitialized() const noexcept { return initialized; }
+  uint32_t GetBaudRate() const noexcept { return base.GetBaudRate(); }
 
 private:
-    FlexCan base;
-    SemaphoreHandle_t mutex;
-    bool initialized;
+  FlexCan base;
+  SemaphoreHandle_t mutex;
+  bool initialized;
 };
 
 #endif // SFFLEXCAN_H_

--- a/inc/SfI2cBus.h
+++ b/inc/SfI2cBus.h
@@ -1,6 +1,7 @@
 /**
  * @file SfI2cBus.h
- * @brief Thread-safe I2C master driver for ESP32-C6 with software mutex control.
+ * @brief Thread-safe I2C master driver for ESP32-C6 with software mutex
+ * control.
  *
  * This class mirrors the SfSpiBus implementation and relies on a FreeRTOS
  * mutex supplied from the HF-RTOSW-ESPIDF component.
@@ -8,10 +9,10 @@
 #ifndef SFI2CBUS_H_
 #define SFI2CBUS_H_
 
+#include <cstdint>
 #include <driver/i2c.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
-#include <cstdint>
 
 /**
  * @class SfI2cBus
@@ -19,74 +20,74 @@
  */
 class SfI2cBus {
 public:
-    /**
-     * @brief Construct an SfI2cBus instance.
-     * @param port I2C port number
-     * @param cfg I2C configuration structure
-     * @param mutexHandle Mutex used for locking during transfers
-     */
-    SfI2cBus(i2c_port_t port, const i2c_config_t &cfg, SemaphoreHandle_t mutexHandle) noexcept;
+  /**
+   * @brief Construct an SfI2cBus instance.
+   * @param port I2C port number
+   * @param cfg I2C configuration structure
+   * @param mutexHandle Mutex used for locking during transfers
+   */
+  SfI2cBus(i2c_port_t port, const i2c_config_t &cfg,
+           SemaphoreHandle_t mutexHandle) noexcept;
 
-    /**
-     * @brief Destructor closes the bus.
-     */
-    ~SfI2cBus() noexcept;
+  /**
+   * @brief Destructor closes the bus.
+   */
+  ~SfI2cBus() noexcept;
 
-    /**
-     * @brief Open and initialize the I2C port.
-     */
-    bool Open() noexcept;
+  /**
+   * @brief Open and initialize the I2C port.
+   */
+  bool Open() noexcept;
 
-    /**
-     * @brief Close and de-initialize the I2C port.
-     */
-    bool Close() noexcept;
+  /**
+   * @brief Close and de-initialize the I2C port.
+   */
+  bool Close() noexcept;
 
-    /**
-     * @brief Write to a device in a thread-safe manner.
-     */
-    bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
-               uint32_t timeoutMsec) noexcept;
+  /**
+   * @brief Write to a device in a thread-safe manner.
+   */
+  bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+             uint32_t timeoutMsec) noexcept;
 
-    /**
-     * @brief Read from a device in a thread-safe manner.
-     */
-    bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
-              uint32_t timeoutMsec) noexcept;
+  /**
+   * @brief Read from a device in a thread-safe manner.
+   */
+  bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+            uint32_t timeoutMsec) noexcept;
 
-    /**
-     * @brief Combined write then read operation.
-     */
-    bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
-                   uint8_t *rxData, uint16_t rxSizeBytes,
-                   uint32_t timeoutMsec) noexcept;
+  /**
+   * @brief Combined write then read operation.
+   */
+  bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
+                 uint8_t *rxData, uint16_t rxSizeBytes,
+                 uint32_t timeoutMsec) noexcept;
 
-    /**
-     * @brief Lock the bus for exclusive access.
-     */
-    bool LockBus(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
+  /**
+   * @brief Lock the bus for exclusive access.
+   */
+  bool LockBus(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
 
-    /**
-     * @brief Unlock the bus.
-     */
-    bool UnlockBus() noexcept;
+  /**
+   * @brief Unlock the bus.
+   */
+  bool UnlockBus() noexcept;
 
-    /**
-     * @brief Get the clock speed in Hz.
-     */
-    uint32_t GetClockHz() const noexcept;
+  /**
+   * @brief Get the clock speed in Hz.
+   */
+  uint32_t GetClockHz() const noexcept;
 
-    /**
-     * @brief Check initialization state.
-     */
-    bool IsInitialized() const noexcept { return initialized; }
+  /**
+   * @brief Check initialization state.
+   */
+  bool IsInitialized() const noexcept { return initialized; }
 
 private:
-    i2c_port_t i2cPort;      ///< Port number
-    i2c_config_t config;     ///< Configuration copy
-    SemaphoreHandle_t busMutex; ///< Mutex for thread safety
-    bool initialized;        ///< Flag
+  i2c_port_t i2cPort;         ///< Port number
+  i2c_config_t config;        ///< Configuration copy
+  SemaphoreHandle_t busMutex; ///< Mutex for thread safety
+  bool initialized;           ///< Flag
 };
 
 #endif // SFI2CBUS_H_
-

--- a/inc/SfSpiBus.h
+++ b/inc/SfSpiBus.h
@@ -1,125 +1,135 @@
 /**
  * @file SfSpiBus.h
- * @brief Declaration of the SfSpiBus class for ESP32 (ESP-IDF), providing thread-safe SPI master communication with software-controlled CS.
+ * @brief Declaration of the SfSpiBus class for ESP32 (ESP-IDF), providing
+ * thread-safe SPI master communication with software-controlled CS.
  *
- * This class abstracts the ESP-IDF SPI master driver and provides thread-safe SPI transactions using FreeRTOS mutexes.
- * All configuration (bus, device, pins, etc.) must be passed in by the caller.
+ * This class abstracts the ESP-IDF SPI master driver and provides thread-safe
+ * SPI transactions using FreeRTOS mutexes. All configuration (bus, device,
+ * pins, etc.) must be passed in by the caller.
  *
  * @author Nebula Tech Corporation
  * @copyright Copyright © 2023 Nebula Tech Corporation. All Rights Reserved.
- * This file is part of HardFOC and is licensed under the GNU General Public License v3.0 or later.
+ * This file is part of HardFOC and is licensed under the GNU General Public
+ * License v3.0 or later.
  */
 
 #ifndef SFSPIBUS_H_
 #define SFSPIBUS_H_
 
-#include <driver/spi_master.h>
+#include <cstdint>
 #include <driver/gpio.h>
+#include <driver/spi_master.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
-#include <cstdint>
 
 /**
  * @class SfSpiBus
- * @brief Thread-safe SPI master bus abstraction for ESP32 (ESP-IDF) with software-controlled CS.
+ * @brief Thread-safe SPI master bus abstraction for ESP32 (ESP-IDF) with
+ * software-controlled CS.
  *
- * This class provides blocking SPI read/write operations with FreeRTOS mutex protection.
- * The CS pin is managed in software (not by the ESP-IDF SPI driver).
- * All configuration (bus, device, pins, etc.) must be passed in by the caller.
+ * This class provides blocking SPI read/write operations with FreeRTOS mutex
+ * protection. The CS pin is managed in software (not by the ESP-IDF SPI
+ * driver). All configuration (bus, device, pins, etc.) must be passed in by the
+ * caller.
  */
 class SfSpiBus {
 public:
-    /**
-     * @brief Constructor for SfSpiBus.
-     * @param host SPI host device (e.g., SPI2_HOST)
-     * @param buscfg SPI bus configuration (pins, etc.)
-     * @param devcfg SPI device configuration (CS, mode, etc.)
-     * @param mutexHandle FreeRTOS mutex handle for thread safety
-     */
-    SfSpiBus(spi_host_device_t host, const spi_bus_config_t& buscfg, const spi_device_interface_config_t& devcfg, SemaphoreHandle_t mutexHandle) noexcept;
+  /**
+   * @brief Constructor for SfSpiBus.
+   * @param host SPI host device (e.g., SPI2_HOST)
+   * @param buscfg SPI bus configuration (pins, etc.)
+   * @param devcfg SPI device configuration (CS, mode, etc.)
+   * @param mutexHandle FreeRTOS mutex handle for thread safety
+   */
+  SfSpiBus(spi_host_device_t host, const spi_bus_config_t &buscfg,
+           const spi_device_interface_config_t &devcfg,
+           SemaphoreHandle_t mutexHandle) noexcept;
 
-    /**
-     * @brief Destructor. Closes the SPI bus if initialized.
-     */
-    ~SfSpiBus() noexcept;
+  /**
+   * @brief Destructor. Closes the SPI bus if initialized.
+   */
+  ~SfSpiBus() noexcept;
 
-    /**
-     * @brief Open and initialize the SPI bus and device.
-     * @return true if open, false otherwise.
-     */
-    bool Open() noexcept;
+  /**
+   * @brief Open and initialize the SPI bus and device.
+   * @return true if open, false otherwise.
+   */
+  bool Open() noexcept;
 
-    /**
-     * @brief Close and de-initialize the SPI bus and device.
-     * @return true if closed, false otherwise.
-     */
-    bool Close() noexcept;
+  /**
+   * @brief Close and de-initialize the SPI bus and device.
+   * @return true if closed, false otherwise.
+   */
+  bool Close() noexcept;
 
-    /**
-     * @brief Write a block of data over the SPI bus (blocking, software CS).
-     * @param data Pointer to the data buffer to send
-     * @param sizeBytes Number of bytes to send
-     * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
-     * @return true if the data was sent successfully, false otherwise
-     */
-    bool Write(const uint8_t* data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept;
+  /**
+   * @brief Write a block of data over the SPI bus (blocking, software CS).
+   * @param data Pointer to the data buffer to send
+   * @param sizeBytes Number of bytes to send
+   * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
+   * @return true if the data was sent successfully, false otherwise
+   */
+  bool Write(const uint8_t *data, uint16_t sizeBytes,
+             uint32_t timeoutMsec) noexcept;
 
-    /**
-     * @brief Read a block of data over the SPI bus (blocking, software CS).
-     * @param data Pointer to the buffer to store received data
-     * @param sizeBytes Number of bytes to read
-     * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
-     * @return true if the data was read successfully, false otherwise
-     */
-    bool Read(uint8_t* data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept;
+  /**
+   * @brief Read a block of data over the SPI bus (blocking, software CS).
+   * @param data Pointer to the buffer to store received data
+   * @param sizeBytes Number of bytes to read
+   * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
+   * @return true if the data was read successfully, false otherwise
+   */
+  bool Read(uint8_t *data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept;
 
-    /**
-     * @brief Write and read a block of data over the SPI bus (full-duplex, blocking, software CS).
-     * @param write_data Pointer to the data buffer to send
-     * @param read_data Pointer to the buffer to store received data
-     * @param sizeBytes Number of bytes to transfer
-     * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
-     * @return true if the transaction was successful, false otherwise
-     */
-    bool WriteRead(const uint8_t* write_data, uint8_t* read_data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept;
+  /**
+   * @brief Write and read a block of data over the SPI bus (full-duplex,
+   * blocking, software CS).
+   * @param write_data Pointer to the data buffer to send
+   * @param read_data Pointer to the buffer to store received data
+   * @param sizeBytes Number of bytes to transfer
+   * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
+   * @return true if the transaction was successful, false otherwise
+   */
+  bool WriteRead(const uint8_t *write_data, uint8_t *read_data,
+                 uint16_t sizeBytes, uint32_t timeoutMsec) noexcept;
 
-    /**
-     * @brief Lock the SPI bus for exclusive access.
-     * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
-     * @return true if the mutex was acquired, false otherwise.
-     */
-    bool LockBus(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
+  /**
+   * @brief Lock the SPI bus for exclusive access.
+   * @param timeoutMsec Timeout in milliseconds for acquiring the mutex
+   * @return true if the mutex was acquired, false otherwise.
+   */
+  bool LockBus(uint32_t timeoutMsec = portMAX_DELAY) noexcept;
 
-    /**
-     * @brief Unlock the SPI bus.
-     * @return true if the mutex was released, false otherwise.
-     */
-    bool UnlockBus() noexcept;
+  /**
+   * @brief Unlock the SPI bus.
+   * @return true if the mutex was released, false otherwise.
+   */
+  bool UnlockBus() noexcept;
 
-    /**
-     * @brief Get the configured SPI clock frequency in Hz.
-     * @return SPI clock frequency in Hz
-     */
-    uint32_t GetClockHz() const noexcept;
+  /**
+   * @brief Get the configured SPI clock frequency in Hz.
+   * @return SPI clock frequency in Hz
+   */
+  uint32_t GetClockHz() const noexcept;
 
-    /**
-     * @brief Check if the class is initialized.
-     * @return true if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept { return initialized; }
+  /**
+   * @brief Check if the class is initialized.
+   * @return true if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept { return initialized; }
 
 private:
-    bool Initialize() noexcept;
-    bool SelectDevice() noexcept;
-    bool DeselectDevice() noexcept;
+  bool Initialize() noexcept;
+  bool SelectDevice() noexcept;
+  bool DeselectDevice() noexcept;
 
-    spi_host_device_t spiHost;                ///< ESP-IDF SPI host
-    spi_device_handle_t spiHandle;            ///< ESP-IDF SPI device handle
-    spi_bus_config_t busConfig;               ///< SPI bus configuration
-    spi_device_interface_config_t devConfig;  ///< SPI device configuration
-    SemaphoreHandle_t busMutex;               ///< FreeRTOS mutex for thread safety
-    bool initialized;                         ///< Initialization state
-    gpio_num_t csPin;                         ///< Chip select GPIO pin (software-controlled)
+  spi_host_device_t spiHost;               ///< ESP-IDF SPI host
+  spi_device_handle_t spiHandle;           ///< ESP-IDF SPI device handle
+  spi_bus_config_t busConfig;              ///< SPI bus configuration
+  spi_device_interface_config_t devConfig; ///< SPI device configuration
+  SemaphoreHandle_t busMutex;              ///< FreeRTOS mutex for thread safety
+  bool initialized;                        ///< Initialization state
+  gpio_num_t csPin; ///< Chip select GPIO pin (software-controlled)
 };
 
 #endif // SFSPIBUS_H_

--- a/inc/SfUartDriver.h
+++ b/inc/SfUartDriver.h
@@ -1,10 +1,10 @@
 #ifndef SFUARTDRIVER_H
 #define SFUARTDRIVER_H
 
+#include <cstdint>
 #include <driver/uart.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
-#include <cstdint>
 
 /**
  * @file SfUartDriver.h
@@ -15,38 +15,39 @@
  */
 class SfUartDriver {
 public:
-    /**
-     * @brief Construct a thread-safe UART driver.
-     * @param port UART port number
-     * @param config UART configuration structure
-     * @param txPin GPIO used for TX
-     * @param rxPin GPIO used for RX
-     * @param mutexHandle Mutex used for locking during transfers
-     */
-    SfUartDriver(uart_port_t port, const uart_config_t& config,
-                 int txPin, int rxPin, SemaphoreHandle_t mutexHandle) noexcept;
-    ~SfUartDriver() noexcept;
-    SfUartDriver(const SfUartDriver&) = delete;
-    SfUartDriver& operator=(const SfUartDriver&) = delete;
+  /**
+   * @brief Construct a thread-safe UART driver.
+   * @param port UART port number
+   * @param config UART configuration structure
+   * @param txPin GPIO used for TX
+   * @param rxPin GPIO used for RX
+   * @param mutexHandle Mutex used for locking during transfers
+   */
+  SfUartDriver(uart_port_t port, const uart_config_t &config, int txPin,
+               int rxPin, SemaphoreHandle_t mutexHandle) noexcept;
+  ~SfUartDriver() noexcept;
+  SfUartDriver(const SfUartDriver &) = delete;
+  SfUartDriver &operator=(const SfUartDriver &) = delete;
 
-    bool Open() noexcept;   ///< Install and configure the driver
-    bool Close() noexcept;  ///< Delete the driver
-    bool Write(const uint8_t* data, uint16_t length, uint32_t timeoutMsec = 1000) noexcept; ///< Blocking write
-    bool Read(uint8_t* data, uint16_t length,
-              TickType_t ticksToWait = portMAX_DELAY) noexcept; ///< Blocking read
+  bool Open() noexcept;  ///< Install and configure the driver
+  bool Close() noexcept; ///< Delete the driver
+  bool Write(const uint8_t *data, uint16_t length,
+             uint32_t timeoutMsec = 1000) noexcept; ///< Blocking write
+  bool Read(uint8_t *data, uint16_t length,
+            TickType_t ticksToWait = portMAX_DELAY) noexcept; ///< Blocking read
 
-    bool Lock() noexcept;   ///< Manually lock the mutex
-    bool Unlock() noexcept; ///< Unlock the mutex
+  bool Lock() noexcept;   ///< Manually lock the mutex
+  bool Unlock() noexcept; ///< Unlock the mutex
 
-    bool IsInitialized() const noexcept { return initialized; }
+  bool IsInitialized() const noexcept { return initialized; }
 
 private:
-    uart_port_t port;
-    uart_config_t config;
-    int txPin;
-    int rxPin;
-    SemaphoreHandle_t mutex;
-    bool initialized;
+  uart_port_t port;
+  uart_config_t config;
+  int txPin;
+  int rxPin;
+  SemaphoreHandle_t mutex;
+  bool initialized;
 };
 
 #endif // SFUARTDRIVER_H

--- a/inc/SpiBus.h
+++ b/inc/SpiBus.h
@@ -1,101 +1,113 @@
 /**
  * @file SpiBus.h
- * @brief Declaration of the SpiBus class for ESP32 (ESP-IDF), providing non-thread-safe SPI master communication.
+ * @brief Declaration of the SpiBus class for ESP32 (ESP-IDF), providing
+ * non-thread-safe SPI master communication.
  *
- * This class abstracts the ESP-IDF SPI master driver and provides blocking SPI transactions.
- * All configuration (bus, device, pins, etc.) must be passed in by the caller.
+ * This class abstracts the ESP-IDF SPI master driver and provides blocking SPI
+ * transactions. All configuration (bus, device, pins, etc.) must be passed in
+ * by the caller.
  *
  * @author Nebula Tech Corporation
  * @copyright Copyright © 2023 Nebula Tech Corporation. All Rights Reserved.
- * This file is part of HardFOC and is licensed under the GNU General Public License v3.0 or later.
+ * This file is part of HardFOC and is licensed under the GNU General Public
+ * License v3.0 or later.
  */
 
 #ifndef SPIBUS_H_
 #define SPIBUS_H_
 
-#include <driver/spi_master.h>
 #include <cstdint>
+#include <driver/spi_master.h>
 
 /**
  * @class SpiBus
  * @brief Non-thread-safe SPI master bus abstraction for ESP32 (ESP-IDF).
  *
- * This class provides blocking SPI read/write operations. The CS pin is managed by the ESP-IDF SPI driver.
- * All configuration (bus, device, pins, etc.) must be passed in by the caller.
+ * This class provides blocking SPI read/write operations. The CS pin is managed
+ * by the ESP-IDF SPI driver. All configuration (bus, device, pins, etc.) must
+ * be passed in by the caller.
  */
 class SpiBus {
 public:
-    /**
-     * @brief Constructor for SpiBus.
-     * @param host SPI host device (e.g., SPI2_HOST)
-     * @param buscfg SPI bus configuration (pins, etc.)
-     * @param devcfg SPI device configuration (CS, mode, etc.)
-     */
-    SpiBus(spi_host_device_t host, const spi_bus_config_t& buscfg, const spi_device_interface_config_t& devcfg) noexcept;
+  /**
+   * @brief Constructor for SpiBus.
+   * @param host SPI host device (e.g., SPI2_HOST)
+   * @param buscfg SPI bus configuration (pins, etc.)
+   * @param devcfg SPI device configuration (CS, mode, etc.)
+   */
+  SpiBus(spi_host_device_t host, const spi_bus_config_t &buscfg,
+         const spi_device_interface_config_t &devcfg) noexcept;
 
-    /**
-     * @brief Destructor. Closes the SPI bus if initialized.
-     */
-    ~SpiBus() noexcept;
+  /**
+   * @brief Destructor. Closes the SPI bus if initialized.
+   */
+  ~SpiBus() noexcept;
 
-    /**
-     * @brief Open and initialize the SPI bus and device.
-     * @return true if open, false otherwise.
-     */
-    bool Open() noexcept;
+  /**
+   * @brief Open and initialize the SPI bus and device.
+   * @return true if open, false otherwise.
+   */
+  bool Open() noexcept;
 
-    /**
-     * @brief Close and de-initialize the SPI bus and device.
-     * @return true if closed, false otherwise.
-     */
-    bool Close() noexcept;
+  /**
+   * @brief Close and de-initialize the SPI bus and device.
+   * @return true if closed, false otherwise.
+   */
+  bool Close() noexcept;
 
-    /**
-     * @brief Write a block of data over the SPI bus (blocking).
-     * @param data Pointer to the data buffer to send
-     * @param sizeBytes Number of bytes to send
-     * @param timeoutMsec Timeout in milliseconds (not used, for API compatibility)
-     * @return true if the data was sent successfully, false otherwise
-     */
-    bool Write(const uint8_t* data, uint16_t sizeBytes, uint32_t timeoutMsec = 0) noexcept;
+  /**
+   * @brief Write a block of data over the SPI bus (blocking).
+   * @param data Pointer to the data buffer to send
+   * @param sizeBytes Number of bytes to send
+   * @param timeoutMsec Timeout in milliseconds (not used, for API
+   * compatibility)
+   * @return true if the data was sent successfully, false otherwise
+   */
+  bool Write(const uint8_t *data, uint16_t sizeBytes,
+             uint32_t timeoutMsec = 0) noexcept;
 
-    /**
-     * @brief Read a block of data over the SPI bus (blocking).
-     * @param data Pointer to the buffer to store received data
-     * @param sizeBytes Number of bytes to read
-     * @param timeoutMsec Timeout in milliseconds (not used, for API compatibility)
-     * @return true if the data was read successfully, false otherwise
-     */
-    bool Read(uint8_t* data, uint16_t sizeBytes, uint32_t timeoutMsec = 0) noexcept;
+  /**
+   * @brief Read a block of data over the SPI bus (blocking).
+   * @param data Pointer to the buffer to store received data
+   * @param sizeBytes Number of bytes to read
+   * @param timeoutMsec Timeout in milliseconds (not used, for API
+   * compatibility)
+   * @return true if the data was read successfully, false otherwise
+   */
+  bool Read(uint8_t *data, uint16_t sizeBytes,
+            uint32_t timeoutMsec = 0) noexcept;
 
-    /**
-     * @brief Write and read a block of data over the SPI bus (full-duplex, blocking).
-     * @param tx Pointer to the data buffer to send
-     * @param rx Pointer to the buffer to store received data
-     * @param sizeBytes Number of bytes to transfer
-     * @param timeoutMsec Timeout in milliseconds (not used, for API compatibility)
-     * @return true if the transaction was successful, false otherwise
-     */
-    bool WriteRead(const uint8_t* tx, uint8_t* rx, uint16_t sizeBytes, uint32_t timeoutMsec = 0) noexcept;
+  /**
+   * @brief Write and read a block of data over the SPI bus (full-duplex,
+   * blocking).
+   * @param tx Pointer to the data buffer to send
+   * @param rx Pointer to the buffer to store received data
+   * @param sizeBytes Number of bytes to transfer
+   * @param timeoutMsec Timeout in milliseconds (not used, for API
+   * compatibility)
+   * @return true if the transaction was successful, false otherwise
+   */
+  bool WriteRead(const uint8_t *tx, uint8_t *rx, uint16_t sizeBytes,
+                 uint32_t timeoutMsec = 0) noexcept;
 
-    /**
-     * @brief Get the configured SPI clock frequency in Hz.
-     * @return SPI clock frequency in Hz
-     */
-    uint32_t GetClockHz() const noexcept;
+  /**
+   * @brief Get the configured SPI clock frequency in Hz.
+   * @return SPI clock frequency in Hz
+   */
+  uint32_t GetClockHz() const noexcept;
 
-    /**
-     * @brief Check if the class is initialized.
-     * @return true if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept { return initialized; }
+  /**
+   * @brief Check if the class is initialized.
+   * @return true if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept { return initialized; }
 
 private:
-    spi_host_device_t spiHost;                ///< ESP-IDF SPI host
-    spi_device_handle_t spiHandle;            ///< ESP-IDF SPI device handle
-    spi_bus_config_t busConfig;               ///< SPI bus configuration
-    spi_device_interface_config_t devConfig;  ///< SPI device configuration
-    bool initialized;                         ///< Initialization state
+  spi_host_device_t spiHost;               ///< ESP-IDF SPI host
+  spi_device_handle_t spiHandle;           ///< ESP-IDF SPI device handle
+  spi_bus_config_t busConfig;              ///< SPI bus configuration
+  spi_device_interface_config_t devConfig; ///< SPI device configuration
+  bool initialized;                        ///< Initialization state
 };
 
 #endif // SPIBUS_H_

--- a/inc/UartDriver.h
+++ b/inc/UartDriver.h
@@ -1,8 +1,8 @@
 #ifndef UARTDRIVER_H
 #define UARTDRIVER_H
 
-#include <driver/uart.h>
 #include <cstdint>
+#include <driver/uart.h>
 
 /**
  * @file UartDriver.h
@@ -13,33 +13,33 @@
  */
 class UartDriver {
 public:
-    /**
-     * @brief Construct a UartDriver.
-     * @param port UART port number
-     * @param config UART configuration structure
-     * @param txPin GPIO used for TX
-     * @param rxPin GPIO used for RX
-     */
-    UartDriver(uart_port_t port, const uart_config_t& config,
-               int txPin, int rxPin) noexcept;
-    ~UartDriver() noexcept;
-    UartDriver(const UartDriver&) = delete;
-    UartDriver& operator=(const UartDriver&) = delete;
+  /**
+   * @brief Construct a UartDriver.
+   * @param port UART port number
+   * @param config UART configuration structure
+   * @param txPin GPIO used for TX
+   * @param rxPin GPIO used for RX
+   */
+  UartDriver(uart_port_t port, const uart_config_t &config, int txPin,
+             int rxPin) noexcept;
+  ~UartDriver() noexcept;
+  UartDriver(const UartDriver &) = delete;
+  UartDriver &operator=(const UartDriver &) = delete;
 
-    bool Open() noexcept;   ///< Install and configure the driver
-    bool Close() noexcept;  ///< Delete the driver
-    bool Write(const uint8_t* data, uint16_t length) noexcept; ///< Blocking write
-    bool Read(uint8_t* data, uint16_t length,
-              TickType_t ticksToWait = portMAX_DELAY) noexcept; ///< Blocking read
+  bool Open() noexcept;  ///< Install and configure the driver
+  bool Close() noexcept; ///< Delete the driver
+  bool Write(const uint8_t *data, uint16_t length) noexcept; ///< Blocking write
+  bool Read(uint8_t *data, uint16_t length,
+            TickType_t ticksToWait = portMAX_DELAY) noexcept; ///< Blocking read
 
-    bool IsInitialized() const noexcept { return initialized; }
+  bool IsInitialized() const noexcept { return initialized; }
 
 private:
-    uart_port_t port;
-    uart_config_t config;
-    int txPin;
-    int rxPin;
-    bool initialized;
+  uart_port_t port;
+  uart_config_t config;
+  int txPin;
+  int rxPin;
+  bool initialized;
 };
 
 #endif // UARTDRIVER_H

--- a/src/BaseGpio.cpp
+++ b/src/BaseGpio.cpp
@@ -1,15 +1,20 @@
 /**
   *
-  *  Contains the declaration and definition of the AveragingFilter class that provides
+  *  Contains the declaration and definition of the AveragingFilter class that
+  provides
   *      an averaging filter.
   *
   *
-  *   Note:  These functions are not thread or interrupt-safe and should be called
-  *          called with appropriate guards if used within an ISR or shared between tasks.
+  *   Note:  These functions are not thread or interrupt-safe and should be
+  called
+  *          called with appropriate guards if used within an ISR or shared
+  between tasks.
   -------------------------------------------------------------------------------------**/
-//   Contains the declaration of the abstract Gpio class, which provides features common to
-//     GPIO classes.  Gpio derived classes are intended to employ lazy initialization;
-//    they are initialized the first time the pin in manipulated.  
+//   Contains the declaration of the abstract Gpio class, which provides
+//   features common to
+//     GPIO classes.  Gpio derived classes are intended to employ lazy
+//     initialization;
+//    they are initialized the first time the pin in manipulated.
 // </summary>
 // -----------------------------------------------------------------------
 
@@ -19,17 +24,17 @@
  * @file BaseGpio.cpp
  * @brief Implementation of BaseGpio for ESP32-C6 using ESP-IDF.
  *
- * This file provides the base implementation for GPIO pin abstraction on ESP32-C6.
+ * This file provides the base implementation for GPIO pin abstraction on
+ * ESP32-C6.
  *
- * @note This implementation is intended for use with ESP-IDF. Pin configuration is expected
- *       to be handled by derived classes or via the PinCfg/gpio_config_esp32c6.hpp utilities.
+ * @note This implementation is intended for use with ESP-IDF. Pin configuration
+ * is expected to be handled by derived classes or via the
+ * PinCfg/gpio_config_esp32c6.hpp utilities.
  */
 
-// For ESP32, pin configuration is typically handled in the derived class or via gpio_config().
-// This function can be overridden by derived classes if needed.
+// For ESP32, pin configuration is typically handled in the derived class or via
+// gpio_config(). This function can be overridden by derived classes if needed.
 uint32_t BaseGpio::GetPinConfiguration() const noexcept {
-    // No default configuration; override in derived class if needed.
-    return 0;
+  // No default configuration; override in derived class if needed.
+  return 0;
 }
-
-

--- a/src/DacOutput.cpp
+++ b/src/DacOutput.cpp
@@ -7,44 +7,47 @@
 #include <driver/dac_oneshot.h>
 #include <esp_log.h>
 
-static const char* TAG = "DacOutput";
+static const char *TAG = "DacOutput";
 
 DacOutput::DacOutput(dac_channel_t ch) noexcept : channel(ch), enabled(false) {}
 
 DacOutput::~DacOutput() noexcept {
-    if (enabled) {
-        Disable();
-    }
+  if (enabled) {
+    Disable();
+  }
 }
 
 bool DacOutput::Enable() noexcept {
-    if (enabled) return true;
-    esp_err_t err = dac_output_enable(channel);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "enable failed: %d", err);
-        return false;
-    }
-    enabled = true;
+  if (enabled)
     return true;
+  esp_err_t err = dac_output_enable(channel);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "enable failed: %d", err);
+    return false;
+  }
+  enabled = true;
+  return true;
 }
 
 bool DacOutput::Disable() noexcept {
-    if (!enabled) return true;
-    esp_err_t err = dac_output_disable(channel);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "disable failed: %d", err);
-        return false;
-    }
-    enabled = false;
+  if (!enabled)
     return true;
+  esp_err_t err = dac_output_disable(channel);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "disable failed: %d", err);
+    return false;
+  }
+  enabled = false;
+  return true;
 }
 
 bool DacOutput::SetValue(uint8_t value) noexcept {
-    if (!enabled) return false;
-    esp_err_t err = dac_output_voltage(channel, value);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "set value failed: %d", err);
-        return false;
-    }
-    return true;
+  if (!enabled)
+    return false;
+  esp_err_t err = dac_output_voltage(channel, value);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "set value failed: %d", err);
+    return false;
+  }
+  return true;
 }

--- a/src/DigitalExternalIRQ.cpp
+++ b/src/DigitalExternalIRQ.cpp
@@ -5,60 +5,62 @@
 DigitalExternalIRQ::DigitalExternalIRQ(gpio_num_t pinArg,
                                        gpio_int_type_t interruptType,
                                        ActiveState activeStateArg) noexcept
-    : DigitalInput(pinArg, activeStateArg),
-      intrType(interruptType),
-      binSem(xSemaphoreCreateBinary()),
-      enabled(false) {}
+    : DigitalInput(pinArg, activeStateArg), intrType(interruptType),
+      binSem(xSemaphoreCreateBinary()), enabled(false) {}
 
 DigitalExternalIRQ::~DigitalExternalIRQ() {
-    Disable();
-    if (binSem) {
-        vSemaphoreDelete(binSem);
-    }
+  Disable();
+  if (binSem) {
+    vSemaphoreDelete(binSem);
+  }
 }
 
 bool DigitalExternalIRQ::Initialize() noexcept {
-    gpio_config_t io_conf = {};
-    io_conf.pin_bit_mask = (1ULL << pin);
-    io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.intr_type = intrType;
-    return gpio_config(&io_conf) == ESP_OK;
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin);
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = intrType;
+  return gpio_config(&io_conf) == ESP_OK;
 }
 
-void IRAM_ATTR DigitalExternalIRQ::IsrHandler(void* arg) {
-    auto* self = static_cast<DigitalExternalIRQ*>(arg);
-    BaseType_t higher_woken = pdFALSE;
-    xSemaphoreGiveFromISR(self->binSem, &higher_woken);
-    if (higher_woken) {
-        portYIELD_FROM_ISR();
-    }
+void IRAM_ATTR DigitalExternalIRQ::IsrHandler(void *arg) {
+  auto *self = static_cast<DigitalExternalIRQ *>(arg);
+  BaseType_t higher_woken = pdFALSE;
+  xSemaphoreGiveFromISR(self->binSem, &higher_woken);
+  if (higher_woken) {
+    portYIELD_FROM_ISR();
+  }
 }
 
 bool DigitalExternalIRQ::Enable() {
-    if (enabled) return true;
-    if (!EnsureInitialized()) return false;
-    esp_err_t err = gpio_install_isr_service(0);
-    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
-        return false;
-    }
-    err = gpio_isr_handler_add(pin, IsrHandler, this);
-    if (err != ESP_OK) {
-        return false;
-    }
-    enabled = true;
+  if (enabled)
     return true;
+  if (!EnsureInitialized())
+    return false;
+  esp_err_t err = gpio_install_isr_service(0);
+  if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+    return false;
+  }
+  err = gpio_isr_handler_add(pin, IsrHandler, this);
+  if (err != ESP_OK) {
+    return false;
+  }
+  enabled = true;
+  return true;
 }
 
 bool DigitalExternalIRQ::Disable() {
-    if (!enabled) return true;
-    gpio_isr_handler_remove(pin);
-    enabled = false;
+  if (!enabled)
     return true;
+  gpio_isr_handler_remove(pin);
+  enabled = false;
+  return true;
 }
 
 bool DigitalExternalIRQ::Wait(uint32_t timeoutMs) {
-    if (!Enable()) return false;
-    return xSemaphoreTake(binSem, pdMS_TO_TICKS(timeoutMs)) == pdTRUE;
+  if (!Enable())
+    return false;
+  return xSemaphoreTake(binSem, pdMS_TO_TICKS(timeoutMs)) == pdTRUE;
 }

--- a/src/DigitalGpio.cpp
+++ b/src/DigitalGpio.cpp
@@ -2,47 +2,58 @@
  * @file DigitalGpio.cpp
  * @brief Implementation of DigitalGpio for ESP32-C6 using ESP-IDF.
  *
- * This file provides the implementation for digital GPIO pin abstraction on ESP32-C6.
+ * This file provides the implementation for digital GPIO pin abstraction on
+ * ESP32-C6.
  *
- * @note This implementation is intended for use with ESP-IDF. Pin configuration is expected
- *       to be handled by derived classes or via the PinCfg/gpio_config_esp32c6.hpp utilities.
+ * @note This implementation is intended for use with ESP-IDF. Pin configuration
+ * is expected to be handled by derived classes or via the
+ * PinCfg/gpio_config_esp32c6.hpp utilities.
  */
 #include "DigitalGpio.h"
 #include "driver/gpio.h"
 
-const char* DigitalGpio::ToString(Mode mode) noexcept {
-    switch (mode) {
-        case Mode::OpenDrain: return "Open-Drain";
-        case Mode::PushPull:  return "Push-Pull";
-    }
-    return "Unknown";
+const char *DigitalGpio::ToString(Mode mode) noexcept {
+  switch (mode) {
+  case Mode::OpenDrain:
+    return "Open-Drain";
+  case Mode::PushPull:
+    return "Push-Pull";
+  }
+  return "Unknown";
 }
-const char* DigitalGpio::ToString(State state) noexcept {
-    switch (state) {
-        case State::Active:   return "Active";
-        case State::Inactive: return "Inactive";
-    }
-    return "Unknown";
+const char *DigitalGpio::ToString(State state) noexcept {
+  switch (state) {
+  case State::Active:
+    return "Active";
+  case State::Inactive:
+    return "Inactive";
+  }
+  return "Unknown";
 }
-const char* DigitalGpio::ToString(ActiveState activeState) noexcept {
-    switch (activeState) {
-        case ActiveState::High: return "High";
-        case ActiveState::Low:  return "Low";
-    }
-    return "Unknown";
+const char *DigitalGpio::ToString(ActiveState activeState) noexcept {
+  switch (activeState) {
+  case ActiveState::High:
+    return "High";
+  case ActiveState::Low:
+    return "Low";
+  }
+  return "Unknown";
 }
-const char* DigitalGpio::ToString(Resistance resistance) noexcept {
-    switch (resistance) {
-        case Resistance::Floating: return "Floating";
-        case Resistance::PullUp:   return "PullUp";
-        case Resistance::PullDown: return "PullDown";
-    }
-    return "Unknown";
+const char *DigitalGpio::ToString(Resistance resistance) noexcept {
+  switch (resistance) {
+  case Resistance::Floating:
+    return "Floating";
+  case Resistance::PullUp:
+    return "PullUp";
+  case Resistance::PullDown:
+    return "PullDown";
+  }
+  return "Unknown";
 }
 
 DigitalGpio::Resistance DigitalGpio::GetResistance() const noexcept {
-    // For ESP32, use gpio_get_pull_mode if needed, or store config in derived class.
-    // Here, we assume derived classes set the pull mode and can override this if needed.
-    // Default: Floating (no pull-up/down)
-    return Resistance::Floating;
+  // For ESP32, use gpio_get_pull_mode if needed, or store config in derived
+  // class. Here, we assume derived classes set the pull mode and can override
+  // this if needed. Default: Floating (no pull-up/down)
+  return Resistance::Floating;
 }

--- a/src/DigitalInput.cpp
+++ b/src/DigitalInput.cpp
@@ -1,15 +1,20 @@
 /**
-  *  Contains the declaration and definition of the AveragingFilter class that provides
+  *  Contains the declaration and definition of the AveragingFilter class that
+  provides
   *      an averaging filter.
   *
   *
-  *   Note:  These functions are not thread or interrupt-safe and should be called
-  *          called with appropriate guards if used within an ISR or shared between tasks.
+  *   Note:  These functions are not thread or interrupt-safe and should be
+  called
+  *          called with appropriate guards if used within an ISR or shared
+  between tasks.
   -------------------------------------------------------------------------------------**/
-//   Contains the declaration of  DigitalInput class, which provides facilities to describe
-//     GPIO input pins.  An I/O pin can be configured in an input mode with floating input, 
-//     with an internal pull - up or pulldown. DigitalInput employ lazy initialization, so that
-//     they are initialized the first time a pin in manipulated.
+//   Contains the declaration of  DigitalInput class, which provides facilities
+//   to describe
+//     GPIO input pins.  An I/O pin can be configured in an input mode with
+//     floating input, with an internal pull - up or pulldown. DigitalInput
+//     employ lazy initialization, so that they are initialized the first time a
+//     pin in manipulated.
 // </summary>
 // -----------------------------------------------------------------------
 #include "DigitalInput.h"
@@ -21,65 +26,61 @@
 /// </summary>
 /// <param name="pin">Pin on that bank 0..16 </param>
 /// <param name="activeState"Indicates whether set bit is activeC</param>
-	
-DigitalInput::DigitalInput(gpio_num_t pinArg, ActiveState activeStateArg) noexcept :
-    DigitalGpio(pinArg, activeStateArg)
-{
-    // No code at this time
+
+DigitalInput::DigitalInput(gpio_num_t pinArg,
+                           ActiveState activeStateArg) noexcept
+    : DigitalGpio(pinArg, activeStateArg) {
+  // No code at this time
 }
 
 ///------------------------------------------------------------------
-///<summary>
+///< summary>
 /// Virtual function to initialize peripheral.
 ///</summary>
-///<returns>true if able to initialize, false otherwise.</returns>
+///< returns>true if able to initialize, false otherwise.</returns>
 
 bool DigitalInput::Initialize() noexcept {
-    gpio_config_t io_conf = {};
-    io_conf.pin_bit_mask = (1ULL << pin);
-    io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.intr_type = GPIO_INTR_DISABLE;
-    return gpio_config(&io_conf) == ESP_OK;
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin);
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = GPIO_INTR_DISABLE;
+  return gpio_config(&io_conf) == ESP_OK;
 }
 
 ///------------------------------------------------------------------
 /// <summary>
 /// This function identifies the logical pin state.
 /// </summary>
-///<returns>true if the pin is logically set, false otherwise</returns>
-      
-bool DigitalInput::IsActive() noexcept {
-    if (EnsureInitialized()) {
-        int level = gpio_get_level(pin);
-        if (IsActiveHigh()) {
-            return level == 1;
-        } else {
-            return level == 0;
-        }
-    }
-    return false;
-}
-      		
+///< returns>true if the pin is logically set, false otherwise</returns>
 
+bool DigitalInput::IsActive() noexcept {
+  if (EnsureInitialized()) {
+    int level = gpio_get_level(pin);
+    if (IsActiveHigh()) {
+      return level == 1;
+    } else {
+      return level == 0;
+    }
+  }
+  return false;
+}
 
 ///------------------------------------------------------------------
 /// <summary>
 /// This function return the current state.
 /// </summary>
-///<returns>Current state</returns>
+///< returns>Current state</returns>
 
 DigitalGpio::State DigitalInput::GetState() noexcept {
-    if (EnsureInitialized()) {
-        int level = gpio_get_level(pin);
-        if (IsActiveHigh()) {
-            return (level == 1) ? State::Active : State::Inactive;
-        } else {
-            return (level == 0) ? State::Active : State::Inactive;
-        }
+  if (EnsureInitialized()) {
+    int level = gpio_get_level(pin);
+    if (IsActiveHigh()) {
+      return (level == 1) ? State::Active : State::Inactive;
+    } else {
+      return (level == 0) ? State::Active : State::Inactive;
     }
-    return State::Inactive;
+  }
+  return State::Inactive;
 }
-
-

--- a/src/DigitalOutput.cpp
+++ b/src/DigitalOutput.cpp
@@ -2,92 +2,92 @@
  * @file DigitalOutput.cpp
  * @brief Implementation of DigitalOutput for ESP32-C6 using ESP-IDF.
  *
- * This file provides the implementation for digital output pin abstraction on ESP32-C6.
+ * This file provides the implementation for digital output pin abstraction on
+ * ESP32-C6.
  *
- * @note This implementation is intended for use with ESP-IDF. Pin configuration is handled via gpio_config().
+ * @note This implementation is intended for use with ESP-IDF. Pin configuration
+ * is handled via gpio_config().
  */
 #include "DigitalOutput.h"
 #include "driver/gpio.h"
 
-DigitalOutput::DigitalOutput(gpio_num_t pinArg, ActiveState activeStateArg, State initialStateArg) noexcept :
-    DigitalGpio(pinArg, activeStateArg),
-    initialState(initialStateArg)
-{
-    // No code at this time.
+DigitalOutput::DigitalOutput(gpio_num_t pinArg, ActiveState activeStateArg,
+                             State initialStateArg) noexcept
+    : DigitalGpio(pinArg, activeStateArg), initialState(initialStateArg) {
+  // No code at this time.
 }
 
 DigitalOutput::~DigitalOutput() {
-    // No dynamic resources to free for ESP32.
+  // No dynamic resources to free for ESP32.
 }
 
 bool DigitalOutput::Initialize() noexcept {
-    gpio_config_t io_conf = {};
-    io_conf.pin_bit_mask = (1ULL << pin);
-    io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.intr_type = GPIO_INTR_DISABLE;
-    bool ok = (gpio_config(&io_conf) == ESP_OK);
-    if (ok) {
-        // Set initial state
-        if (IsActiveHigh()) {
-            gpio_set_level(pin, initialState == State::Active ? 1 : 0);
-        } else {
-            gpio_set_level(pin, initialState == State::Active ? 0 : 1);
-        }
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin);
+  io_conf.mode = GPIO_MODE_OUTPUT;
+  io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = GPIO_INTR_DISABLE;
+  bool ok = (gpio_config(&io_conf) == ESP_OK);
+  if (ok) {
+    // Set initial state
+    if (IsActiveHigh()) {
+      gpio_set_level(pin, initialState == State::Active ? 1 : 0);
+    } else {
+      gpio_set_level(pin, initialState == State::Active ? 0 : 1);
     }
-    return ok;
+  }
+  return ok;
 }
 
 DigitalGpio::Mode DigitalOutput::OutputMode() const noexcept {
-    // For ESP32, open-drain can be set in derived class if needed.
-    // Here, always return PushPull for default implementation.
-    return Mode::PushPull;
+  // For ESP32, open-drain can be set in derived class if needed.
+  // Here, always return PushPull for default implementation.
+  return Mode::PushPull;
 }
 
 bool DigitalOutput::IsActive() noexcept {
-    if (EnsureInitialized()) {
-        int level = gpio_get_level(pin);
-        if (IsActiveHigh()) {
-            return level == 1;
-        } else {
-            return level == 0;
-        }
+  if (EnsureInitialized()) {
+    int level = gpio_get_level(pin);
+    if (IsActiveHigh()) {
+      return level == 1;
+    } else {
+      return level == 0;
     }
-    return false;
+  }
+  return false;
 }
 
 bool DigitalOutput::SetActive() noexcept {
-    if (EnsureInitialized()) {
-        if (IsActiveHigh()) {
-            return gpio_set_level(pin, 1) == ESP_OK;
-        } else {
-            return gpio_set_level(pin, 0) == ESP_OK;
-        }
+  if (EnsureInitialized()) {
+    if (IsActiveHigh()) {
+      return gpio_set_level(pin, 1) == ESP_OK;
+    } else {
+      return gpio_set_level(pin, 0) == ESP_OK;
     }
-    return false;
+  }
+  return false;
 }
 
 bool DigitalOutput::SetInactive() noexcept {
-    if (EnsureInitialized()) {
-        if (IsActiveHigh()) {
-            return gpio_set_level(pin, 0) == ESP_OK;
-        } else {
-            return gpio_set_level(pin, 1) == ESP_OK;
-        }
+  if (EnsureInitialized()) {
+    if (IsActiveHigh()) {
+      return gpio_set_level(pin, 0) == ESP_OK;
+    } else {
+      return gpio_set_level(pin, 1) == ESP_OK;
     }
-    return false;
+  }
+  return false;
 }
 
 bool DigitalOutput::Toggle() noexcept {
-    if (EnsureInitialized()) {
-        int level = gpio_get_level(pin);
-        if (IsActive()) {
-            return SetInactive();
-        } else {
-            return SetActive();
-        }
+  if (EnsureInitialized()) {
+    int level = gpio_get_level(pin);
+    if (IsActive()) {
+      return SetInactive();
+    } else {
+      return SetActive();
     }
-    return false;
+  }
+  return false;
 }
-

--- a/src/DigitalOutputGuard.cpp
+++ b/src/DigitalOutputGuard.cpp
@@ -2,13 +2,15 @@
  * Nebula Tech Corporation
  *
  * Copyright © 2023 Nebula Tech Corporation.   All Rights Reserved.
- * This file is part of HardFOC and is licensed under the GNU General Public License v3.0 or later.
+ * This file is part of HardFOC and is licensed under the GNU General Public
+License v3.0 or later.
 
 /**
  * @file DigitalOutputGuard.cpp
  * @brief Source file for the DigitalOutputGuard class.
  *
- * The DigitalOutputGuard class ensures that a DigitalOutput instance is set active
+ * The DigitalOutputGuard class ensures that a DigitalOutput instance is set
+active
  * in its constructor and inactive in its destructor (RAII pattern).
  */
 
@@ -33,15 +35,20 @@ static constexpr bool verbose = false;
  *
  * The constructor sets the associated DigitalOutput instance active.
  */
-DigitalOutputGuard::DigitalOutputGuard(DigitalOutput& output) :
-		p_output_(&output)
-{
-	bool active = p_output_->SetActive();
-	if(active) {
-		WRITE_CONDITIONAL(verbose, "DigitalOutputGuard() - Digital output - %s - successfully set ACTIVE", PinToString(p_output_->GetPin()));
-	} else {
-		WRITE_CONDITIONAL(verbose, "DigitalOutputGuard() - Digital output - %s - !!! FAILED !!! to set ACTIVE", PinToString(p_output_->GetPin()));
-	}
+DigitalOutputGuard::DigitalOutputGuard(DigitalOutput &output)
+    : p_output_(&output) {
+  bool active = p_output_->SetActive();
+  if (active) {
+    WRITE_CONDITIONAL(
+        verbose,
+        "DigitalOutputGuard() - Digital output - %s - successfully set ACTIVE",
+        PinToString(p_output_->GetPin()));
+  } else {
+    WRITE_CONDITIONAL(verbose,
+                      "DigitalOutputGuard() - Digital output - %s - !!! FAILED "
+                      "!!! to set ACTIVE",
+                      PinToString(p_output_->GetPin()));
+  }
 }
 
 /**
@@ -50,15 +57,20 @@ DigitalOutputGuard::DigitalOutputGuard(DigitalOutput& output) :
  *
  * The constructor sets the associated DigitalOutput instance active.
  */
-DigitalOutputGuard::DigitalOutputGuard(DigitalOutput* output) :
-		p_output_(output)
-{
-	bool active = p_output_->SetActive();
-	if(active) {
-		WRITE_CONDITIONAL(verbose, "DigitalOutputGuard() - Digital output - %s - successfully set ACTIVE", PinToString(p_output_->GetPin()));
-	} else {
-		WRITE_CONDITIONAL(verbose, "DigitalOutputGuard() - Digital output - %s - !!! FAILED !!! to set ACTIVE", PinToString(p_output_->GetPin()));
-	}
+DigitalOutputGuard::DigitalOutputGuard(DigitalOutput *output)
+    : p_output_(output) {
+  bool active = p_output_->SetActive();
+  if (active) {
+    WRITE_CONDITIONAL(
+        verbose,
+        "DigitalOutputGuard() - Digital output - %s - successfully set ACTIVE",
+        PinToString(p_output_->GetPin()));
+  } else {
+    WRITE_CONDITIONAL(verbose,
+                      "DigitalOutputGuard() - Digital output - %s - !!! FAILED "
+                      "!!! to set ACTIVE",
+                      PinToString(p_output_->GetPin()));
+  }
 }
 
 /**
@@ -67,10 +79,16 @@ DigitalOutputGuard::DigitalOutputGuard(DigitalOutput* output) :
  * The destructor sets the associated DigitalOutput instance inactive.
  */
 DigitalOutputGuard::~DigitalOutputGuard() {
-	bool inactive = p_output_->SetInactive();
-	if(inactive) {
-		WRITE_CONDITIONAL(verbose, "~DigitalOutputGuard() - Digital output - %s - successfully set INACTIVE", PinToString(p_output_->GetPin()));
-	} else {
-		WRITE_CONDITIONAL(verbose, "~DigitalOutputGuard() - Digital output - %s - !!! FAILED !!! to set INACTIVE", PinToString(p_output_->GetPin()));
-	}
+  bool inactive = p_output_->SetInactive();
+  if (inactive) {
+    WRITE_CONDITIONAL(verbose,
+                      "~DigitalOutputGuard() - Digital output - %s - "
+                      "successfully set INACTIVE",
+                      PinToString(p_output_->GetPin()));
+  } else {
+    WRITE_CONDITIONAL(verbose,
+                      "~DigitalOutputGuard() - Digital output - %s - !!! "
+                      "FAILED !!! to set INACTIVE",
+                      PinToString(p_output_->GetPin()));
+  }
 }

--- a/src/Esp32C6Adc.cpp
+++ b/src/Esp32C6Adc.cpp
@@ -4,77 +4,79 @@
  *
  * This file provides the implementation for ADC abstraction on ESP32-C6.
  *
- * @note This implementation is intended for use with ESP-IDF. Pin configuration is handled via gpio_config().
+ * @note This implementation is intended for use with ESP-IDF. Pin configuration
+ * is handled via gpio_config().
  */
 #include "Esp32C6Adc.h"
 #include "driver/adc.h"
 #include "esp_adc_cal.h"
 #include <unistd.h>
 
-Esp32C6Adc::Esp32C6Adc(adc_unit_t adc_unit, adc_atten_t attenuation, adc_bits_width_t width)
-    : adcUnit(adc_unit), attenuation(attenuation), width(width), initialized(false) {}
+Esp32C6Adc::Esp32C6Adc(adc_unit_t adc_unit, adc_atten_t attenuation,
+                       adc_bits_width_t width)
+    : adcUnit(adc_unit), attenuation(attenuation), width(width),
+      initialized(false) {}
 
 Esp32C6Adc::~Esp32C6Adc() noexcept {}
 
 bool Esp32C6Adc::Initialize() noexcept {
-    // For ESP32, ADC configuration is mostly static, but width/attenuation can be set per channel.
-    // This function can be extended for more advanced setups.
-    initialized = true;
-    return true;
+  // For ESP32, ADC configuration is mostly static, but width/attenuation can be
+  // set per channel. This function can be extended for more advanced setups.
+  initialized = true;
+  return true;
 }
 
-BaseAdc::AdcErr Esp32C6Adc::ReadChannelCount(uint8_t channel_num, uint32_t& channel_reading_count, uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
-    if (!EnsureInitialized()) return AdcErr::ADC_ERR_FAILURE;
-    uint32_t sum = 0;
-    for (uint8_t i = 0; i < numOfSamplesToAvg; ++i) {
-        int raw = 0;
-        if (adcUnit == ADC_UNIT_1) {
-            adc1_config_width(width);
-            adc1_config_channel_atten((adc1_channel_t)channel_num, attenuation);
-            raw = adc1_get_raw((adc1_channel_t)channel_num);
-        } else {
-            // Only ADC1 supported in ESP32-C6 for now
-            return AdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
-        }
-        sum += raw;
-        if (timeBetweenSamples > 0) usleep(timeBetweenSamples * 1000);
+BaseAdc::AdcErr Esp32C6Adc::ReadChannelCount(
+    uint8_t channel_num, uint32_t &channel_reading_count,
+    uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
+  if (!EnsureInitialized())
+    return AdcErr::ADC_ERR_FAILURE;
+  uint32_t sum = 0;
+  for (uint8_t i = 0; i < numOfSamplesToAvg; ++i) {
+    int raw = 0;
+    if (adcUnit == ADC_UNIT_1) {
+      adc1_config_width(width);
+      adc1_config_channel_atten((adc1_channel_t)channel_num, attenuation);
+      raw = adc1_get_raw((adc1_channel_t)channel_num);
+    } else {
+      // Only ADC1 supported in ESP32-C6 for now
+      return AdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
     }
-    channel_reading_count = sum / numOfSamplesToAvg;
-    return AdcErr::ADC_SUCCESS;
+    sum += raw;
+    if (timeBetweenSamples > 0)
+      usleep(timeBetweenSamples * 1000);
+  }
+  channel_reading_count = sum / numOfSamplesToAvg;
+  return AdcErr::ADC_SUCCESS;
 }
 
-BaseAdc::AdcErr Esp32C6Adc::ReadChannelV(uint8_t channel_num, float& channel_reading_v, uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
-    uint32_t count = 0;
-    auto err = ReadChannelCount(channel_num, count, numOfSamplesToAvg, timeBetweenSamples);
-    if (err != AdcErr::ADC_SUCCESS) return err;
-    // Use ESP-IDF calibration API if available
-    esp_adc_cal_characteristics_t characteristics;
-    esp_adc_cal_value_t val_type = esp_adc_cal_characterize(adcUnit, attenuation, width, 0, &characteristics);
-    channel_reading_v = esp_adc_cal_raw_to_voltage(count, &characteristics) / 1000.0f; // Convert mV to V
-    return AdcErr::ADC_SUCCESS;
+BaseAdc::AdcErr Esp32C6Adc::ReadChannelV(uint8_t channel_num,
+                                         float &channel_reading_v,
+                                         uint8_t numOfSamplesToAvg,
+                                         uint32_t timeBetweenSamples) noexcept {
+  uint32_t count = 0;
+  auto err = ReadChannelCount(channel_num, count, numOfSamplesToAvg,
+                              timeBetweenSamples);
+  if (err != AdcErr::ADC_SUCCESS)
+    return err;
+  // Use ESP-IDF calibration API if available
+  esp_adc_cal_characteristics_t characteristics;
+  esp_adc_cal_value_t val_type = esp_adc_cal_characterize(
+      adcUnit, attenuation, width, 0, &characteristics);
+  channel_reading_v = esp_adc_cal_raw_to_voltage(count, &characteristics) /
+                      1000.0f; // Convert mV to V
+  return AdcErr::ADC_SUCCESS;
 }
 
-BaseAdc::AdcErr Esp32C6Adc::ReadChannel(uint8_t channel_num, uint32_t& channel_reading_count, float& channel_reading_v, uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
-    auto err = ReadChannelCount(channel_num, channel_reading_count, numOfSamplesToAvg, timeBetweenSamples);
-    if (err != AdcErr::ADC_SUCCESS) return err;
-    return ReadChannelV(channel_num, channel_reading_v, numOfSamplesToAvg, timeBetweenSamples);
+BaseAdc::AdcErr Esp32C6Adc::ReadChannel(uint8_t channel_num,
+                                        uint32_t &channel_reading_count,
+                                        float &channel_reading_v,
+                                        uint8_t numOfSamplesToAvg,
+                                        uint32_t timeBetweenSamples) noexcept {
+  auto err = ReadChannelCount(channel_num, channel_reading_count,
+                              numOfSamplesToAvg, timeBetweenSamples);
+  if (err != AdcErr::ADC_SUCCESS)
+    return err;
+  return ReadChannelV(channel_num, channel_reading_v, numOfSamplesToAvg,
+                      timeBetweenSamples);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/I2cBus.cpp
+++ b/src/I2cBus.cpp
@@ -12,67 +12,64 @@ I2cBus::I2cBus(i2c_port_t port, const i2c_config_t &cfg) noexcept
     : i2cPort(port), config(cfg), initialized(false) {}
 
 I2cBus::~I2cBus() noexcept {
-    if (initialized) {
-        Close();
-    }
+  if (initialized) {
+    Close();
+  }
 }
 
 bool I2cBus::Open() noexcept {
-    if (initialized)
-        return true;
-
-    esp_err_t ret = i2c_param_config(i2cPort, &config);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "param_config failed: %d", ret);
-        return false;
-    }
-    ret = i2c_driver_install(i2cPort, config.mode, 0, 0, 0);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "driver_install failed: %d", ret);
-        return false;
-    }
-    initialized = true;
+  if (initialized)
     return true;
+
+  esp_err_t ret = i2c_param_config(i2cPort, &config);
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "param_config failed: %d", ret);
+    return false;
+  }
+  ret = i2c_driver_install(i2cPort, config.mode, 0, 0, 0);
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "driver_install failed: %d", ret);
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool I2cBus::Close() noexcept {
-    if (!initialized)
-        return true;
-    i2c_driver_delete(i2cPort);
-    initialized = false;
+  if (!initialized)
     return true;
+  i2c_driver_delete(i2cPort);
+  initialized = false;
+  return true;
 }
 
 bool I2cBus::Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
                    uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    esp_err_t ret = i2c_master_write_to_device(
-        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
-    return ret == ESP_OK;
+  if (!initialized)
+    return false;
+  esp_err_t ret = i2c_master_write_to_device(i2cPort, addr, data, sizeBytes,
+                                             pdMS_TO_TICKS(timeoutMsec));
+  return ret == ESP_OK;
 }
 
 bool I2cBus::Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
                   uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    esp_err_t ret = i2c_master_read_from_device(
-        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
-    return ret == ESP_OK;
+  if (!initialized)
+    return false;
+  esp_err_t ret = i2c_master_read_from_device(i2cPort, addr, data, sizeBytes,
+                                              pdMS_TO_TICKS(timeoutMsec));
+  return ret == ESP_OK;
 }
 
-bool I2cBus::WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
-                       uint8_t *rxData, uint16_t rxSizeBytes,
-                       uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    esp_err_t ret = i2c_master_write_read_device(
-        i2cPort, addr, txData, txSizeBytes, rxData, rxSizeBytes,
-        pdMS_TO_TICKS(timeoutMsec));
-    return ret == ESP_OK;
+bool I2cBus::WriteRead(uint8_t addr, const uint8_t *txData,
+                       uint16_t txSizeBytes, uint8_t *rxData,
+                       uint16_t rxSizeBytes, uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  esp_err_t ret =
+      i2c_master_write_read_device(i2cPort, addr, txData, txSizeBytes, rxData,
+                                   rxSizeBytes, pdMS_TO_TICKS(timeoutMsec));
+  return ret == ESP_OK;
 }
 
-uint32_t I2cBus::GetClockHz() const noexcept {
-    return config.master.clk_speed;
-}
-
+uint32_t I2cBus::GetClockHz() const noexcept { return config.master.clk_speed; }

--- a/src/NvsStorage.cpp
+++ b/src/NvsStorage.cpp
@@ -6,66 +6,65 @@
 #include "NvsStorage.h"
 #include <cstring>
 
-NvsStorage::NvsStorage(const char* ns) noexcept
-    : nsName(ns), handle(0) {}
+NvsStorage::NvsStorage(const char *ns) noexcept : nsName(ns), handle(0) {}
 
 NvsStorage::~NvsStorage() noexcept {
-    if (handle) {
-        Close();
-    }
+  if (handle) {
+    Close();
+  }
 }
 
 bool NvsStorage::Open() noexcept {
-    if (handle)
-        return true;
-    esp_err_t err = nvs_flash_init();
-    if (err != ESP_OK && err != ESP_ERR_NVS_NO_FREE_PAGES &&
-        err != ESP_ERR_NVS_NEW_VERSION_FOUND) {
-        return false;
-    }
-    if (err != ESP_OK) {
-        nvs_flash_erase();
-        if (nvs_flash_init() != ESP_OK)
-            return false;
-    }
-    err = nvs_open(nsName, NVS_READWRITE, &handle);
-    return err == ESP_OK;
+  if (handle)
+    return true;
+  esp_err_t err = nvs_flash_init();
+  if (err != ESP_OK && err != ESP_ERR_NVS_NO_FREE_PAGES &&
+      err != ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    return false;
+  }
+  if (err != ESP_OK) {
+    nvs_flash_erase();
+    if (nvs_flash_init() != ESP_OK)
+      return false;
+  }
+  err = nvs_open(nsName, NVS_READWRITE, &handle);
+  return err == ESP_OK;
 }
 
 void NvsStorage::Close() noexcept {
-    if (handle) {
-        nvs_close(handle);
-        handle = 0;
-    }
+  if (handle) {
+    nvs_close(handle);
+    handle = 0;
+  }
 }
 
-bool NvsStorage::SetU32(const char* key, uint32_t value) noexcept {
-    if (!handle)
-        return false;
-    esp_err_t err = nvs_set_u32(handle, key, value);
-    if (err != ESP_OK)
-        return false;
-    return Commit();
+bool NvsStorage::SetU32(const char *key, uint32_t value) noexcept {
+  if (!handle)
+    return false;
+  esp_err_t err = nvs_set_u32(handle, key, value);
+  if (err != ESP_OK)
+    return false;
+  return Commit();
 }
 
-bool NvsStorage::GetU32(const char* key, uint32_t& value) noexcept {
-    if (!handle)
-        return false;
-    esp_err_t err = nvs_get_u32(handle, key, &value);
-    return err == ESP_OK;
+bool NvsStorage::GetU32(const char *key, uint32_t &value) noexcept {
+  if (!handle)
+    return false;
+  esp_err_t err = nvs_get_u32(handle, key, &value);
+  return err == ESP_OK;
 }
 
-bool NvsStorage::EraseKey(const char* key) noexcept {
-    if (!handle)
-        return false;
-    esp_err_t err = nvs_erase_key(handle, key);
-    if (err != ESP_OK)
-        return false;
-    return Commit();
+bool NvsStorage::EraseKey(const char *key) noexcept {
+  if (!handle)
+    return false;
+  esp_err_t err = nvs_erase_key(handle, key);
+  if (err != ESP_OK)
+    return false;
+  return Commit();
 }
 
 bool NvsStorage::Commit() noexcept {
-    if (!handle)
-        return false;
-    return nvs_commit(handle) == ESP_OK;
+  if (!handle)
+    return false;
+  return nvs_commit(handle) == ESP_OK;
 }

--- a/src/PeriodicTimer.cpp
+++ b/src/PeriodicTimer.cpp
@@ -1,59 +1,58 @@
 #include "PeriodicTimer.h"
 #include <esp_log.h>
 
-static const char* TAG = "PeriodicTimer";
+static const char *TAG = "PeriodicTimer";
 
-PeriodicTimer::PeriodicTimer(Callback cb, void* arg) noexcept
+PeriodicTimer::PeriodicTimer(Callback cb, void *arg) noexcept
     : handle(nullptr), userCb(cb), userArg(arg), running(false) {}
 
 PeriodicTimer::~PeriodicTimer() noexcept {
-    Stop();
-    if (handle) {
-        esp_timer_delete(handle);
-        handle = nullptr;
-    }
+  Stop();
+  if (handle) {
+    esp_timer_delete(handle);
+    handle = nullptr;
+  }
 }
 
 bool PeriodicTimer::CreateHandle() noexcept {
-    if (handle)
-        return true;
-    esp_timer_create_args_t args = {};
-    args.callback = &PeriodicTimer::Dispatch;
-    args.arg = this;
-    args.dispatch_method = ESP_TIMER_TASK;
-    esp_err_t ret = esp_timer_create(&args, &handle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "esp_timer_create failed: %d", ret);
-        return false;
-    }
+  if (handle)
     return true;
+  esp_timer_create_args_t args = {};
+  args.callback = &PeriodicTimer::Dispatch;
+  args.arg = this;
+  args.dispatch_method = ESP_TIMER_TASK;
+  esp_err_t ret = esp_timer_create(&args, &handle);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_timer_create failed: %d", ret);
+    return false;
+  }
+  return true;
 }
 
 bool PeriodicTimer::Start(uint64_t periodUs) noexcept {
-    if (!CreateHandle())
-        return false;
-    esp_err_t ret = esp_timer_start_periodic(handle, periodUs);
-    if (ret == ESP_OK)
-        running = true;
-    else
-        ESP_LOGE(TAG, "esp_timer_start_periodic failed: %d", ret);
-    return ret == ESP_OK;
+  if (!CreateHandle())
+    return false;
+  esp_err_t ret = esp_timer_start_periodic(handle, periodUs);
+  if (ret == ESP_OK)
+    running = true;
+  else
+    ESP_LOGE(TAG, "esp_timer_start_periodic failed: %d", ret);
+  return ret == ESP_OK;
 }
 
 bool PeriodicTimer::Stop() noexcept {
-    if (!handle || !running)
-        return true;
-    esp_err_t ret = esp_timer_stop(handle);
-    if (ret == ESP_OK)
-        running = false;
-    else
-        ESP_LOGE(TAG, "esp_timer_stop failed: %d", ret);
-    return ret == ESP_OK;
+  if (!handle || !running)
+    return true;
+  esp_err_t ret = esp_timer_stop(handle);
+  if (ret == ESP_OK)
+    running = false;
+  else
+    ESP_LOGE(TAG, "esp_timer_stop failed: %d", ret);
+  return ret == ESP_OK;
 }
 
-void PeriodicTimer::Dispatch(void* arg) {
-    auto self = static_cast<PeriodicTimer*>(arg);
-    if (self && self->userCb)
-        self->userCb(self->userArg);
+void PeriodicTimer::Dispatch(void *arg) {
+  auto self = static_cast<PeriodicTimer *>(arg);
+  if (self && self->userCb)
+    self->userCb(self->userArg);
 }
-

--- a/src/PwmOutput.cpp
+++ b/src/PwmOutput.cpp
@@ -5,64 +5,65 @@ PwmOutput::PwmOutput(gpio_num_t pinArg, ledc_channel_t channelArg,
                      ledc_timer_t timerArg, uint32_t freqHz,
                      ledc_timer_bit_t resolutionArg,
                      ActiveState activeStateArg) noexcept
-    : DigitalGpio(pinArg, activeStateArg),
-      channel(channelArg),
-      timer(timerArg),
-      frequency(freqHz),
-      resolution(resolutionArg) {}
+    : DigitalGpio(pinArg, activeStateArg), channel(channelArg), timer(timerArg),
+      frequency(freqHz), resolution(resolutionArg) {}
 
-PwmOutput::~PwmOutput() noexcept {
-    Stop();
-}
+PwmOutput::~PwmOutput() noexcept { Stop(); }
 
 bool PwmOutput::Initialize() noexcept {
-    ledc_timer_config_t timer_conf = {};
-    timer_conf.speed_mode = LEDC_LOW_SPEED_MODE;
-    timer_conf.timer_num = timer;
-    timer_conf.freq_hz = frequency;
-    timer_conf.duty_resolution = resolution;
-    if (ledc_timer_config(&timer_conf) != ESP_OK) {
-        return false;
-    }
+  ledc_timer_config_t timer_conf = {};
+  timer_conf.speed_mode = LEDC_LOW_SPEED_MODE;
+  timer_conf.timer_num = timer;
+  timer_conf.freq_hz = frequency;
+  timer_conf.duty_resolution = resolution;
+  if (ledc_timer_config(&timer_conf) != ESP_OK) {
+    return false;
+  }
 
-    ledc_channel_config_t ch_conf = {};
-    ch_conf.channel = channel;
-    ch_conf.gpio_num = pin;
-    ch_conf.speed_mode = LEDC_LOW_SPEED_MODE;
-    ch_conf.hpoint = 0;
-    ch_conf.timer_sel = timer;
-    ch_conf.duty = 0;
-    if (ledc_channel_config(&ch_conf) != ESP_OK) {
-        return false;
-    }
-    return true;
+  ledc_channel_config_t ch_conf = {};
+  ch_conf.channel = channel;
+  ch_conf.gpio_num = pin;
+  ch_conf.speed_mode = LEDC_LOW_SPEED_MODE;
+  ch_conf.hpoint = 0;
+  ch_conf.timer_sel = timer;
+  ch_conf.duty = 0;
+  if (ledc_channel_config(&ch_conf) != ESP_OK) {
+    return false;
+  }
+  return true;
 }
 
 bool PwmOutput::Start() noexcept {
-    if (!EnsureInitialized()) return false;
-    return ledc_update_duty(LEDC_LOW_SPEED_MODE, channel) == ESP_OK;
+  if (!EnsureInitialized())
+    return false;
+  return ledc_update_duty(LEDC_LOW_SPEED_MODE, channel) == ESP_OK;
 }
 
 bool PwmOutput::Stop() noexcept {
-    if (!initialized) return true;
-    return ledc_stop(LEDC_LOW_SPEED_MODE, channel, IsActiveHigh() ? 0 : 1) == ESP_OK;
+  if (!initialized)
+    return true;
+  return ledc_stop(LEDC_LOW_SPEED_MODE, channel, IsActiveHigh() ? 0 : 1) ==
+         ESP_OK;
 }
 
 bool PwmOutput::SetDuty(float duty) noexcept {
-    if (!EnsureInitialized()) return false;
-    if (duty < 0.0f) duty = 0.0f;
-    if (duty > 1.0f) duty = 1.0f;
-    uint32_t max_duty = (1u << resolution) - 1u;
-    uint32_t duty_val = static_cast<uint32_t>(duty * max_duty);
-    if (ledc_set_duty(LEDC_LOW_SPEED_MODE, channel, duty_val) != ESP_OK) {
-        return false;
-    }
-    return ledc_update_duty(LEDC_LOW_SPEED_MODE, channel) == ESP_OK;
+  if (!EnsureInitialized())
+    return false;
+  if (duty < 0.0f)
+    duty = 0.0f;
+  if (duty > 1.0f)
+    duty = 1.0f;
+  uint32_t max_duty = (1u << resolution) - 1u;
+  uint32_t duty_val = static_cast<uint32_t>(duty * max_duty);
+  if (ledc_set_duty(LEDC_LOW_SPEED_MODE, channel, duty_val) != ESP_OK) {
+    return false;
+  }
+  return ledc_update_duty(LEDC_LOW_SPEED_MODE, channel) == ESP_OK;
 }
 
 bool PwmOutput::SetFrequency(uint32_t freqHz) noexcept {
-    if (!EnsureInitialized()) return false;
-    frequency = freqHz;
-    return ledc_set_freq(LEDC_LOW_SPEED_MODE, timer, frequency) > 0;
+  if (!EnsureInitialized())
+    return false;
+  frequency = freqHz;
+  return ledc_set_freq(LEDC_LOW_SPEED_MODE, timer, frequency) > 0;
 }
-

--- a/src/RmtOutput.cpp
+++ b/src/RmtOutput.cpp
@@ -1,39 +1,40 @@
 #include "RmtOutput.h"
 
-RmtOutput::RmtOutput(rmt_channel_t channel, gpio_num_t pin, uint32_t clk_div) noexcept
+RmtOutput::RmtOutput(rmt_channel_t channel, gpio_num_t pin,
+                     uint32_t clk_div) noexcept
     : chan(channel), gpio(pin), div(clk_div), installed(false) {}
 
-RmtOutput::~RmtOutput() noexcept {
-    Close();
-}
+RmtOutput::~RmtOutput() noexcept { Close(); }
 
 bool RmtOutput::Open() noexcept {
-    if (installed) return true;
-    rmt_config_t cfg = {};
-    cfg.rmt_mode = RMT_MODE_TX;
-    cfg.channel = chan;
-    cfg.gpio_num = gpio;
-    cfg.clk_div = div;
-    cfg.mem_block_num = 1;
-    if (rmt_config(&cfg) != ESP_OK) {
-        return false;
-    }
-    if (rmt_driver_install(chan, 0, 0) != ESP_OK) {
-        return false;
-    }
-    installed = true;
+  if (installed)
     return true;
+  rmt_config_t cfg = {};
+  cfg.rmt_mode = RMT_MODE_TX;
+  cfg.channel = chan;
+  cfg.gpio_num = gpio;
+  cfg.clk_div = div;
+  cfg.mem_block_num = 1;
+  if (rmt_config(&cfg) != ESP_OK) {
+    return false;
+  }
+  if (rmt_driver_install(chan, 0, 0) != ESP_OK) {
+    return false;
+  }
+  installed = true;
+  return true;
 }
 
 void RmtOutput::Close() noexcept {
-    if (installed) {
-        rmt_driver_uninstall(chan);
-        installed = false;
-    }
+  if (installed) {
+    rmt_driver_uninstall(chan);
+    installed = false;
+  }
 }
 
-bool RmtOutput::Write(const rmt_item32_t* items, size_t len, bool wait_tx_done) noexcept {
-    if (!installed) return false;
-    return rmt_write_items(chan, items, len, wait_tx_done) == ESP_OK;
+bool RmtOutput::Write(const rmt_item32_t *items, size_t len,
+                      bool wait_tx_done) noexcept {
+  if (!installed)
+    return false;
+  return rmt_write_items(chan, items, len, wait_tx_done) == ESP_OK;
 }
-

--- a/src/SfFlexCan.cpp
+++ b/src/SfFlexCan.cpp
@@ -5,55 +5,55 @@
 
 #include "SfFlexCan.h"
 
-SfFlexCan::SfFlexCan(uint8_t port, uint32_t baudRate, SemaphoreHandle_t mtx) noexcept
+SfFlexCan::SfFlexCan(uint8_t port, uint32_t baudRate,
+                     SemaphoreHandle_t mtx) noexcept
     : base(port, baudRate), mutex(mtx), initialized(false) {}
 
 SfFlexCan::~SfFlexCan() noexcept {
-    if (initialized)
-        Close();
+  if (initialized)
+    Close();
 }
 
 bool SfFlexCan::Open() noexcept {
-    if (initialized)
-        return true;
-    if (!base.Open())
-        return false;
-    initialized = true;
+  if (initialized)
     return true;
+  if (!base.Open())
+    return false;
+  initialized = true;
+  return true;
 }
 
 bool SfFlexCan::Close() noexcept {
-    if (!initialized)
-        return true;
-    base.Close();
-    initialized = false;
+  if (!initialized)
     return true;
+  base.Close();
+  initialized = false;
+  return true;
 }
 
-bool SfFlexCan::Write(const FlexCan::Frame& frame, uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
-        return false;
-    bool ok = base.Write(frame);
-    xSemaphoreGive(mutex);
-    return ok;
+bool SfFlexCan::Write(const FlexCan::Frame &frame,
+                      uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  bool ok = base.Write(frame);
+  xSemaphoreGive(mutex);
+  return ok;
 }
 
-bool SfFlexCan::Read(FlexCan::Frame& frame, uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
-        return false;
-    bool ok = base.Read(frame, timeoutMsec);
-    xSemaphoreGive(mutex);
-    return ok;
+bool SfFlexCan::Read(FlexCan::Frame &frame, uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  bool ok = base.Read(frame, timeoutMsec);
+  xSemaphoreGive(mutex);
+  return ok;
 }
 
 bool SfFlexCan::Lock(uint32_t timeoutMsec) noexcept {
-    return xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE;
+  return xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE;
 }
 
-bool SfFlexCan::Unlock() noexcept {
-    return xSemaphoreGive(mutex) == pdTRUE;
-}
+bool SfFlexCan::Unlock() noexcept { return xSemaphoreGive(mutex) == pdTRUE; }

--- a/src/SfI2cBus.cpp
+++ b/src/SfI2cBus.cpp
@@ -8,91 +8,91 @@
 
 static const char *TAG = "SfI2cBus";
 
-SfI2cBus::SfI2cBus(i2c_port_t port, const i2c_config_t &cfg, SemaphoreHandle_t mutexHandle) noexcept
+SfI2cBus::SfI2cBus(i2c_port_t port, const i2c_config_t &cfg,
+                   SemaphoreHandle_t mutexHandle) noexcept
     : i2cPort(port), config(cfg), busMutex(mutexHandle), initialized(false) {}
 
 SfI2cBus::~SfI2cBus() noexcept {
-    if (initialized) {
-        Close();
-    }
+  if (initialized) {
+    Close();
+  }
 }
 
 bool SfI2cBus::Open() noexcept {
-    if (initialized)
-        return true;
-    esp_err_t ret = i2c_param_config(i2cPort, &config);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "param_config failed: %d", ret);
-        return false;
-    }
-    ret = i2c_driver_install(i2cPort, config.mode, 0, 0, 0);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "driver_install failed: %d", ret);
-        return false;
-    }
-    initialized = true;
+  if (initialized)
     return true;
+  esp_err_t ret = i2c_param_config(i2cPort, &config);
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "param_config failed: %d", ret);
+    return false;
+  }
+  ret = i2c_driver_install(i2cPort, config.mode, 0, 0, 0);
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "driver_install failed: %d", ret);
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool SfI2cBus::Close() noexcept {
-    if (!initialized)
-        return true;
-    i2c_driver_delete(i2cPort);
-    initialized = false;
+  if (!initialized)
     return true;
+  i2c_driver_delete(i2cPort);
+  initialized = false;
+  return true;
 }
 
 bool SfI2cBus::Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
                      uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
-        return false;
-    esp_err_t ret = i2c_master_write_to_device(
-        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
-    xSemaphoreGive(busMutex);
-    return ret == ESP_OK;
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  esp_err_t ret = i2c_master_write_to_device(i2cPort, addr, data, sizeBytes,
+                                             pdMS_TO_TICKS(timeoutMsec));
+  xSemaphoreGive(busMutex);
+  return ret == ESP_OK;
 }
 
 bool SfI2cBus::Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
                     uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
-        return false;
-    esp_err_t ret = i2c_master_read_from_device(
-        i2cPort, addr, data, sizeBytes, pdMS_TO_TICKS(timeoutMsec));
-    xSemaphoreGive(busMutex);
-    return ret == ESP_OK;
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  esp_err_t ret = i2c_master_read_from_device(i2cPort, addr, data, sizeBytes,
+                                              pdMS_TO_TICKS(timeoutMsec));
+  xSemaphoreGive(busMutex);
+  return ret == ESP_OK;
 }
 
-bool SfI2cBus::WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes,
-                         uint8_t *rxData, uint16_t rxSizeBytes,
-                         uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
-        return false;
-    esp_err_t ret = i2c_master_write_read_device(
-        i2cPort, addr, txData, txSizeBytes, rxData, rxSizeBytes,
-        pdMS_TO_TICKS(timeoutMsec));
-    xSemaphoreGive(busMutex);
-    return ret == ESP_OK;
+bool SfI2cBus::WriteRead(uint8_t addr, const uint8_t *txData,
+                         uint16_t txSizeBytes, uint8_t *rxData,
+                         uint16_t rxSizeBytes, uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  esp_err_t ret =
+      i2c_master_write_read_device(i2cPort, addr, txData, txSizeBytes, rxData,
+                                   rxSizeBytes, pdMS_TO_TICKS(timeoutMsec));
+  xSemaphoreGive(busMutex);
+  return ret == ESP_OK;
 }
 
 bool SfI2cBus::LockBus(uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    return xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE;
+  if (!initialized)
+    return false;
+  return xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE;
 }
 
 bool SfI2cBus::UnlockBus() noexcept {
-    if (!initialized)
-        return false;
-    return xSemaphoreGive(busMutex) == pdTRUE;
+  if (!initialized)
+    return false;
+  return xSemaphoreGive(busMutex) == pdTRUE;
 }
 
 uint32_t SfI2cBus::GetClockHz() const noexcept {
-    return config.master.clk_speed;
+  return config.master.clk_speed;
 }
-

--- a/src/SfSpiBus.cpp
+++ b/src/SfSpiBus.cpp
@@ -1,124 +1,142 @@
 /**
  * @file SfSpiBus.cpp
- * @brief Implementation of the SfSpiBus class for ESP32 (ESP-IDF), providing SPI master communication with thread safety and software-controlled CS.
+ * @brief Implementation of the SfSpiBus class for ESP32 (ESP-IDF), providing
+ * SPI master communication with thread safety and software-controlled CS.
  *
- * This class abstracts the ESP-IDF SPI master driver and provides thread-safe SPI transactions using FreeRTOS mutexes.
- * It allows for software-controlled chip select (CS) pin, supporting multi-device SPI buses.
+ * This class abstracts the ESP-IDF SPI master driver and provides thread-safe
+ * SPI transactions using FreeRTOS mutexes. It allows for software-controlled
+ * chip select (CS) pin, supporting multi-device SPI buses.
  *
  * @author Nebula Tech Corporation
  * @copyright Copyright © 2023 Nebula Tech Corporation. All Rights Reserved.
- * This file is part of HardFOC and is licensed under the GNU General Public License v3.0 or later.
+ * This file is part of HardFOC and is licensed under the GNU General Public
+ * License v3.0 or later.
  */
 
 #include "SfSpiBus.h"
 #include <cstring>
 #include <esp_log.h>
 
-static const char* TAG = "SfSpiBus";
+static const char *TAG = "SfSpiBus";
 
-SfSpiBus::SfSpiBus(spi_host_device_t host, const spi_bus_config_t& buscfg, const spi_device_interface_config_t& devcfg, SemaphoreHandle_t mutexHandle) noexcept
-    : spiHost(host), spiHandle(nullptr), busConfig(buscfg), devConfig(devcfg), busMutex(mutexHandle), initialized(false), csPin((gpio_num_t)devcfg.spics_io_num)
-{
-    // No additional initialization required here.
+SfSpiBus::SfSpiBus(spi_host_device_t host, const spi_bus_config_t &buscfg,
+                   const spi_device_interface_config_t &devcfg,
+                   SemaphoreHandle_t mutexHandle) noexcept
+    : spiHost(host), spiHandle(nullptr), busConfig(buscfg), devConfig(devcfg),
+      busMutex(mutexHandle), initialized(false),
+      csPin((gpio_num_t)devcfg.spics_io_num) {
+  // No additional initialization required here.
 }
 
 SfSpiBus::~SfSpiBus() noexcept {
-    if (initialized) {
-        Close();
-    }
+  if (initialized) {
+    Close();
+  }
 }
 
 bool SfSpiBus::Open() noexcept {
-    if (initialized) return true;
-    esp_err_t ret = spi_bus_initialize(spiHost, &busConfig, SPI_DMA_CH_AUTO);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "Failed to initialize SPI bus: %d", ret);
-        return false;
-    }
-    spi_device_interface_config_t devcfgCopy = devConfig;
-    devcfgCopy.spics_io_num = -1; // Software-controlled CS
-    ret = spi_bus_add_device(spiHost, &devcfgCopy, &spiHandle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to add SPI device: %d", ret);
-        return false;
-    }
-    gpio_set_direction(csPin, GPIO_MODE_OUTPUT);
-    gpio_set_level(csPin, 1); // Inactive (high)
-    initialized = true;
+  if (initialized)
     return true;
+  esp_err_t ret = spi_bus_initialize(spiHost, &busConfig, SPI_DMA_CH_AUTO);
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "Failed to initialize SPI bus: %d", ret);
+    return false;
+  }
+  spi_device_interface_config_t devcfgCopy = devConfig;
+  devcfgCopy.spics_io_num = -1; // Software-controlled CS
+  ret = spi_bus_add_device(spiHost, &devcfgCopy, &spiHandle);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to add SPI device: %d", ret);
+    return false;
+  }
+  gpio_set_direction(csPin, GPIO_MODE_OUTPUT);
+  gpio_set_level(csPin, 1); // Inactive (high)
+  initialized = true;
+  return true;
 }
 
 bool SfSpiBus::Close() noexcept {
-    if (!initialized) return true;
-    spi_bus_remove_device(spiHandle);
-    spi_bus_free(spiHost);
-    initialized = false;
+  if (!initialized)
     return true;
+  spi_bus_remove_device(spiHandle);
+  spi_bus_free(spiHost);
+  initialized = false;
+  return true;
 }
 
-bool SfSpiBus::Write(const uint8_t* data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept {
-    if (!initialized) return false;
-    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE) return false;
-    SelectDevice();
-    spi_transaction_t t = {};
-    t.length = sizeBytes * 8;
-    t.tx_buffer = data;
-    t.rx_buffer = nullptr;
-    esp_err_t ret = spi_device_transmit(spiHandle, &t);
-    DeselectDevice();
-    xSemaphoreGive(busMutex);
-    return (ret == ESP_OK);
+bool SfSpiBus::Write(const uint8_t *data, uint16_t sizeBytes,
+                     uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  SelectDevice();
+  spi_transaction_t t = {};
+  t.length = sizeBytes * 8;
+  t.tx_buffer = data;
+  t.rx_buffer = nullptr;
+  esp_err_t ret = spi_device_transmit(spiHandle, &t);
+  DeselectDevice();
+  xSemaphoreGive(busMutex);
+  return (ret == ESP_OK);
 }
 
-bool SfSpiBus::Read(uint8_t* data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept {
-    if (!initialized) return false;
-    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE) return false;
-    SelectDevice();
-    spi_transaction_t t = {};
-    t.length = sizeBytes * 8;
-    t.tx_buffer = nullptr;
-    t.rx_buffer = data;
-    esp_err_t ret = spi_device_transmit(spiHandle, &t);
-    DeselectDevice();
-    xSemaphoreGive(busMutex);
-    return (ret == ESP_OK);
+bool SfSpiBus::Read(uint8_t *data, uint16_t sizeBytes,
+                    uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  SelectDevice();
+  spi_transaction_t t = {};
+  t.length = sizeBytes * 8;
+  t.tx_buffer = nullptr;
+  t.rx_buffer = data;
+  esp_err_t ret = spi_device_transmit(spiHandle, &t);
+  DeselectDevice();
+  xSemaphoreGive(busMutex);
+  return (ret == ESP_OK);
 }
 
-bool SfSpiBus::WriteRead(const uint8_t* write_data, uint8_t* read_data, uint16_t sizeBytes, uint32_t timeoutMsec) noexcept {
-    if (!initialized) return false;
-    if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE) return false;
-    SelectDevice();
-    spi_transaction_t t = {};
-    t.length = sizeBytes * 8;
-    t.tx_buffer = write_data;
-    t.rx_buffer = read_data;
-    esp_err_t ret = spi_device_transmit(spiHandle, &t);
-    DeselectDevice();
-    xSemaphoreGive(busMutex);
-    return (ret == ESP_OK);
+bool SfSpiBus::WriteRead(const uint8_t *write_data, uint8_t *read_data,
+                         uint16_t sizeBytes, uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  SelectDevice();
+  spi_transaction_t t = {};
+  t.length = sizeBytes * 8;
+  t.tx_buffer = write_data;
+  t.rx_buffer = read_data;
+  esp_err_t ret = spi_device_transmit(spiHandle, &t);
+  DeselectDevice();
+  xSemaphoreGive(busMutex);
+  return (ret == ESP_OK);
 }
 
 bool SfSpiBus::LockBus(uint32_t timeoutMsec) noexcept {
-    if (!initialized) return false;
-    return (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE);
+  if (!initialized)
+    return false;
+  return (xSemaphoreTake(busMutex, pdMS_TO_TICKS(timeoutMsec)) == pdTRUE);
 }
 
 bool SfSpiBus::UnlockBus() noexcept {
-    if (!initialized) return false;
-    return (xSemaphoreGive(busMutex) == pdTRUE);
+  if (!initialized)
+    return false;
+  return (xSemaphoreGive(busMutex) == pdTRUE);
 }
 
 uint32_t SfSpiBus::GetClockHz() const noexcept {
-    return devConfig.clock_speed_hz;
+  return devConfig.clock_speed_hz;
 }
 
 bool SfSpiBus::SelectDevice() noexcept {
-    gpio_set_level(csPin, 0);
-    return true;
+  gpio_set_level(csPin, 0);
+  return true;
 }
 
 bool SfSpiBus::DeselectDevice() noexcept {
-    gpio_set_level(csPin, 1);
-    return true;
+  gpio_set_level(csPin, 1);
+  return true;
 }
-

--- a/src/SfUartDriver.cpp
+++ b/src/SfUartDriver.cpp
@@ -6,79 +6,83 @@
 #include "SfUartDriver.h"
 #include <esp_log.h>
 
-static const char* TAG = "SfUartDriver";
+static const char *TAG = "SfUartDriver";
 
-SfUartDriver::SfUartDriver(uart_port_t p, const uart_config_t& cfg,
-                           int tx, int rx, SemaphoreHandle_t mtx) noexcept
-    : port(p), config(cfg), txPin(tx), rxPin(rx), mutex(mtx), initialized(false) {}
+SfUartDriver::SfUartDriver(uart_port_t p, const uart_config_t &cfg, int tx,
+                           int rx, SemaphoreHandle_t mtx) noexcept
+    : port(p), config(cfg), txPin(tx), rxPin(rx), mutex(mtx),
+      initialized(false) {}
 
 SfUartDriver::~SfUartDriver() noexcept {
-    if (initialized) {
-        Close();
-    }
+  if (initialized) {
+    Close();
+  }
 }
 
 bool SfUartDriver::Open() noexcept {
-    if (initialized)
-        return true;
-    esp_err_t err = uart_param_config(port, &config);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "param config failed: %d", err);
-        return false;
-    }
-    err = uart_set_pin(port, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "set pin failed: %d", err);
-        return false;
-    }
-    err = uart_driver_install(port,
-                              config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
-                              config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
-                              0, nullptr, 0);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "driver install failed: %d", err);
-        return false;
-    }
-    initialized = true;
+  if (initialized)
     return true;
+  esp_err_t err = uart_param_config(port, &config);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "param config failed: %d", err);
+    return false;
+  }
+  err =
+      uart_set_pin(port, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "set pin failed: %d", err);
+    return false;
+  }
+  err = uart_driver_install(
+      port, config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
+      config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256, 0, nullptr,
+      0);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "driver install failed: %d", err);
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool SfUartDriver::Close() noexcept {
-    if (!initialized)
-        return true;
-    uart_driver_delete(port);
-    initialized = false;
+  if (!initialized)
     return true;
+  uart_driver_delete(port);
+  initialized = false;
+  return true;
 }
 
-bool SfUartDriver::Write(const uint8_t* data, uint16_t length, uint32_t timeoutMsec) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
-        return false;
-    int ret = uart_write_bytes(port, data, length);
-    xSemaphoreGive(mutex);
-    return ret == length;
+bool SfUartDriver::Write(const uint8_t *data, uint16_t length,
+                         uint32_t timeoutMsec) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(mutex, pdMS_TO_TICKS(timeoutMsec)) != pdTRUE)
+    return false;
+  int ret = uart_write_bytes(port, data, length);
+  xSemaphoreGive(mutex);
+  return ret == length;
 }
 
-bool SfUartDriver::Read(uint8_t* data, uint16_t length, TickType_t ticksToWait) noexcept {
-    if (!initialized)
-        return false;
-    if (xSemaphoreTake(mutex, ticksToWait) != pdTRUE)
-        return false;
-    int ret = uart_read_bytes(port, data, length, ticksToWait);
-    xSemaphoreGive(mutex);
-    return ret == length;
+bool SfUartDriver::Read(uint8_t *data, uint16_t length,
+                        TickType_t ticksToWait) noexcept {
+  if (!initialized)
+    return false;
+  if (xSemaphoreTake(mutex, ticksToWait) != pdTRUE)
+    return false;
+  int ret = uart_read_bytes(port, data, length, ticksToWait);
+  xSemaphoreGive(mutex);
+  return ret == length;
 }
 
 bool SfUartDriver::Lock() noexcept {
-    if (!initialized)
-        return false;
-    return xSemaphoreTake(mutex, portMAX_DELAY) == pdTRUE;
+  if (!initialized)
+    return false;
+  return xSemaphoreTake(mutex, portMAX_DELAY) == pdTRUE;
 }
 
 bool SfUartDriver::Unlock() noexcept {
-    if (!initialized)
-        return false;
-    return xSemaphoreGive(mutex) == pdTRUE;
+  if (!initialized)
+    return false;
+  return xSemaphoreGive(mutex) == pdTRUE;
 }

--- a/src/SpiBus.cpp
+++ b/src/SpiBus.cpp
@@ -1,87 +1,99 @@
 /**
  * @file SpiBus.cpp
- * @brief Implementation of the SpiBus class for ESP32 (ESP-IDF), providing SPI master communication.
+ * @brief Implementation of the SpiBus class for ESP32 (ESP-IDF), providing SPI
+ * master communication.
  *
- * This class abstracts the ESP-IDF SPI master driver and provides SPI transactions.
- * It replaces Synergy/ThreadX/SSP-specific code with ESP-IDF APIs.
+ * This class abstracts the ESP-IDF SPI master driver and provides SPI
+ * transactions. It replaces Synergy/ThreadX/SSP-specific code with ESP-IDF
+ * APIs.
  *
  * @author Nebula Tech Corporation
  * @copyright Copyright © 2023 Nebula Tech Corporation. All Rights Reserved.
- * This file is part of HardFOC and is licensed under the GNU General Public License v3.0 or later.
+ * This file is part of HardFOC and is licensed under the GNU General Public
+ * License v3.0 or later.
  */
 
 #include "SpiBus.h"
 #include <cstring>
 #include <esp_log.h>
 
-static const char* TAG = "SpiBus";
+static const char *TAG = "SpiBus";
 
-SpiBus::SpiBus(spi_host_device_t host, const spi_bus_config_t& buscfg, const spi_device_interface_config_t& devcfg) noexcept
-    : spiHost(host), spiHandle(nullptr), busConfig(buscfg), devConfig(devcfg), initialized(false)
-{
-    // No additional initialization required here.
+SpiBus::SpiBus(spi_host_device_t host, const spi_bus_config_t &buscfg,
+               const spi_device_interface_config_t &devcfg) noexcept
+    : spiHost(host), spiHandle(nullptr), busConfig(buscfg), devConfig(devcfg),
+      initialized(false) {
+  // No additional initialization required here.
 }
 
 SpiBus::~SpiBus() noexcept {
-    if (initialized) {
-        Close();
-    }
+  if (initialized) {
+    Close();
+  }
 }
 
 bool SpiBus::Open() noexcept {
-    if (initialized) return true;
-    esp_err_t ret = spi_bus_initialize(spiHost, &busConfig, SPI_DMA_CH_AUTO);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "Failed to initialize SPI bus: %d", ret);
-        return false;
-    }
-    ret = spi_bus_add_device(spiHost, &devConfig, &spiHandle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to add SPI device: %d", ret);
-        return false;
-    }
-    initialized = true;
+  if (initialized)
     return true;
+  esp_err_t ret = spi_bus_initialize(spiHost, &busConfig, SPI_DMA_CH_AUTO);
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "Failed to initialize SPI bus: %d", ret);
+    return false;
+  }
+  ret = spi_bus_add_device(spiHost, &devConfig, &spiHandle);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to add SPI device: %d", ret);
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool SpiBus::Close() noexcept {
-    if (!initialized) return true;
-    spi_bus_remove_device(spiHandle);
-    spi_bus_free(spiHost);
-    initialized = false;
+  if (!initialized)
     return true;
+  spi_bus_remove_device(spiHandle);
+  spi_bus_free(spiHost);
+  initialized = false;
+  return true;
 }
 
-bool SpiBus::Write(const uint8_t* data, uint16_t sizeBytes, uint32_t /*timeoutMsec*/) noexcept {
-    if (!initialized) return false;
-    spi_transaction_t t = {};
-    t.length = sizeBytes * 8;
-    t.tx_buffer = data;
-    t.rx_buffer = nullptr;
-    esp_err_t ret = spi_device_transmit(spiHandle, &t);
-    return (ret == ESP_OK);
+bool SpiBus::Write(const uint8_t *data, uint16_t sizeBytes,
+                   uint32_t /*timeoutMsec*/) noexcept {
+  if (!initialized)
+    return false;
+  spi_transaction_t t = {};
+  t.length = sizeBytes * 8;
+  t.tx_buffer = data;
+  t.rx_buffer = nullptr;
+  esp_err_t ret = spi_device_transmit(spiHandle, &t);
+  return (ret == ESP_OK);
 }
 
-bool SpiBus::Read(uint8_t* data, uint16_t sizeBytes, uint32_t /*timeoutMsec*/) noexcept {
-    if (!initialized) return false;
-    spi_transaction_t t = {};
-    t.length = sizeBytes * 8;
-    t.tx_buffer = nullptr;
-    t.rx_buffer = data;
-    esp_err_t ret = spi_device_transmit(spiHandle, &t);
-    return (ret == ESP_OK);
+bool SpiBus::Read(uint8_t *data, uint16_t sizeBytes,
+                  uint32_t /*timeoutMsec*/) noexcept {
+  if (!initialized)
+    return false;
+  spi_transaction_t t = {};
+  t.length = sizeBytes * 8;
+  t.tx_buffer = nullptr;
+  t.rx_buffer = data;
+  esp_err_t ret = spi_device_transmit(spiHandle, &t);
+  return (ret == ESP_OK);
 }
 
-bool SpiBus::WriteRead(const uint8_t* tx, uint8_t* rx, uint16_t sizeBytes, uint32_t /*timeoutMsec*/) noexcept {
-    if (!initialized) return false;
-    spi_transaction_t t = {};
-    t.length = sizeBytes * 8;
-    t.tx_buffer = tx;
-    t.rx_buffer = rx;
-    esp_err_t ret = spi_device_transmit(spiHandle, &t);
-    return (ret == ESP_OK);
+bool SpiBus::WriteRead(const uint8_t *tx, uint8_t *rx, uint16_t sizeBytes,
+                       uint32_t /*timeoutMsec*/) noexcept {
+  if (!initialized)
+    return false;
+  spi_transaction_t t = {};
+  t.length = sizeBytes * 8;
+  t.tx_buffer = tx;
+  t.rx_buffer = rx;
+  esp_err_t ret = spi_device_transmit(spiHandle, &t);
+  return (ret == ESP_OK);
 }
 
 uint32_t SpiBus::GetClockHz() const noexcept {
-    return devConfig.clock_speed_hz;
+  return devConfig.clock_speed_hz;
 }

--- a/src/UartDriver.cpp
+++ b/src/UartDriver.cpp
@@ -6,55 +6,63 @@
 #include "UartDriver.h"
 #include <esp_log.h>
 
-static const char* TAG = "UartDriver";
+static const char *TAG = "UartDriver";
 
-UartDriver::UartDriver(uart_port_t p, const uart_config_t& cfg, int tx, int rx) noexcept
+UartDriver::UartDriver(uart_port_t p, const uart_config_t &cfg, int tx,
+                       int rx) noexcept
     : port(p), config(cfg), txPin(tx), rxPin(rx), initialized(false) {}
 
 UartDriver::~UartDriver() noexcept {
-    if (initialized) {
-        Close();
-    }
+  if (initialized) {
+    Close();
+  }
 }
 
 bool UartDriver::Open() noexcept {
-    if (initialized) return true;
-    esp_err_t err = uart_param_config(port, &config);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "param config failed: %d", err);
-        return false;
-    }
-    err = uart_set_pin(port, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "set pin failed: %d", err);
-        return false;
-    }
-    err = uart_driver_install(port, config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
-                              config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
-                              0, nullptr, 0);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "driver install failed: %d", err);
-        return false;
-    }
-    initialized = true;
+  if (initialized)
     return true;
+  esp_err_t err = uart_param_config(port, &config);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "param config failed: %d", err);
+    return false;
+  }
+  err =
+      uart_set_pin(port, txPin, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "set pin failed: %d", err);
+    return false;
+  }
+  err = uart_driver_install(
+      port, config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256,
+      config.rx_flow_ctrl_thresh ? config.rx_flow_ctrl_thresh : 256, 0, nullptr,
+      0);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "driver install failed: %d", err);
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool UartDriver::Close() noexcept {
-    if (!initialized) return true;
-    uart_driver_delete(port);
-    initialized = false;
+  if (!initialized)
     return true;
+  uart_driver_delete(port);
+  initialized = false;
+  return true;
 }
 
-bool UartDriver::Write(const uint8_t* data, uint16_t length) noexcept {
-    if (!initialized) return false;
-    int ret = uart_write_bytes(port, data, length);
-    return (ret == length);
+bool UartDriver::Write(const uint8_t *data, uint16_t length) noexcept {
+  if (!initialized)
+    return false;
+  int ret = uart_write_bytes(port, data, length);
+  return (ret == length);
 }
 
-bool UartDriver::Read(uint8_t* data, uint16_t length, TickType_t ticksToWait) noexcept {
-    if (!initialized) return false;
-    int ret = uart_read_bytes(port, data, length, ticksToWait);
-    return (ret == length);
+bool UartDriver::Read(uint8_t *data, uint16_t length,
+                      TickType_t ticksToWait) noexcept {
+  if (!initialized)
+    return false;
+  int ret = uart_read_bytes(port, data, length, ticksToWait);
+  return (ret == length);
 }


### PR DESCRIPTION
## Summary
- format all headers and sources using `clang-format`

## Testing
- `clang-format --dry-run --Werror inc/*.h src/*.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684f47590450832886e1fee4079d41ac