### PR TITLE
Fix DacOutput for older ESP-IDF versions

### DIFF
--- a/inc/DacOutput.h
+++ b/inc/DacOutput.h
@@ -1,9 +1,15 @@
 #ifndef DACOUTPUT_H
 #define DACOUTPUT_H
 
+#include "esp_idf_version.h"
 #include <cstdint>
-#include <driver/dac_types.h>
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
 #include <driver/dac_oneshot.h>
+#include <driver/dac_types.h>
+#else
+#include <driver/dac_common.h>
+#endif
 
 /**
  * @file DacOutput.h
@@ -26,7 +32,9 @@ public:
 
 private:
   dac_channel_t channel;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
   dac_oneshot_handle_t handle;
+#endif
   bool enabled;
 };
 

--- a/src/DacOutput.cpp
+++ b/src/DacOutput.cpp
@@ -4,14 +4,26 @@
  */
 
 #include "DacOutput.h"
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
 #include <driver/dac_oneshot.h>
+#else
+#include <driver/dac_output.h>
+#endif
 #include <esp_log.h>
 
 static const char *TAG = "DacOutput";
 
-DacOutput::DacOutput(dac_channel_t ch) noexcept : channel(ch), handle(nullptr), enabled(false) {}
+DacOutput::DacOutput(dac_channel_t ch) noexcept
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    : channel(ch), handle(nullptr), enabled(false){}
+#else
+    : channel(ch), enabled(false) {
+}
+#endif
 
-DacOutput::~DacOutput() noexcept {
+      DacOutput::~DacOutput() noexcept {
   if (enabled) {
     Disable();
   }
@@ -20,8 +32,12 @@ DacOutput::~DacOutput() noexcept {
 bool DacOutput::Enable() noexcept {
   if (enabled)
     return true;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
   dac_oneshot_config_t cfg{.chan_id = channel};
   esp_err_t err = dac_oneshot_new_channel(&cfg, &handle);
+#else
+  esp_err_t err = dac_output_enable(channel);
+#endif
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "enable failed: %d", err);
     return false;
@@ -33,12 +49,18 @@ bool DacOutput::Enable() noexcept {
 bool DacOutput::Disable() noexcept {
   if (!enabled)
     return true;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
   esp_err_t err = dac_oneshot_del_channel(handle);
+#else
+  esp_err_t err = dac_output_disable(channel);
+#endif
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "disable failed: %d", err);
     return false;
   }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
   handle = nullptr;
+#endif
   enabled = false;
   return true;
 }
@@ -46,7 +68,11 @@ bool DacOutput::Disable() noexcept {
 bool DacOutput::SetValue(uint8_t value) noexcept {
   if (!enabled)
     return false;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
   esp_err_t err = dac_oneshot_output_voltage(handle, value);
+#else
+  esp_err_t err = dac_output_voltage(channel, value);
+#endif
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "set value failed: %d", err);
     return false;


### PR DESCRIPTION
## Summary
- handle both new `dac_oneshot` driver and older `dac_output` API
- guard fields and includes based on `ESP_IDF_VERSION`
