### PR TITLE
Add ESP-IDF example and CI build

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI \u2022 Build \u00b7 Size \u00b7 Static Analyse
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IDF_TARGET: esp32c6
+  BUILD_PATH: ci_project
+  ESP_IDF_VERSIONS: '["release-v5.5"]'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build \u279c ${{ matrix.idf_version }} \u00b7 ${{ matrix.build_type }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_version: [release-v5.5]
+        build_type: [Release, Debug]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Format check
+        run: clang-format --dry-run --Werror src/*.cpp inc/*.h examples/esp32/main/*.cpp
+
+      - name: ESP-IDF build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: ${{ matrix.idf_version }}
+          target: ${{ env.IDF_TARGET }}
+          path: .
+          command: |
+            idf.py create-project ${{ env.BUILD_PATH }}
+            cp examples/esp32/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
+            sed -i "s|../../|../|" ${{ env.BUILD_PATH }}/CMakeLists.txt
+            rm -rf ${{ env.BUILD_PATH }}/main
+            cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
+            cp -r examples/common ${{ env.BUILD_PATH }}/common
+            idf.py -C ${{ env.BUILD_PATH }} -DIDF_TARGET=${{ env.IDF_TARGET }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} build
+            idf.py -C ${{ env.BUILD_PATH }} size-components > ${{ env.BUILD_PATH }}/build/size.txt
+            idf.py -C ${{ env.BUILD_PATH }} size --format json > ${{ env.BUILD_PATH }}/build/size.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: fw-${{ matrix.idf_version }}-${{ matrix.build_type }}
+          retention-days: 14
+          path: |
+            ${{ env.BUILD_PATH }}/build/*.bin
+            ${{ env.BUILD_PATH }}/build/*.elf
+            ${{ env.BUILD_PATH }}/build/*.map
+            ${{ env.BUILD_PATH }}/build/size.*
+
+  static-analysis:
+    if: github.event_name == 'pull_request'
+    name: Static analyse (cppcheck + clang-tidy)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: deep5050/cppcheck-action@v3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          enable: all
+          inconclusive: true
+          std: c99
+          include: main
+
+      - uses: ZedThree/clang-tidy-review@v0.21.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .clang-tidy
+
+  workflow-lint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.6.25

--- a/examples/common/DummyDevice.hpp
+++ b/examples/common/DummyDevice.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "I2cBus.h"
+
+class DummyDevice {
+public:
+    DummyDevice(I2cBus& bus, uint8_t address) : bus(bus), address(address) {}
+    bool Init() {
+        uint8_t id = 0;
+        return bus.WriteRead(address, nullptr, 0, &id, 1);
+    }
+private:
+    I2cBus& bus;
+    uint8_t address;
+};

--- a/examples/esp32/CMakeLists.txt
+++ b/examples/esp32/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(EXTRA_COMPONENT_DIRS "../../")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(iid_example)

--- a/examples/esp32/main/CMakeLists.txt
+++ b/examples/esp32/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "main.cpp"
+    INCLUDE_DIRS "." ".." "../../common"
+    REQUIRES iid-espidf
+)

--- a/examples/esp32/main/main.cpp
+++ b/examples/esp32/main/main.cpp
@@ -1,0 +1,15 @@
+#include "DigitalOutput.h"
+#include "I2cBus.h"
+#include "DummyDevice.hpp"
+
+extern "C" void app_main(void) {
+    i2c_config_t cfg{};
+    cfg.sda_io_num = GPIO_NUM_21;
+    cfg.scl_io_num = GPIO_NUM_22;
+    I2cBus bus(I2C_NUM_0, cfg);
+    bus.Open();
+    DummyDevice dev(bus, 0x50);
+    dev.Init();
+    DigitalOutput led(GPIO_NUM_2, DigitalGpio::ActiveState::High);
+    led.SetActive();
+}


### PR DESCRIPTION
## Summary
- add clang-tidy config for static analysis
- add CI workflow that builds an ESP-IDF example
- add example project with dummy device
