### PR TITLE
Fix formatting for ESP32 example

### DIFF
--- a/examples/esp32/main/main.cpp
+++ b/examples/esp32/main/main.cpp
@@ -1,15 +1,15 @@
 #include "DigitalOutput.h"
-#include "I2cBus.h"
 #include "DummyDevice.hpp"
+#include "I2cBus.h"
 
 extern "C" void app_main(void) {
-    i2c_config_t cfg{};
-    cfg.sda_io_num = GPIO_NUM_21;
-    cfg.scl_io_num = GPIO_NUM_22;
-    I2cBus bus(I2C_NUM_0, cfg);
-    bus.Open();
-    DummyDevice dev(bus, 0x50);
-    dev.Init();
-    DigitalOutput led(GPIO_NUM_2, DigitalGpio::ActiveState::High);
-    led.SetActive();
+  i2c_config_t cfg{};
+  cfg.sda_io_num = GPIO_NUM_21;
+  cfg.scl_io_num = GPIO_NUM_22;
+  I2cBus bus(I2C_NUM_0, cfg);
+  bus.Open();
+  DummyDevice dev(bus, 0x50);
+  dev.Init();
+  DigitalOutput led(GPIO_NUM_2, DigitalGpio::ActiveState::High);
+  led.SetActive();
 }


### PR DESCRIPTION
## Summary
- format `examples/esp32/main/main.cpp` with clang-format so CI passes

## Testing
- `clang-format --dry-run --Werror src/*.cpp inc/*.h examples/esp32/main/*.cpp`


------
https://chatgpt.com/codex/tasks/task_e_684f918c7a608328a2a0429c16242324