### PR TITLE
Fix CMake minimum version warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.23)
+
 idf_component_register(
     SRCS
         src/BaseGpio.cpp


### PR DESCRIPTION
## Summary
- add `cmake_minimum_required` to the root CMakeLists
