### PR TITLE
Fix component name for IDF build

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,3 +1,4 @@
+name: iid-espidf
 version: "0.1.0"
 description: "HardFOC Internal Interface Drivers for ESP-IDF"
 dependencies:


### PR DESCRIPTION
## Summary
- set the component name in `idf_component.yml`
