### PR TITLE
Fix build component paths

### DIFF
--- a/components/iid-espidf/CMakeLists.txt
+++ b/components/iid-espidf/CMakeLists.txt
@@ -2,23 +2,23 @@ cmake_minimum_required(VERSION 3.23)
 
 idf_component_register(
     SRCS
-        src/BaseGpio.cpp
-        src/DigitalExternalIRQ.cpp
-        src/DigitalGpio.cpp
-        src/DigitalInput.cpp
-        src/DigitalOutput.cpp
-        src/Esp32C6Adc.cpp
-        src/FlexCan.cpp
-        src/SfFlexCan.cpp
-        src/I2cBus.cpp
-        src/SfSpiBus.cpp
-        src/SfI2cBus.cpp
-        src/SpiBus.cpp
-        src/PwmOutput.cpp
-        src/PeriodicTimer.cpp
-        src/UartDriver.cpp
-        src/SfUartDriver.cpp
-        src/RMT.cpp
-        src/NvsStorage.cpp
-    INCLUDE_DIRS "inc"
+        ../../src/BaseGpio.cpp
+        ../../src/DigitalExternalIRQ.cpp
+        ../../src/DigitalGpio.cpp
+        ../../src/DigitalInput.cpp
+        ../../src/DigitalOutput.cpp
+        ../../src/Esp32C6Adc.cpp
+        ../../src/FlexCan.cpp
+        ../../src/SfFlexCan.cpp
+        ../../src/I2cBus.cpp
+        ../../src/SfSpiBus.cpp
+        ../../src/SfI2cBus.cpp
+        ../../src/SpiBus.cpp
+        ../../src/PwmOutput.cpp
+        ../../src/PeriodicTimer.cpp
+        ../../src/UartDriver.cpp
+        ../../src/SfUartDriver.cpp
+        ../../src/RMT.cpp
+        ../../src/NvsStorage.cpp
+    INCLUDE_DIRS "../../inc"
 )


### PR DESCRIPTION
## Summary
- fix the include and source paths so `idf.py` can find the headers and sources

## Testing
- `clang-format --dry-run --Werror src/*.cpp inc/*.h examples/esp32/main/*.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684fba20864c8328a10beeab4c67050b