### PR TITLE
Replace old RMT item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ serial.Write(reinterpret_cast<const uint8_t*>("hi"), 2);
 ```cpp
 RMT rmt(RMT_CHANNEL_0, GPIO_NUM_18, 80);
 rmt.OpenTx();
-rmt_item32_t item = {};
+rmt_symbol_word_t item = {};
 item.level0 = 1;
 item.duration0 = 500;
 item.level1 = 0;

--- a/docs/RMT.md
+++ b/docs/RMT.md
@@ -4,15 +4,15 @@ Wrapper around the ESP‑IDF RMT API for transmitting or receiving pulse sequenc
 
 ## Features
 - Configure a channel for TX or RX on demand
-- Send arrays of `rmt_item32_t`
-- Receive `rmt_item32_t` buffers
+- Send arrays of `rmt_symbol_word_t`
+- Receive `rmt_symbol_word_t` buffers
 - RAII cleanup of the driver
 
 ## Example
 ```cpp
 RMT rmt(RMT_CHANNEL_0, GPIO_NUM_18, 80);
 rmt.OpenTx();
-rmt_item32_t item = {};
+rmt_symbol_word_t item = {};
 item.level0 = 1;
 item.duration0 = 500;
 item.level1 = 0;

--- a/inc/RMT.hpp
+++ b/inc/RMT.hpp
@@ -291,8 +291,8 @@ public:
   bool OpenRx(uint32_t idle_threshold_us = 1000, uint32_t filter_ns = 200) noexcept;
   void Close() noexcept;
 
-  bool Write(const rmt_item32_t *items, size_t len, bool wait_tx_done = true) noexcept;
-  bool Receive(rmt_item32_t *buffer, size_t buffer_symbols, size_t *out_symbols) noexcept;
+  bool Write(const rmt_symbol_word_t *items, size_t len, bool wait_tx_done = true) noexcept;
+  bool Receive(rmt_symbol_word_t *buffer, size_t buffer_symbols, size_t *out_symbols) noexcept;
 
   bool IsTxOpen() const noexcept {
     return static_cast<bool>(tx);

--- a/src/RMT.cpp
+++ b/src/RMT.cpp
@@ -30,16 +30,15 @@ void RMT::Close() noexcept {
   rx.reset();
 }
 
-bool RMT::Write(const rmt_item32_t *items, size_t len, bool wait_tx_done) noexcept {
+bool RMT::Write(const rmt_symbol_word_t *items, size_t len, bool wait_tx_done) noexcept {
   (void)wait_tx_done;
   if (!tx)
     return false;
-  return tx->transmit(reinterpret_cast<const rmt_symbol_word_t *>(items), len) == ESP_OK;
+  return tx->transmit(items, len) == ESP_OK;
 }
 
-bool RMT::Receive(rmt_item32_t *buffer, size_t buffer_symbols, size_t *out_symbols) noexcept {
+bool RMT::Receive(rmt_symbol_word_t *buffer, size_t buffer_symbols, size_t *out_symbols) noexcept {
   if (!rx)
     return false;
-  return rx->receive(reinterpret_cast<rmt_symbol_word_t *>(buffer), buffer_symbols, out_symbols) ==
-         ESP_OK;
+  return rx->receive(buffer, buffer_symbols, out_symbols) == ESP_OK;
 }


### PR DESCRIPTION
## Summary
- remove the `rmt_item32_t` compatibility alias
- expose `rmt_symbol_word_t` in the RMT class API

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68509cec1fdc8328a81558ab8d432f6b