### PR TITLE
Add docs for GitHub Pages and component map

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,20 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen
+      - name: Build Docs
+        run: doxygen Doxyfile
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./html

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Platform-agnostic internal interface drivers – handy wrappers that provide uni
 > **Note:** This component supports multiple platforms through the hf_platform system. Currently includes ESP-IDF support (requires v5.5 or newer) with extensibility for other platforms.
 
 For detailed API guides see [docs/index.md](docs/index.md).
+For a list of headers and source files see the [Component Map](docs/ComponentMap.md).
 
 ## Platform-Agnostic Architecture
 

--- a/docs/ComponentMap.md
+++ b/docs/ComponentMap.md
@@ -1,0 +1,50 @@
+# 🗺️ Component Map
+
+This document lists the main header and source files in the project and provides quick links to the related documentation pages. Use it as a directory when exploring the codebase.
+
+## 📂 Directory Overview
+
+| Folder | Purpose |
+|-------|---------|
+| `include/base` | Abstract base interfaces |
+| `include/mcu` | MCU-specific implementations |
+| `include/thread_safe` | Thread-safe wrappers |
+| `include/utils` | Utility classes |
+| `src/mcu` | Implementation of MCU classes |
+| `src/thread_safe` | Implementation of thread-safe classes |
+| `src/utils` | Utility implementations |
+
+## 🔗 File Reference
+
+| Header | Source | Documentation |
+|-------|-------|--------------|
+| [`BaseAdc.h`](../include/base/BaseAdc.h) | *(header only)* | [BaseAdc](api/BaseAdc.md) |
+| [`BaseCan.h`](../include/base/BaseCan.h) | *(header only)* | [BaseCan](api/BaseCan.md) |
+| [`BaseGpio.h`](../include/base/BaseGpio.h) | *(header only)* | [BaseGpio](api/BaseGpio.md) |
+| [`BaseI2cBus.h`](../include/base/BaseI2cBus.h) | *(header only)* | [BaseI2cBus](api/BaseI2cBus.md) |
+| [`BasePio.h`](../include/base/BasePio.h) | *(header only)* | [BasePio](api/BasePio.md) |
+| [`BasePwm.h`](../include/base/BasePwm.h) | *(header only)* | [BasePwm](api/BasePwm.md) |
+| [`BaseSpiBus.h`](../include/base/BaseSpiBus.h) | *(header only)* | [BaseSpiBus](api/BaseSpiBus.md) |
+| [`BaseUartDriver.h`](../include/base/BaseUartDriver.h) | *(header only)* | [BaseUartDriver](api/BaseUartDriver.md) |
+| [`McuDigitalGpio.h`](../include/mcu/McuDigitalGpio.h) | [`src/mcu/McuDigitalGpio.cpp`](../src/mcu/McuDigitalGpio.cpp) | [McuDigitalGpio](api/McuDigitalGpio.md) |
+| [`McuAdc.h`](../include/mcu/McuAdc.h) | [`src/mcu/McuAdc.cpp`](../src/mcu/McuAdc.cpp) | [McuAdc](api/McuAdc.md) |
+| [`McuI2cBus.h`](../include/mcu/McuI2cBus.h) | [`src/mcu/McuI2cBus.cpp`](../src/mcu/McuI2cBus.cpp) | API pending |
+| [`McuSpiBus.h`](../include/mcu/McuSpiBus.h) | [`src/mcu/McuSpiBus.cpp`](../src/mcu/McuSpiBus.cpp) | API pending |
+| [`McuUartDriver.h`](../include/mcu/McuUartDriver.h) | [`src/mcu/McuUartDriver.cpp`](../src/mcu/McuUartDriver.cpp) | API pending |
+| [`McuCan.h`](../include/mcu/McuCan.h) | [`src/mcu/McuCan.cpp`](../src/mcu/McuCan.cpp) | API pending |
+| [`McuPwm.h`](../include/mcu/McuPwm.h) | [`src/mcu/McuPwm.cpp`](../src/mcu/McuPwm.cpp) | API pending |
+| [`McuPio.h`](../include/mcu/McuPio.h) | [`src/mcu/McuPio.cpp`](../src/mcu/McuPio.cpp) | API pending |
+| [`SfGpio.h`](../include/thread_safe/SfGpio.h) | [`src/thread_safe/SfGpio.cpp`](../src/thread_safe/SfGpio.cpp) | API pending |
+| [`SfAdc.h`](../include/thread_safe/SfAdc.h) | [`src/thread_safe/SfAdc.cpp`](../src/thread_safe/SfAdc.cpp) | API pending |
+| [`SfI2cBus.h`](../include/thread_safe/SfI2cBus.h) | [`src/thread_safe/SfI2cBus.cpp`](../src/thread_safe/SfI2cBus.cpp) | API pending |
+| [`SfSpiBus.h`](../include/thread_safe/SfSpiBus.h) | [`src/thread_safe/SfSpiBus.cpp`](../src/thread_safe/SfSpiBus.cpp) | API pending |
+| [`SfUartDriver.h`](../include/thread_safe/SfUartDriver.h) | [`src/thread_safe/SfUartDriver.cpp`](../src/thread_safe/SfUartDriver.cpp) | API pending |
+| [`SfCan.h`](../include/thread_safe/SfCan.h) | [`src/thread_safe/SfCan.cpp`](../src/thread_safe/SfCan.cpp) | API pending |
+| [`SfPwm.h`](../include/thread_safe/SfPwm.h) | [`src/thread_safe/SfPwm.cpp`](../src/thread_safe/SfPwm.cpp) | API pending |
+| [`DigitalOutputGuard.h`](../include/utils/DigitalOutputGuard.h) | [`src/utils/DigitalOutputGuard.cpp`](../src/utils/DigitalOutputGuard.cpp) | [DigitalOutputGuard](api/DigitalOutputGuard.md) |
+| [`NvsStorage.h`](../include/utils/NvsStorage.h) | [`src/utils/NvsStorage.cpp`](../src/utils/NvsStorage.cpp) | API pending |
+| [`PeriodicTimer.h`](../include/utils/PeriodicTimer.h) | [`src/utils/PeriodicTimer.cpp`](../src/utils/PeriodicTimer.cpp) | API pending |
+
+Use the links above to quickly locate files and read the corresponding documentation.
+
+[⬆️ Back to Index](index.md)

--- a/docs/guides/github-pages.md
+++ b/docs/guides/github-pages.md
@@ -1,0 +1,77 @@
+# 🌐 Publishing Documentation to GitHub Pages
+
+This guide describes how to build the documentation and deploy it to **GitHub Pages** so your project has a polished website with navigation links.
+
+## 🚀 Overview
+
+1. **Build HTML with Doxygen** – Generate the API reference from your headers and source files.
+2. **Create a GitHub Actions workflow** – Automate the build and deployment process.
+3. **Enable GitHub Pages** – Serve the generated site from the `gh-pages` branch.
+
+## 🔧 Prerequisites
+
+- A GitHub repository with this project
+- Doxygen installed locally (`sudo apt-get install doxygen`)
+- Basic knowledge of GitHub Actions
+
+## 🏗️ Building the Docs
+
+Run the following from the repository root:
+
+```bash
+# Generate HTML documentation
+$ doxygen Doxyfile
+```
+
+This creates an `html/` directory containing the rendered site. Verify `html/index.html` opens correctly in your browser.
+
+## 🤖 GitHub Actions Workflow
+
+Create `.github/workflows/deploy-docs.yml` in your repository with the following contents:
+
+```yaml
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen
+      - name: Build Docs
+        run: doxygen Doxyfile
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./html
+```
+
+The workflow builds the docs on every push to `main` and publishes them to the `gh-pages` branch.
+
+## 🌍 Enabling GitHub Pages
+
+1. Navigate to **Settings → Pages** in your GitHub repository.
+2. Select **Deploy from a branch**.
+3. Choose the `gh-pages` branch and `/` root folder.
+4. Save the settings – your site will be available at `https://<user>.github.io/<repo>/`.
+
+## 🔗 Navigation Helpers
+
+To make your docs easier to browse, add navigation links to the bottom of each Markdown page:
+
+```markdown
+[⬅️ Prev](../examples/basic-gpio.md) | [⬆️ Index](../index.md) | [Next ➡️](../examples/basic-adc.md)
+```
+
+These links allow readers to move sequentially through the documentation and quickly return to the index page.
+
+## ✅ Summary
+
+With a small workflow file and GitHub Pages enabled, you can host a beautiful documentation site directly from your repository. Combine this with the existing Markdown guides and API reference to deliver a professional browsing experience.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,11 @@
 - [🏗️ **Architecture**](#️-architecture) 
 - [📖 **API Reference**](#-api-reference)
 - [🚀 **Quick Start**](#-quick-start)
+- [🗺️ **Component Map**](ComponentMap.md)
 - [📋 **User Guides**](#-user-guides)
 - [💡 **Examples**](#-examples)
 - [🔧 **Development**](#-development)
+- [🕸️ **GitHub Pages**](guides/github-pages.md)
 
 ---
 
@@ -251,6 +253,7 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 | [🧪 **Testing Framework**](guides/testing-guide.md) | Unit testing and validation | QA Engineers |
 | [⚡ **Performance Optimization**](guides/performance-guide.md) | Real-time optimization | Advanced Users |
 | [🛡️ **Error Handling**](guides/error-handling.md) | Robust error management | All Users |
+| [🕸️ **GitHub Pages Workflow**](guides/github-pages.md) | Publish docs automatically | All Users |
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to publish the docs using GitHub Pages
- add a component map linking headers to sources
- reference the new docs from README and index
- create a GitHub Pages deployment workflow