### PR TITLE
Fix docs to match renamed communication classes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering a contribution to the HardFOC Internal Interface Wrapp
 
 1. Install **ESP-IDF v5.5+** and export the environment using `source $IDF_PATH/export.sh`.
 2. Clone this repository and initialize submodules if present.
-3. Build the tests: `cd tests && mkdir build && cd build && cmake .. && make`.
+3. (Optional) If you add tests, build them in a `tests` directory with CMake.
 
 ## Coding Style
 
@@ -18,7 +18,7 @@ Thank you for considering a contribution to the HardFOC Internal Interface Wrapp
 
 1. Fork the repository and create a feature branch.
 2. Ensure `scripts/check_docs.py docs/index.md` reports no broken links.
-3. Run all unit tests and fix any failures.
+3. If tests are added, run them and fix any failures.
 4. Open a pull request describing your changes.
 
 We appreciate improvements to documentation, bug fixes, and new platform implementations.

--- a/docs/ComponentMap.md
+++ b/docs/ComponentMap.md
@@ -21,16 +21,16 @@ This document lists the main header and source files in the project and provides
 | [`BaseAdc.h`](../include/base/BaseAdc.h) | *(header only)* | [BaseAdc](api/BaseAdc.md) |
 | [`BaseCan.h`](../include/base/BaseCan.h) | *(header only)* | [BaseCan](api/BaseCan.md) |
 | [`BaseGpio.h`](../include/base/BaseGpio.h) | *(header only)* | [BaseGpio](api/BaseGpio.md) |
-| [`BaseI2cBus.h`](../include/base/BaseI2cBus.h) | *(header only)* | [BaseI2cBus](api/BaseI2cBus.md) |
+| [`BaseI2c.h`](../include/base/BaseI2c.h) | *(header only)* | [BaseI2c](api/BaseI2c.md) |
 | [`BasePio.h`](../include/base/BasePio.h) | *(header only)* | [BasePio](api/BasePio.md) |
 | [`BasePwm.h`](../include/base/BasePwm.h) | *(header only)* | [BasePwm](api/BasePwm.md) |
-| [`BaseSpiBus.h`](../include/base/BaseSpiBus.h) | *(header only)* | [BaseSpiBus](api/BaseSpiBus.md) |
-| [`BaseUartDriver.h`](../include/base/BaseUartDriver.h) | *(header only)* | [BaseUartDriver](api/BaseUartDriver.md) |
+| [`BaseSpi.h`](../include/base/BaseSpi.h) | *(header only)* | [BaseSpi](api/BaseSpi.md) |
+| [`BaseUart.h`](../include/base/BaseUart.h) | *(header only)* | [BaseUart](api/BaseUart.md) |
 | [`McuDigitalGpio.h`](../include/mcu/McuDigitalGpio.h) | [`src/mcu/McuDigitalGpio.cpp`](../src/mcu/McuDigitalGpio.cpp) | [McuDigitalGpio](api/McuDigitalGpio.md) |
 | [`McuAdc.h`](../include/mcu/McuAdc.h) | [`src/mcu/McuAdc.cpp`](../src/mcu/McuAdc.cpp) | [McuAdc](api/McuAdc.md) |
-| [`McuI2cBus.h`](../include/mcu/McuI2cBus.h) | [`src/mcu/McuI2cBus.cpp`](../src/mcu/McuI2cBus.cpp) | API pending |
-| [`McuSpiBus.h`](../include/mcu/McuSpiBus.h) | [`src/mcu/McuSpiBus.cpp`](../src/mcu/McuSpiBus.cpp) | API pending |
-| [`McuUartDriver.h`](../include/mcu/McuUartDriver.h) | [`src/mcu/McuUartDriver.cpp`](../src/mcu/McuUartDriver.cpp) | API pending |
+| [`McuI2c.h`](../include/mcu/McuI2c.h) | [`src/mcu/McuI2c.cpp`](../src/mcu/McuI2c.cpp) | API pending |
+| [`McuSpi.h`](../include/mcu/McuSpi.h) | [`src/mcu/McuSpi.cpp`](../src/mcu/McuSpi.cpp) | API pending |
+| [`McuUart.h`](../include/mcu/McuUart.h) | [`src/mcu/McuUart.cpp`](../src/mcu/McuUart.cpp) | API pending |
 | [`McuCan.h`](../include/mcu/McuCan.h) | [`src/mcu/McuCan.cpp`](../src/mcu/McuCan.cpp) | API pending |
 | [`McuPwm.h`](../include/mcu/McuPwm.h) | [`src/mcu/McuPwm.cpp`](../src/mcu/McuPwm.cpp) | API pending |
 | [`McuPio.h`](../include/mcu/McuPio.h) | [`src/mcu/McuPio.cpp`](../src/mcu/McuPio.cpp) | API pending |

--- a/docs/api/BaseAdc.md
+++ b/docs/api/BaseAdc.md
@@ -568,7 +568,7 @@ public:
 
 ### ✅ **Unit Test Coverage**
 
-The BaseAdc implementation includes comprehensive unit tests:
+Unit tests are not provided in this repository.
 
 ```cpp
 // Test initialization

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -286,14 +286,7 @@ if (!can->SendMessage(msg)) {
 
 ## 🧪 Testing
 
-The BaseCan class can be tested using:
-
-```cpp
-#include "tests/CommBusTests.h"
-
-// Run comprehensive CAN tests
-bool success = TestCanCommunication();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 

--- a/docs/api/BaseGpio.md
+++ b/docs/api/BaseGpio.md
@@ -550,7 +550,7 @@ void bidirectional_communication() {
 
 ### ✅ **Unit Test Coverage**
 
-The BaseGpio implementation includes comprehensive unit tests:
+Unit tests are not provided in this repository.
 
 ```cpp
 // Test initialization

--- a/docs/api/BaseI2c.md
+++ b/docs/api/BaseI2c.md
@@ -1,14 +1,14 @@
-# 🔗 BaseI2cBus API Documentation
+# 🔗 BaseI2c API Documentation
 
 ## 📋 Overview
 
-The `BaseI2cBus` class is an abstract base class that provides a unified, platform-agnostic interface for I2C (Inter-Integrated Circuit) bus communication in the HardFOC system. This class enables communication with various I2C devices such as sensors, EEPROMs, DACs, and other peripherals through a consistent API.
+The `BaseI2c` class is an abstract base class that provides a unified, platform-agnostic interface for I2C (Inter-Integrated Circuit) bus communication in the HardFOC system. This class enables communication with various I2C devices such as sensors, EEPROMs, DACs, and other peripherals through a consistent API.
 
 ## 🏗️ Class Hierarchy
 
 ```
-BaseI2cBus (Abstract Base Class)
-    ├── McuI2cBus (ESP32/STM32 hardware I2C)
+BaseI2c (Abstract Base Class)
+    ├── McuI2c (ESP32/STM32 hardware I2C)
     ├── BitBangI2c (Software I2C implementation)
     └── SfI2cBus (Thread-safe wrapper)
 ```
@@ -195,7 +195,7 @@ std::vector<uint8_t> ScanBus(uint32_t timeout_ms = 0) noexcept
 
 ### Basic I2C Communication
 ```cpp
-#include "mcu/McuI2cBus.h"
+#include "mcu/McuI2c.h"
 
 // Configure I2C bus
 I2cBusConfig config;
@@ -205,7 +205,7 @@ config.scl_pin = 22;
 config.clock_speed_hz = 400000;  // 400kHz Fast Mode
 
 // Create I2C instance
-auto i2c = std::make_unique<McuI2cBus>(config);
+auto i2c = std::make_unique<McuI2c>(config);
 
 // Initialize
 if (!i2c->EnsureInitialized()) {
@@ -325,19 +325,12 @@ custom_config.timeout_ms = 2000;           // 2s timeout for slow devices
 custom_config.tx_buffer_size = 128;        // Enable buffering
 custom_config.rx_buffer_size = 128;
 
-auto i2c_slow = std::make_unique<McuI2cBus>(custom_config);
+auto i2c_slow = std::make_unique<McuI2c>(custom_config);
 ```
 
 ## 🧪 Testing
 
-The BaseI2cBus class can be tested using:
-
-```cpp
-#include "tests/CommBusTests.h"
-
-// Run comprehensive I2C tests
-bool success = TestI2cCommunication();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 
@@ -352,7 +345,7 @@ bool success = TestI2cCommunication();
 
 - [`BaseGpio`](BaseGpio.md) - GPIO interface for I2C pin configuration
 - [`BaseAdc`](BaseAdc.md) - ADC interface following same pattern
-- [`McuI2cBus`](../mcu/McuI2cBus.md) - Hardware I2C implementation
+- [`McuI2c`](../mcu/McuI2c.md) - Hardware I2C implementation
 - [`SfI2cBus`](../thread_safe/SfI2cBus.md) - Thread-safe wrapper
 
 ## 📝 See Also

--- a/docs/api/BasePio.md
+++ b/docs/api/BasePio.md
@@ -436,14 +436,7 @@ if (result != HfPioErr::PIO_SUCCESS) {
 
 ## 🧪 Testing
 
-The BasePio class can be tested using:
-
-```cpp
-#include "tests/PioTests.h"
-
-// Run comprehensive PIO tests
-bool success = TestPioFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 

--- a/docs/api/BasePwm.md
+++ b/docs/api/BasePwm.md
@@ -430,14 +430,7 @@ if (result != HfPwmErr::PWM_SUCCESS) {
 
 ## 🧪 Testing
 
-The BasePwm class can be tested using:
-
-```cpp
-#include "tests/PwmTests.h"
-
-// Run comprehensive PWM tests
-bool success = TestPwmFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -1,16 +1,16 @@
-# 🔄 BaseSpiBus API Documentation
+# 🔄 BaseSpi API Documentation
 
 ## 📋 Overview
 
-The `BaseSpiBus` class is an abstract base class that provides a unified, platform-agnostic interface for SPI (Serial Peripheral Interface) bus communication in the HardFOC system. This class enables high-speed communication with various SPI devices such as ADCs, DACs, sensors, displays, and external controllers.
+The `BaseSpi` class is an abstract base class that provides a unified, platform-agnostic interface for SPI (Serial Peripheral Interface) bus communication in the HardFOC system. This class enables high-speed communication with various SPI devices such as ADCs, DACs, sensors, displays, and external controllers.
 
 ## 🏗️ Class Hierarchy
 
 ```
-BaseSpiBus (Abstract Base Class)
-    ├── McuSpiBus (ESP32 SPI implementation)
-    ├── StmSpiBus (STM32 SPI implementation)
-    ├── BitBangSpiBus (Software SPI implementation)
+BaseSpi (Abstract Base Class)
+    ├── McuSpi (ESP32 SPI implementation)
+    ├── StmSpi (STM32 SPI implementation)
+    ├── BitBangSpi (Software SPI implementation)
     └── SfSpiBus (Thread-safe wrapper)
 ```
 
@@ -232,10 +232,10 @@ virtual HfSpiErr ReadRegister(uint8_t device_id, uint8_t reg_addr,
 
 ### Basic SPI Setup and Communication
 ```cpp
-#include "mcu/McuSpiBus.h"
+#include "mcu/McuSpi.h"
 
 // Create SPI instance
-auto spi = McuSpiBus::Create();
+auto spi = McuSpi::Create();
 
 // Configure SPI bus
 SpiBusConfig config;
@@ -438,14 +438,7 @@ BenchmarkTransfer("Write-only 64 bytes", [&]() {
 
 ## 🧪 Testing
 
-The BaseSpiBus class can be tested using:
-
-```cpp
-#include "tests/SpiBusTests.h"
-
-// Run comprehensive SPI tests
-bool success = TestSpiBusFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 
@@ -459,9 +452,9 @@ bool success = TestSpiBusFunctionality();
 
 ## 🔗 Related Classes
 
-- [`BaseI2cBus`](BaseI2cBus.md) - I2C interface following same pattern
+- [`BaseI2c`](BaseI2c.md) - I2C interface following same pattern
 - [`BaseGpio`](BaseGpio.md) - GPIO interface for CS and other control pins
-- [`McuSpiBus`](../mcu/McuSpiBus.md) - ESP32 SPI implementation
+- [`McuSpi`](../mcu/McuSpi.md) - ESP32 SPI implementation
 - [`SfSpiBus`](../thread_safe/SfSpiBus.md) - Thread-safe wrapper
 
 ## 📝 See Also

--- a/docs/api/BaseUart.md
+++ b/docs/api/BaseUart.md
@@ -1,16 +1,16 @@
-# 📡 BaseUartDriver API Documentation
+# 📡 BaseUart API Documentation
 
 ## 📋 Overview
 
-The `BaseUartDriver` class is an abstract base class that provides a unified, platform-agnostic interface for UART (Universal Asynchronous Receiver-Transmitter) communication in the HardFOC system. This class enables serial communication with external devices, debugging interfaces, wireless modules, and other UART-based peripherals.
+The `BaseUart` class is an abstract base class that provides a unified, platform-agnostic interface for UART (Universal Asynchronous Receiver-Transmitter) communication in the HardFOC system. This class enables serial communication with external devices, debugging interfaces, wireless modules, and other UART-based peripherals.
 
 ## 🏗️ Class Hierarchy
 
 ```
-BaseUartDriver (Abstract Base Class)
-    ├── McuUartDriver (ESP32 UART implementation)
-    ├── StmUartDriver (STM32 UART implementation)
-    ├── VirtualUartDriver (USB CDC/Virtual COM port)
+BaseUart (Abstract Base Class)
+    ├── McuUart (ESP32 UART implementation)
+    ├── StmUart (STM32 UART implementation)
+    ├── VirtualUart (USB CDC/Virtual COM port)
     └── SfUartDriver (Thread-safe wrapper)
 ```
 
@@ -256,10 +256,10 @@ virtual HfUartErr SetReceiveCallback(UartReceiveCallback callback) noexcept = 0
 
 ### Basic UART Communication
 ```cpp
-#include "mcu/McuUartDriver.h"
+#include "mcu/McuUart.h"
 
 // Create UART instance
-auto uart = McuUartDriver::Create();
+auto uart = McuUart::Create();
 
 // Configure UART for debug console
 UartConfig config;
@@ -535,14 +535,7 @@ if (result != HfUartErr::UART_SUCCESS) {
 
 ## 🧪 Testing
 
-The BaseUartDriver class can be tested using:
-
-```cpp
-#include "tests/UartTests.h"
-
-// Run comprehensive UART tests
-bool success = TestUartFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 
@@ -556,9 +549,9 @@ bool success = TestUartFunctionality();
 
 ## 🔗 Related Classes
 
-- [`BaseI2cBus`](BaseI2cBus.md) - I2C interface for different communication needs
-- [`BaseSpiBus`](BaseSpiBus.md) - SPI interface for high-speed synchronous communication
-- [`McuUartDriver`](../mcu/McuUartDriver.md) - ESP32 UART implementation
+- [`BaseI2c`](BaseI2c.md) - I2C interface for different communication needs
+- [`BaseSpi`](BaseSpi.md) - SPI interface for high-speed synchronous communication
+- [`McuUart`](../mcu/McuUart.md) - ESP32 UART implementation
 - [`SfUartDriver`](../thread_safe/SfUartDriver.md) - Thread-safe wrapper
 
 ## 📝 See Also

--- a/docs/examples/basic-i2c.md
+++ b/docs/examples/basic-i2c.md
@@ -8,9 +8,9 @@ Communicate with a simple I2C temperature sensor.
 
 ## 🚀 Code
 ```cpp
-#include "McuI2cBus.h"
+#include "McuI2c.h"
 
-McuI2cBus i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
+McuI2c i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
 
 void app_main() {
     i2c.Open();

--- a/docs/guides/DeveloperGuide.md
+++ b/docs/guides/DeveloperGuide.md
@@ -143,7 +143,7 @@ auto gpio_impl = std::make_shared<McuDigitalGpio>(2);
 SfGpio safe_gpio(gpio_impl);
 
 // Safe to call from multiple threads
-safe_gpio.setPinLevel(2, HF_GPIO_LEVEL_HIGH);
+safe_gpio.digitalWrite(2, true);
 ```
 
 **When to use:** Multi-threaded applications, FreeRTOS tasks.
@@ -214,11 +214,11 @@ public:
     }
     
     void TurnOn() {
-        led_gpio_->setPinLevel(pin_, HF_GPIO_LEVEL_HIGH);
+        led_gpio_->digitalWrite(pin_, true);
     }
-    
+
     void TurnOff() {
-        led_gpio_->setPinLevel(pin_, HF_GPIO_LEVEL_LOW);
+        led_gpio_->digitalWrite(pin_, false);
     }
     
     void Blink(int duration_ms) {
@@ -470,7 +470,7 @@ fast_gpio.SetActive();     // ~1µs
 
 // Slower: Thread-safe wrapper
 SfGpio safe_gpio(gpio_impl);
-safe_gpio.setPinLevel(2, HF_GPIO_LEVEL_HIGH); // ~3µs (includes mutex)
+safe_gpio.digitalWrite(2, true); // ~3µs (includes mutex)
 ```
 
 ### 3. Memory Usage
@@ -691,8 +691,8 @@ void BenchmarkGpioOperations() {
     
     start = esp_timer_get_time();
     for (int i = 0; i < 1000; ++i) {
-        safe_gpio->setPinLevel(3, HF_GPIO_LEVEL_HIGH);
-        safe_gpio->setPinLevel(3, HF_GPIO_LEVEL_LOW);
+        safe_gpio->digitalWrite(3, true);
+        safe_gpio->digitalWrite(3, false);
     }
     end = esp_timer_get_time();
     

--- a/docs/guides/can-guide.md
+++ b/docs/guides/can-guide.md
@@ -44,10 +44,9 @@ For multi-threaded systems use `SfCan` which protects all operations with a mute
 
 ```cpp
 #include "SfCan.h"
-#include <mutex>
+#include "McuCan.h"
 
-std::mutex can_mutex;
-SfCan safe_can(HF_CAN_PORT_0, 500000, can_mutex);
+SfCan safe_can(std::make_unique<McuCan>(0, 500000));
 ```
 
 ## Tips

--- a/docs/guides/gpio-guide.md
+++ b/docs/guides/gpio-guide.md
@@ -38,10 +38,8 @@ Interrupt callbacks run in an ISR context, so keep them short.
 
 ```cpp
 #include "SfGpio.h"
-#include <mutex>
 
-std::mutex gpio_mutex;
-SfGpio safe_led(std::make_shared<McuDigitalGpio>(HF_GPIO_NUM_2), gpio_mutex);
+SfGpio safe_led(std::make_shared<McuDigitalGpio>(HF_GPIO_NUM_2));
 ```
 
 ## Best Practices

--- a/docs/guides/i2c-guide.md
+++ b/docs/guides/i2c-guide.md
@@ -5,9 +5,9 @@ The I2C bus wrapper simplifies communication with sensors and peripheral chips.
 ## Initialization
 
 ```cpp
-#include "McuI2cBus.h"
+#include "McuI2c.h"
 
-McuI2cBus i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
+McuI2c i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
 i2c.Open();
 ```
 
@@ -40,10 +40,9 @@ Wrap the instance with `SfI2cBus` when shared across tasks.
 
 ```cpp
 #include "SfI2cBus.h"
-#include <mutex>
 
-std::mutex i2c_mutex;
-SfI2cBus safe_i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000, i2c_mutex);
+I2cBusConfig cfg{/*params*/};
+SfI2cBus safe_i2c(cfg);
 ```
 
 Refer to the [Porting Guide](porting-guide.md) for implementing a new I2C backend.

--- a/docs/guides/spi-guide.md
+++ b/docs/guides/spi-guide.md
@@ -5,9 +5,9 @@ The SPI bus wrapper supports full-duplex transfers with configurable modes.
 ## Configuration
 
 ```cpp
-#include "McuSpiBus.h"
+#include "McuSpi.h"
 
-McuSpiBus spi(HF_SPI_HOST_1);
+McuSpi spi(HF_SPI_HOST_1);
 spi.Open(1000000, HF_SPI_MODE_0); // 1 MHz, mode 0
 ```
 

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -1,31 +1,24 @@
 # 🧪 Testing Guide
 
-Unit tests validate the correctness of each driver and utility class. Follow these instructions to build and execute the tests.
+This project currently does not include unit tests. The instructions below are kept for reference in case a future release adds them.
 
 ## Building
 
 ```bash
-cd tests
-mkdir build && cd build
-cmake ..
-make
+# (Tests directory not present in this repository)
 ```
 
 Set up your toolchain as described in the README. The CMake project will compile mock implementations for host-based testing.
 
 ## Running
 
-```bash
-./test_runner
-```
-
-The test runner outputs a summary of passed and failed cases.
+Test binaries are not provided. When tests become available, this section will describe how to execute them.
 
 ## Writing Tests
 
 - Use the provided mock classes for hardware independent verification.
 - Keep tests deterministic and free of timing dependencies.
-- Group related tests into separate files under `tests/`.
+- Group related tests into separate files when a testing framework is added.
 
 See the existing tests for examples of mocking and expectation setup.
 

--- a/docs/guides/thread-safety.md
+++ b/docs/guides/thread-safety.md
@@ -6,14 +6,12 @@ Multi-threaded applications must coordinate access to hardware. The wrapper prov
 
 ```cpp
 #include "SfGpio.h"
-#include <mutex>
 
-std::mutex gpio_mutex;
 auto base = std::make_shared<McuDigitalGpio>(HF_GPIO_NUM_2);
-SfGpio safe_gpio(base, gpio_mutex);
+SfGpio safe_gpio(base); // SfGpio creates its own FreeRTOS mutex
 ```
 
-All member functions of `SfGpio` automatically acquire the provided mutex before delegating to `McuDigitalGpio`.
+All member functions of `SfGpio` automatically acquire an internal mutex before delegating to `McuDigitalGpio`.
 
 ## RAII Helpers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ The **HardFOC Internal Interface Wrapper** provides a comprehensive, platform-ag
 |-----------|------------|-------------------|---------------------|
 | 🔌 **GPIO** | `BaseGpio` | `McuDigitalGpio` | `SfGpio` |
 | 📊 **ADC** | `BaseAdc` | `McuAdc` | `SfAdc` |
-| 🔄 **I2C** | `BaseI2cBus` | `McuI2cBus` | `SfI2cBus` |
-| ⚡ **SPI** | `BaseSpiBus` | `McuSpiBus` | `SfSpiBus` |
-| 📡 **UART** | `BaseUartDriver` | `McuUartDriver` | `SfUartDriver` |
+| 🔄 **I2C** | `BaseI2c` | `McuI2c` | `SfI2cBus` |
+| ⚡ **SPI** | `BaseSpi` | `McuSpi` | `SfSpiBus` |
+| 📡 **UART** | `BaseUart` | `McuUart` | `SfUartDriver` |
 | 🚗 **CAN** | `BaseCan` | `McuCan` | `SfCan` |
 | 🎛️ **PWM** | `BasePwm` | `McuPwm` | `SfPwm` |
 | 📻 **PIO** | `BasePio` | `McuPio` | - |
@@ -77,16 +77,16 @@ graph TB
     subgraph "🏛️ Abstract Base Layer"
         G[BaseGpio]
         H[BaseAdc] 
-        I[BaseI2cBus]
-        J[BaseSpiBus]
+        I[BaseI2c]
+        J[BaseSpi]
         K[BaseCan]
     end
     
     subgraph "⚙️ MCU Implementation Layer"
         L[McuDigitalGpio]
         M[McuAdc]
-        N[McuI2cBus]
-        O[McuSpiBus]
+        N[McuI2c]
+        O[McuSpi]
         P[McuCan]
     end
     
@@ -137,9 +137,9 @@ graph TB
 |-------|-------------|--------------|
 | [`BaseGpio`](api/BaseGpio.md) | 🔌 GPIO abstraction | Dynamic mode switching, pull resistors, interrupts |
 | [`BaseAdc`](api/BaseAdc.md) | 📊 ADC abstraction | Multi-channel, calibration, voltage conversion |
-| [`BaseI2cBus`](api/BaseI2cBus.md) | 🔄 I2C communication | Master mode, device scanning, error recovery |
-| [`BaseSpiBus`](api/BaseSpiBus.md) | ⚡ SPI communication | Full-duplex, configurable modes, DMA support |
-| [`BaseUartDriver`](api/BaseUartDriver.md) | 📡 UART communication | Async I/O, flow control, configurable parameters |
+| [`BaseI2c`](api/BaseI2c.md) | 🔄 I2C communication | Master mode, device scanning, error recovery |
+| [`BaseSpi`](api/BaseSpi.md) | ⚡ SPI communication | Full-duplex, configurable modes, DMA support |
+| [`BaseUart`](api/BaseUart.md) | 📡 UART communication | Async I/O, flow control, configurable parameters |
 | [`BaseCan`](api/BaseCan.md) | 🚗 CAN bus communication | Standard/Extended frames, filtering, error handling |
 | [`BasePwm`](api/BasePwm.md) | 🎛️ PWM generation | Multi-channel, frequency control, duty cycle |
 | [`BasePio`](api/BasePio.md) | 📻 Programmable I/O | Custom protocols, precise timing, hardware encoding |
@@ -150,9 +150,9 @@ graph TB
 |-------|-------------|------------------|
 | [`McuDigitalGpio`](api/McuDigitalGpio.md) | 🔌 ESP32-C6 GPIO | Native GPIO pins with validation |
 | [`McuAdc`](api/McuAdc.md) | 📊 ESP32-C6 ADC | ADC1/ADC2 with calibration |
-| [`McuI2cBus`](api/McuI2cBus.md) | 🔄 ESP32-C6 I2C | Hardware I2C controller |
-| [`McuSpiBus`](api/McuSpiBus.md) | ⚡ ESP32-C6 SPI | SPI2/SPI3 with DMA support |
-| [`McuUartDriver`](api/McuUartDriver.md) | 📡 ESP32-C6 UART | Hardware UART with DMA |
+| [`McuI2c`](api/McuI2c.md) | 🔄 ESP32-C6 I2C | Hardware I2C controller |
+| [`McuSpi`](api/McuSpi.md) | ⚡ ESP32-C6 SPI | SPI2/SPI3 with DMA support |
+| [`McuUart`](api/McuUart.md) | 📡 ESP32-C6 UART | Hardware UART with DMA |
 | [`McuCan`](api/McuCan.md) | 🚗 ESP32-C6 TWAI | TWAI controller integration |
 | [`McuPwm`](api/McuPwm.md) | 🎛️ ESP32-C6 LEDC | LEDC peripheral wrapper |
 | [`McuPio`](api/McuPio.md) | 📻 ESP32-C6 RMT | RMT-based programmable I/O |
@@ -291,19 +291,13 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 # Build the project
 idf.py build
 
-# Run tests
+# Flash the firmware
 idf.py -p /dev/ttyUSB0 flash monitor
 ```
 
 ### 🧪 **Testing**
 
-```bash
-# Run unit tests
-cd tests
-mkdir build && cd build
-cmake .. && make
-./test_runner
-```
+Unit tests are not included in this repository.
 
 ### 📊 **Documentation Generation**
 


### PR DESCRIPTION
## Summary
- rename BaseI2cBus/SpiBus/UartDriver docs to match new BaseI2c/BaseSpi/BaseUart APIs
- update index architecture and tables with new class names
- adjust guides and examples for McuI2c/McuSpi usage
- update component map to reference new headers
