### PR TITLE
Fix README and clang format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ This component provides a truly platform-agnostic hardware abstraction layer. Al
 - **No Conditional Compilation**: Interface classes are clean and portable
 - **Layered CAN Stack**: CanBus → FlexCan → SfCan with proper abstraction
 - **Legacy Compatibility**: Preserved useful utility functions like `IsActiveHigh()`
-- **Thread-Safe Variants**: Built-in thread safety using standard C++ mutexes
+- **Thread-Safe Variants**: Built-in thread safety. Most wrappers use `std::mutex`, while `SfGpio` manages its own FreeRTOS semaphore internally.
 
 Each abstraction is intentionally compact and header-focused where possible. Create an object, call `Open()` or `Start()` and off you go. All the platform-specific ceremony is performed behind the scenes so your code stays compact and portable between MCU families.
 
 
 ### Interface Classes with Legacy Support
 - **GPIO**: `BaseGpio`, `DigitalInput`, `DigitalOutput`, `DigitalGpio` with legacy helpers like `IsActiveHigh()`
-- **Communication**: `I2cBus`, `SpiBus`, `UartDriver` with convenience methods like `WriteByte()`, `ReadRegister()`
+- **Communication**: `McuI2c`, `McuSpi`, `McuUart` with convenience methods like `WriteByte()`, `ReadRegister()`
 - **CAN Stack**: `CanBus` (platform-agnostic) → `FlexCan` (compatibility) → `SfCan` (thread-safe)
 - **ADC**: `McuAdc` with legacy functions like `ReadVoltage()`, `ReadAveraged()`
 - **PWM**: `PwmOutput` with utilities like `SetDutyPercent()`, `GenerateSquareWave()`
-- **Thread-Safe Variants**: `SfI2cBus`, `SfSpiBus`, `SfUartDriver`, `SfCan` using standard C++ mutexes
+- **Thread-Safe Variants**: `SfI2cBus`, `SfSpiBus`, `SfUartDriver`, `SfCan` use `std::mutex`; `SfGpio` uses an internal FreeRTOS semaphore
 - **Timers**: `PeriodicTimer` with platform-agnostic callback support
 - **Storage**: `NvsStorage` for non-volatile key-value storage
 
@@ -91,9 +91,9 @@ void app_main() {
 
 ### I2C example
 ```cpp
-#include "I2cBus.h"
+#include "McuI2c.h"
 
-I2cBus i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
+McuI2c i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
 
 void app_main() {
     i2c.Open();
@@ -110,9 +110,6 @@ void app_main() {
 ### SfUartDriver example
 ```cpp
 #include "SfUartDriver.h"
-#include <mutex>
-
-std::mutex uart_mutex;
 hf_uart_config_t cfg = {
     .baud_rate = 115200,
     .data_bits = HF_UART_DATA_8_BITS,
@@ -121,7 +118,7 @@ hf_uart_config_t cfg = {
     .flow_ctrl = HF_UART_HW_FLOWCTRL_DISABLE
 };
 
-SfUartDriver serial(HF_UART_NUM_1, cfg, HF_GPIO_NUM_1, HF_GPIO_NUM_3, uart_mutex);
+SfUartDriver serial(HF_UART_NUM_1, cfg, HF_GPIO_NUM_1, HF_GPIO_NUM_3);
 
 void app_main() {
     serial.Open();
@@ -132,10 +129,9 @@ void app_main() {
 ### Thread-Safe CAN example
 ```cpp
 #include "SfCan.h"
-#include <mutex>
+#include "McuCan.h"
 
-std::mutex can_mutex;
-SfCan can(0, 500000, can_mutex);
+SfCan can(std::make_unique<McuCan>(0, 500000));
 
 void app_main() {
     can.Open();
@@ -191,17 +187,16 @@ void app_main() {
     hf_u32_t avg = adc.ReadAveraged(10);
 }
 ```
-### Building & Testing
+### Building
 
-Follow these steps to build the library and run the unit tests:
+Follow these steps to build the library:
 
 ```bash
 $IDF_PATH/export.sh
-cd tests
-mkdir build && cd build
-cmake .. && make
-./test_runner
+idf.py build
 ```
+
+Unit tests are not included in this repository.
 
 
 ### License

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering a contribution to the HardFOC Internal Interface Wrapp
 
 1. Install **ESP-IDF v5.5+** and export the environment using `source $IDF_PATH/export.sh`.
 2. Clone this repository and initialize submodules if present.
-3. Build the tests: `cd tests && mkdir build && cd build && cmake .. && make`.
+3. (Optional) If you add tests, build them in a `tests` directory with CMake.
 
 ## Coding Style
 
@@ -18,7 +18,7 @@ Thank you for considering a contribution to the HardFOC Internal Interface Wrapp
 
 1. Fork the repository and create a feature branch.
 2. Ensure `scripts/check_docs.py docs/index.md` reports no broken links.
-3. Run all unit tests and fix any failures.
+3. If tests are added, run them and fix any failures.
 4. Open a pull request describing your changes.
 
 We appreciate improvements to documentation, bug fixes, and new platform implementations.

--- a/docs/ComponentMap.md
+++ b/docs/ComponentMap.md
@@ -21,16 +21,16 @@ This document lists the main header and source files in the project and provides
 | [`BaseAdc.h`](../include/base/BaseAdc.h) | *(header only)* | [BaseAdc](api/BaseAdc.md) |
 | [`BaseCan.h`](../include/base/BaseCan.h) | *(header only)* | [BaseCan](api/BaseCan.md) |
 | [`BaseGpio.h`](../include/base/BaseGpio.h) | *(header only)* | [BaseGpio](api/BaseGpio.md) |
-| [`BaseI2cBus.h`](../include/base/BaseI2cBus.h) | *(header only)* | [BaseI2cBus](api/BaseI2cBus.md) |
+| [`BaseI2c.h`](../include/base/BaseI2c.h) | *(header only)* | [BaseI2c](api/BaseI2c.md) |
 | [`BasePio.h`](../include/base/BasePio.h) | *(header only)* | [BasePio](api/BasePio.md) |
 | [`BasePwm.h`](../include/base/BasePwm.h) | *(header only)* | [BasePwm](api/BasePwm.md) |
-| [`BaseSpiBus.h`](../include/base/BaseSpiBus.h) | *(header only)* | [BaseSpiBus](api/BaseSpiBus.md) |
-| [`BaseUartDriver.h`](../include/base/BaseUartDriver.h) | *(header only)* | [BaseUartDriver](api/BaseUartDriver.md) |
+| [`BaseSpi.h`](../include/base/BaseSpi.h) | *(header only)* | [BaseSpi](api/BaseSpi.md) |
+| [`BaseUart.h`](../include/base/BaseUart.h) | *(header only)* | [BaseUart](api/BaseUart.md) |
 | [`McuDigitalGpio.h`](../include/mcu/McuDigitalGpio.h) | [`src/mcu/McuDigitalGpio.cpp`](../src/mcu/McuDigitalGpio.cpp) | [McuDigitalGpio](api/McuDigitalGpio.md) |
 | [`McuAdc.h`](../include/mcu/McuAdc.h) | [`src/mcu/McuAdc.cpp`](../src/mcu/McuAdc.cpp) | [McuAdc](api/McuAdc.md) |
-| [`McuI2cBus.h`](../include/mcu/McuI2cBus.h) | [`src/mcu/McuI2cBus.cpp`](../src/mcu/McuI2cBus.cpp) | API pending |
-| [`McuSpiBus.h`](../include/mcu/McuSpiBus.h) | [`src/mcu/McuSpiBus.cpp`](../src/mcu/McuSpiBus.cpp) | API pending |
-| [`McuUartDriver.h`](../include/mcu/McuUartDriver.h) | [`src/mcu/McuUartDriver.cpp`](../src/mcu/McuUartDriver.cpp) | API pending |
+| [`McuI2c.h`](../include/mcu/McuI2c.h) | [`src/mcu/McuI2c.cpp`](../src/mcu/McuI2c.cpp) | API pending |
+| [`McuSpi.h`](../include/mcu/McuSpi.h) | [`src/mcu/McuSpi.cpp`](../src/mcu/McuSpi.cpp) | API pending |
+| [`McuUart.h`](../include/mcu/McuUart.h) | [`src/mcu/McuUart.cpp`](../src/mcu/McuUart.cpp) | API pending |
 | [`McuCan.h`](../include/mcu/McuCan.h) | [`src/mcu/McuCan.cpp`](../src/mcu/McuCan.cpp) | API pending |
 | [`McuPwm.h`](../include/mcu/McuPwm.h) | [`src/mcu/McuPwm.cpp`](../src/mcu/McuPwm.cpp) | API pending |
 | [`McuPio.h`](../include/mcu/McuPio.h) | [`src/mcu/McuPio.cpp`](../src/mcu/McuPio.cpp) | API pending |

--- a/docs/api/BaseAdc.md
+++ b/docs/api/BaseAdc.md
@@ -568,7 +568,7 @@ public:
 
 ### ✅ **Unit Test Coverage**
 
-The BaseAdc implementation includes comprehensive unit tests:
+Unit tests are not provided in this repository.
 
 ```cpp
 // Test initialization

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -286,14 +286,7 @@ if (!can->SendMessage(msg)) {
 
 ## 🧪 Testing
 
-The BaseCan class can be tested using:
-
-```cpp
-#include "tests/CommBusTests.h"
-
-// Run comprehensive CAN tests
-bool success = TestCanCommunication();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 

--- a/docs/api/BaseGpio.md
+++ b/docs/api/BaseGpio.md
@@ -550,7 +550,7 @@ void bidirectional_communication() {
 
 ### ✅ **Unit Test Coverage**
 
-The BaseGpio implementation includes comprehensive unit tests:
+Unit tests are not provided in this repository.
 
 ```cpp
 // Test initialization

--- a/docs/api/BaseI2c.md
+++ b/docs/api/BaseI2c.md
@@ -1,14 +1,14 @@
-# 🔗 BaseI2cBus API Documentation
+# 🔗 BaseI2c API Documentation
 
 ## 📋 Overview
 
-The `BaseI2cBus` class is an abstract base class that provides a unified, platform-agnostic interface for I2C (Inter-Integrated Circuit) bus communication in the HardFOC system. This class enables communication with various I2C devices such as sensors, EEPROMs, DACs, and other peripherals through a consistent API.
+The `BaseI2c` class is an abstract base class that provides a unified, platform-agnostic interface for I2C (Inter-Integrated Circuit) bus communication in the HardFOC system. This class enables communication with various I2C devices such as sensors, EEPROMs, DACs, and other peripherals through a consistent API.
 
 ## 🏗️ Class Hierarchy
 
 ```
-BaseI2cBus (Abstract Base Class)
-    ├── McuI2cBus (ESP32/STM32 hardware I2C)
+BaseI2c (Abstract Base Class)
+    ├── McuI2c (ESP32/STM32 hardware I2C)
     ├── BitBangI2c (Software I2C implementation)
     └── SfI2cBus (Thread-safe wrapper)
 ```
@@ -195,7 +195,7 @@ std::vector<uint8_t> ScanBus(uint32_t timeout_ms = 0) noexcept
 
 ### Basic I2C Communication
 ```cpp
-#include "mcu/McuI2cBus.h"
+#include "mcu/McuI2c.h"
 
 // Configure I2C bus
 I2cBusConfig config;
@@ -205,7 +205,7 @@ config.scl_pin = 22;
 config.clock_speed_hz = 400000;  // 400kHz Fast Mode
 
 // Create I2C instance
-auto i2c = std::make_unique<McuI2cBus>(config);
+auto i2c = std::make_unique<McuI2c>(config);
 
 // Initialize
 if (!i2c->EnsureInitialized()) {
@@ -325,19 +325,12 @@ custom_config.timeout_ms = 2000;           // 2s timeout for slow devices
 custom_config.tx_buffer_size = 128;        // Enable buffering
 custom_config.rx_buffer_size = 128;
 
-auto i2c_slow = std::make_unique<McuI2cBus>(custom_config);
+auto i2c_slow = std::make_unique<McuI2c>(custom_config);
 ```
 
 ## 🧪 Testing
 
-The BaseI2cBus class can be tested using:
-
-```cpp
-#include "tests/CommBusTests.h"
-
-// Run comprehensive I2C tests
-bool success = TestI2cCommunication();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 
@@ -352,7 +345,7 @@ bool success = TestI2cCommunication();
 
 - [`BaseGpio`](BaseGpio.md) - GPIO interface for I2C pin configuration
 - [`BaseAdc`](BaseAdc.md) - ADC interface following same pattern
-- [`McuI2cBus`](../mcu/McuI2cBus.md) - Hardware I2C implementation
+- [`McuI2c`](../mcu/McuI2c.md) - Hardware I2C implementation
 - [`SfI2cBus`](../thread_safe/SfI2cBus.md) - Thread-safe wrapper
 
 ## 📝 See Also

--- a/docs/api/BasePio.md
+++ b/docs/api/BasePio.md
@@ -436,14 +436,7 @@ if (result != HfPioErr::PIO_SUCCESS) {
 
 ## 🧪 Testing
 
-The BasePio class can be tested using:
-
-```cpp
-#include "tests/PioTests.h"
-
-// Run comprehensive PIO tests
-bool success = TestPioFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 

--- a/docs/api/BasePwm.md
+++ b/docs/api/BasePwm.md
@@ -430,14 +430,7 @@ if (result != HfPwmErr::PWM_SUCCESS) {
 
 ## 🧪 Testing
 
-The BasePwm class can be tested using:
-
-```cpp
-#include "tests/PwmTests.h"
-
-// Run comprehensive PWM tests
-bool success = TestPwmFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -1,16 +1,16 @@
-# 🔄 BaseSpiBus API Documentation
+# 🔄 BaseSpi API Documentation
 
 ## 📋 Overview
 
-The `BaseSpiBus` class is an abstract base class that provides a unified, platform-agnostic interface for SPI (Serial Peripheral Interface) bus communication in the HardFOC system. This class enables high-speed communication with various SPI devices such as ADCs, DACs, sensors, displays, and external controllers.
+The `BaseSpi` class is an abstract base class that provides a unified, platform-agnostic interface for SPI (Serial Peripheral Interface) bus communication in the HardFOC system. This class enables high-speed communication with various SPI devices such as ADCs, DACs, sensors, displays, and external controllers.
 
 ## 🏗️ Class Hierarchy
 
 ```
-BaseSpiBus (Abstract Base Class)
-    ├── McuSpiBus (ESP32 SPI implementation)
-    ├── StmSpiBus (STM32 SPI implementation)
-    ├── BitBangSpiBus (Software SPI implementation)
+BaseSpi (Abstract Base Class)
+    ├── McuSpi (ESP32 SPI implementation)
+    ├── StmSpi (STM32 SPI implementation)
+    ├── BitBangSpi (Software SPI implementation)
     └── SfSpiBus (Thread-safe wrapper)
 ```
 
@@ -232,10 +232,10 @@ virtual HfSpiErr ReadRegister(uint8_t device_id, uint8_t reg_addr,
 
 ### Basic SPI Setup and Communication
 ```cpp
-#include "mcu/McuSpiBus.h"
+#include "mcu/McuSpi.h"
 
 // Create SPI instance
-auto spi = McuSpiBus::Create();
+auto spi = McuSpi::Create();
 
 // Configure SPI bus
 SpiBusConfig config;
@@ -438,14 +438,7 @@ BenchmarkTransfer("Write-only 64 bytes", [&]() {
 
 ## 🧪 Testing
 
-The BaseSpiBus class can be tested using:
-
-```cpp
-#include "tests/SpiBusTests.h"
-
-// Run comprehensive SPI tests
-bool success = TestSpiBusFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 
@@ -459,9 +452,9 @@ bool success = TestSpiBusFunctionality();
 
 ## 🔗 Related Classes
 
-- [`BaseI2cBus`](BaseI2cBus.md) - I2C interface following same pattern
+- [`BaseI2c`](BaseI2c.md) - I2C interface following same pattern
 - [`BaseGpio`](BaseGpio.md) - GPIO interface for CS and other control pins
-- [`McuSpiBus`](../mcu/McuSpiBus.md) - ESP32 SPI implementation
+- [`McuSpi`](../mcu/McuSpi.md) - ESP32 SPI implementation
 - [`SfSpiBus`](../thread_safe/SfSpiBus.md) - Thread-safe wrapper
 
 ## 📝 See Also

--- a/docs/api/BaseUart.md
+++ b/docs/api/BaseUart.md
@@ -1,16 +1,16 @@
-# 📡 BaseUartDriver API Documentation
+# 📡 BaseUart API Documentation
 
 ## 📋 Overview
 
-The `BaseUartDriver` class is an abstract base class that provides a unified, platform-agnostic interface for UART (Universal Asynchronous Receiver-Transmitter) communication in the HardFOC system. This class enables serial communication with external devices, debugging interfaces, wireless modules, and other UART-based peripherals.
+The `BaseUart` class is an abstract base class that provides a unified, platform-agnostic interface for UART (Universal Asynchronous Receiver-Transmitter) communication in the HardFOC system. This class enables serial communication with external devices, debugging interfaces, wireless modules, and other UART-based peripherals.
 
 ## 🏗️ Class Hierarchy
 
 ```
-BaseUartDriver (Abstract Base Class)
-    ├── McuUartDriver (ESP32 UART implementation)
-    ├── StmUartDriver (STM32 UART implementation)
-    ├── VirtualUartDriver (USB CDC/Virtual COM port)
+BaseUart (Abstract Base Class)
+    ├── McuUart (ESP32 UART implementation)
+    ├── StmUart (STM32 UART implementation)
+    ├── VirtualUart (USB CDC/Virtual COM port)
     └── SfUartDriver (Thread-safe wrapper)
 ```
 
@@ -256,10 +256,10 @@ virtual HfUartErr SetReceiveCallback(UartReceiveCallback callback) noexcept = 0
 
 ### Basic UART Communication
 ```cpp
-#include "mcu/McuUartDriver.h"
+#include "mcu/McuUart.h"
 
 // Create UART instance
-auto uart = McuUartDriver::Create();
+auto uart = McuUart::Create();
 
 // Configure UART for debug console
 UartConfig config;
@@ -535,14 +535,7 @@ if (result != HfUartErr::UART_SUCCESS) {
 
 ## 🧪 Testing
 
-The BaseUartDriver class can be tested using:
-
-```cpp
-#include "tests/UartTests.h"
-
-// Run comprehensive UART tests
-bool success = TestUartFunctionality();
-```
+Unit tests are not provided in this repository.
 
 ## ⚠️ Important Notes
 
@@ -556,9 +549,9 @@ bool success = TestUartFunctionality();
 
 ## 🔗 Related Classes
 
-- [`BaseI2cBus`](BaseI2cBus.md) - I2C interface for different communication needs
-- [`BaseSpiBus`](BaseSpiBus.md) - SPI interface for high-speed synchronous communication
-- [`McuUartDriver`](../mcu/McuUartDriver.md) - ESP32 UART implementation
+- [`BaseI2c`](BaseI2c.md) - I2C interface for different communication needs
+- [`BaseSpi`](BaseSpi.md) - SPI interface for high-speed synchronous communication
+- [`McuUart`](../mcu/McuUart.md) - ESP32 UART implementation
 - [`SfUartDriver`](../thread_safe/SfUartDriver.md) - Thread-safe wrapper
 
 ## 📝 See Also

--- a/docs/examples/basic-i2c.md
+++ b/docs/examples/basic-i2c.md
@@ -8,9 +8,9 @@ Communicate with a simple I2C temperature sensor.
 
 ## 🚀 Code
 ```cpp
-#include "McuI2cBus.h"
+#include "McuI2c.h"
 
-McuI2cBus i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
+McuI2c i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
 
 void app_main() {
     i2c.Open();

--- a/docs/guides/DeveloperGuide.md
+++ b/docs/guides/DeveloperGuide.md
@@ -143,7 +143,7 @@ auto gpio_impl = std::make_shared<McuDigitalGpio>(2);
 SfGpio safe_gpio(gpio_impl);
 
 // Safe to call from multiple threads
-safe_gpio.setPinLevel(2, HF_GPIO_LEVEL_HIGH);
+safe_gpio.digitalWrite(2, true);
 ```
 
 **When to use:** Multi-threaded applications, FreeRTOS tasks.
@@ -214,11 +214,11 @@ public:
     }
     
     void TurnOn() {
-        led_gpio_->setPinLevel(pin_, HF_GPIO_LEVEL_HIGH);
+        led_gpio_->digitalWrite(pin_, true);
     }
-    
+
     void TurnOff() {
-        led_gpio_->setPinLevel(pin_, HF_GPIO_LEVEL_LOW);
+        led_gpio_->digitalWrite(pin_, false);
     }
     
     void Blink(int duration_ms) {
@@ -470,7 +470,7 @@ fast_gpio.SetActive();     // ~1µs
 
 // Slower: Thread-safe wrapper
 SfGpio safe_gpio(gpio_impl);
-safe_gpio.setPinLevel(2, HF_GPIO_LEVEL_HIGH); // ~3µs (includes mutex)
+safe_gpio.digitalWrite(2, true); // ~3µs (includes mutex)
 ```
 
 ### 3. Memory Usage
@@ -691,8 +691,8 @@ void BenchmarkGpioOperations() {
     
     start = esp_timer_get_time();
     for (int i = 0; i < 1000; ++i) {
-        safe_gpio->setPinLevel(3, HF_GPIO_LEVEL_HIGH);
-        safe_gpio->setPinLevel(3, HF_GPIO_LEVEL_LOW);
+        safe_gpio->digitalWrite(3, true);
+        safe_gpio->digitalWrite(3, false);
     }
     end = esp_timer_get_time();
     

--- a/docs/guides/can-guide.md
+++ b/docs/guides/can-guide.md
@@ -44,10 +44,9 @@ For multi-threaded systems use `SfCan` which protects all operations with a mute
 
 ```cpp
 #include "SfCan.h"
-#include <mutex>
+#include "McuCan.h"
 
-std::mutex can_mutex;
-SfCan safe_can(HF_CAN_PORT_0, 500000, can_mutex);
+SfCan safe_can(std::make_unique<McuCan>(0, 500000));
 ```
 
 ## Tips

--- a/docs/guides/gpio-guide.md
+++ b/docs/guides/gpio-guide.md
@@ -38,10 +38,8 @@ Interrupt callbacks run in an ISR context, so keep them short.
 
 ```cpp
 #include "SfGpio.h"
-#include <mutex>
 
-std::mutex gpio_mutex;
-SfGpio safe_led(std::make_shared<McuDigitalGpio>(HF_GPIO_NUM_2), gpio_mutex);
+SfGpio safe_led(std::make_shared<McuDigitalGpio>(HF_GPIO_NUM_2));
 ```
 
 ## Best Practices

--- a/docs/guides/i2c-guide.md
+++ b/docs/guides/i2c-guide.md
@@ -5,9 +5,9 @@ The I2C bus wrapper simplifies communication with sensors and peripheral chips.
 ## Initialization
 
 ```cpp
-#include "McuI2cBus.h"
+#include "McuI2c.h"
 
-McuI2cBus i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
+McuI2c i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000);
 i2c.Open();
 ```
 
@@ -40,10 +40,9 @@ Wrap the instance with `SfI2cBus` when shared across tasks.
 
 ```cpp
 #include "SfI2cBus.h"
-#include <mutex>
 
-std::mutex i2c_mutex;
-SfI2cBus safe_i2c(HF_I2C_NUM_0, HF_GPIO_NUM_21, HF_GPIO_NUM_22, 400000, i2c_mutex);
+I2cBusConfig cfg{/*params*/};
+SfI2cBus safe_i2c(cfg);
 ```
 
 Refer to the [Porting Guide](porting-guide.md) for implementing a new I2C backend.

--- a/docs/guides/spi-guide.md
+++ b/docs/guides/spi-guide.md
@@ -5,9 +5,9 @@ The SPI bus wrapper supports full-duplex transfers with configurable modes.
 ## Configuration
 
 ```cpp
-#include "McuSpiBus.h"
+#include "McuSpi.h"
 
-McuSpiBus spi(HF_SPI_HOST_1);
+McuSpi spi(HF_SPI_HOST_1);
 spi.Open(1000000, HF_SPI_MODE_0); // 1 MHz, mode 0
 ```
 

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -1,31 +1,24 @@
 # 🧪 Testing Guide
 
-Unit tests validate the correctness of each driver and utility class. Follow these instructions to build and execute the tests.
+This project currently does not include unit tests. The instructions below are kept for reference in case a future release adds them.
 
 ## Building
 
 ```bash
-cd tests
-mkdir build && cd build
-cmake ..
-make
+# (Tests directory not present in this repository)
 ```
 
 Set up your toolchain as described in the README. The CMake project will compile mock implementations for host-based testing.
 
 ## Running
 
-```bash
-./test_runner
-```
-
-The test runner outputs a summary of passed and failed cases.
+Test binaries are not provided. When tests become available, this section will describe how to execute them.
 
 ## Writing Tests
 
 - Use the provided mock classes for hardware independent verification.
 - Keep tests deterministic and free of timing dependencies.
-- Group related tests into separate files under `tests/`.
+- Group related tests into separate files when a testing framework is added.
 
 See the existing tests for examples of mocking and expectation setup.
 

--- a/docs/guides/thread-safety.md
+++ b/docs/guides/thread-safety.md
@@ -6,14 +6,12 @@ Multi-threaded applications must coordinate access to hardware. The wrapper prov
 
 ```cpp
 #include "SfGpio.h"
-#include <mutex>
 
-std::mutex gpio_mutex;
 auto base = std::make_shared<McuDigitalGpio>(HF_GPIO_NUM_2);
-SfGpio safe_gpio(base, gpio_mutex);
+SfGpio safe_gpio(base); // SfGpio creates its own FreeRTOS mutex
 ```
 
-All member functions of `SfGpio` automatically acquire the provided mutex before delegating to `McuDigitalGpio`.
+All member functions of `SfGpio` automatically acquire an internal mutex before delegating to `McuDigitalGpio`.
 
 ## RAII Helpers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ The **HardFOC Internal Interface Wrapper** provides a comprehensive, platform-ag
 |-----------|------------|-------------------|---------------------|
 | 🔌 **GPIO** | `BaseGpio` | `McuDigitalGpio` | `SfGpio` |
 | 📊 **ADC** | `BaseAdc` | `McuAdc` | `SfAdc` |
-| 🔄 **I2C** | `BaseI2cBus` | `McuI2cBus` | `SfI2cBus` |
-| ⚡ **SPI** | `BaseSpiBus` | `McuSpiBus` | `SfSpiBus` |
-| 📡 **UART** | `BaseUartDriver` | `McuUartDriver` | `SfUartDriver` |
+| 🔄 **I2C** | `BaseI2c` | `McuI2c` | `SfI2cBus` |
+| ⚡ **SPI** | `BaseSpi` | `McuSpi` | `SfSpiBus` |
+| 📡 **UART** | `BaseUart` | `McuUart` | `SfUartDriver` |
 | 🚗 **CAN** | `BaseCan` | `McuCan` | `SfCan` |
 | 🎛️ **PWM** | `BasePwm` | `McuPwm` | `SfPwm` |
 | 📻 **PIO** | `BasePio` | `McuPio` | - |
@@ -77,16 +77,16 @@ graph TB
     subgraph "🏛️ Abstract Base Layer"
         G[BaseGpio]
         H[BaseAdc] 
-        I[BaseI2cBus]
-        J[BaseSpiBus]
+        I[BaseI2c]
+        J[BaseSpi]
         K[BaseCan]
     end
     
     subgraph "⚙️ MCU Implementation Layer"
         L[McuDigitalGpio]
         M[McuAdc]
-        N[McuI2cBus]
-        O[McuSpiBus]
+        N[McuI2c]
+        O[McuSpi]
         P[McuCan]
     end
     
@@ -137,9 +137,9 @@ graph TB
 |-------|-------------|--------------|
 | [`BaseGpio`](api/BaseGpio.md) | 🔌 GPIO abstraction | Dynamic mode switching, pull resistors, interrupts |
 | [`BaseAdc`](api/BaseAdc.md) | 📊 ADC abstraction | Multi-channel, calibration, voltage conversion |
-| [`BaseI2cBus`](api/BaseI2cBus.md) | 🔄 I2C communication | Master mode, device scanning, error recovery |
-| [`BaseSpiBus`](api/BaseSpiBus.md) | ⚡ SPI communication | Full-duplex, configurable modes, DMA support |
-| [`BaseUartDriver`](api/BaseUartDriver.md) | 📡 UART communication | Async I/O, flow control, configurable parameters |
+| [`BaseI2c`](api/BaseI2c.md) | 🔄 I2C communication | Master mode, device scanning, error recovery |
+| [`BaseSpi`](api/BaseSpi.md) | ⚡ SPI communication | Full-duplex, configurable modes, DMA support |
+| [`BaseUart`](api/BaseUart.md) | 📡 UART communication | Async I/O, flow control, configurable parameters |
 | [`BaseCan`](api/BaseCan.md) | 🚗 CAN bus communication | Standard/Extended frames, filtering, error handling |
 | [`BasePwm`](api/BasePwm.md) | 🎛️ PWM generation | Multi-channel, frequency control, duty cycle |
 | [`BasePio`](api/BasePio.md) | 📻 Programmable I/O | Custom protocols, precise timing, hardware encoding |
@@ -150,9 +150,9 @@ graph TB
 |-------|-------------|------------------|
 | [`McuDigitalGpio`](api/McuDigitalGpio.md) | 🔌 ESP32-C6 GPIO | Native GPIO pins with validation |
 | [`McuAdc`](api/McuAdc.md) | 📊 ESP32-C6 ADC | ADC1/ADC2 with calibration |
-| [`McuI2cBus`](api/McuI2cBus.md) | 🔄 ESP32-C6 I2C | Hardware I2C controller |
-| [`McuSpiBus`](api/McuSpiBus.md) | ⚡ ESP32-C6 SPI | SPI2/SPI3 with DMA support |
-| [`McuUartDriver`](api/McuUartDriver.md) | 📡 ESP32-C6 UART | Hardware UART with DMA |
+| [`McuI2c`](api/McuI2c.md) | 🔄 ESP32-C6 I2C | Hardware I2C controller |
+| [`McuSpi`](api/McuSpi.md) | ⚡ ESP32-C6 SPI | SPI2/SPI3 with DMA support |
+| [`McuUart`](api/McuUart.md) | 📡 ESP32-C6 UART | Hardware UART with DMA |
 | [`McuCan`](api/McuCan.md) | 🚗 ESP32-C6 TWAI | TWAI controller integration |
 | [`McuPwm`](api/McuPwm.md) | 🎛️ ESP32-C6 LEDC | LEDC peripheral wrapper |
 | [`McuPio`](api/McuPio.md) | 📻 ESP32-C6 RMT | RMT-based programmable I/O |
@@ -291,19 +291,13 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 # Build the project
 idf.py build
 
-# Run tests
+# Flash the firmware
 idf.py -p /dev/ttyUSB0 flash monitor
 ```
 
 ### 🧪 **Testing**
 
-```bash
-# Run unit tests
-cd tests
-mkdir build && cd build
-cmake .. && make
-./test_runner
-```
+Unit tests are not included in this repository.
 
 ### 📊 **Documentation Generation**
 

--- a/inc/base/BaseAdc.h
+++ b/inc/base/BaseAdc.h
@@ -1,12 +1,12 @@
 /**
  * @file BaseAdc.h
  * @brief Abstract base class for ADC implementations in the HardFOC system
- * 
+ *
  * @details This file contains the declaration of the BaseAdc abstract class,
  *          which provides a common interface and features for all ADC implementations.
  *          ADC derived classes employ lazy initialization - they are initialized
  *          the first time a channel operation is performed.
- * 
+ *
  * @note These functions are not thread or interrupt-safe and should be called
  *       with appropriate synchronization guards if used within an ISR or shared tasks.
  */
@@ -16,8 +16,8 @@
 
 #include "HardwareTypes.h"
 #include <cstdint>
-#include <string_view>
 #include <functional>
+#include <string_view>
 
 //--------------------------------------
 //  HardFOC ADC Error Codes (Table)
@@ -29,62 +29,62 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_ADC_ERR_LIST(X) \
-    /* Success codes */ \
-    X(ADC_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(ADC_ERR_FAILURE, 1, "General failure") \
-    X(ADC_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(ADC_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(ADC_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(ADC_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(ADC_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Channel errors */ \
-    X(ADC_ERR_CHANNEL_NOT_FOUND, 7, "Channel not found") \
-    X(ADC_ERR_CHANNEL_NOT_ENABLED, 8, "Channel not enabled") \
-    X(ADC_ERR_CHANNEL_NOT_CONFIGURED, 9, "Channel not configured") \
-    X(ADC_ERR_CHANNEL_ALREADY_REGISTERED, 10, "Channel already registered") \
-    X(ADC_ERR_CHANNEL_READ_ERR, 11, "Channel read error") \
-    X(ADC_ERR_CHANNEL_WRITE_ERR, 12, "Channel write error") \
-    X(ADC_ERR_INVALID_CHANNEL, 13, "Invalid channel") \
-    X(ADC_ERR_CHANNEL_BUSY, 14, "Channel busy") \
-    /* Sampling errors */ \
-    X(ADC_ERR_INVALID_SAMPLE_COUNT, 15, "Invalid sample count") \
-    X(ADC_ERR_SAMPLE_TIMEOUT, 16, "Sample timeout") \
-    X(ADC_ERR_SAMPLE_OVERFLOW, 17, "Sample overflow") \
-    X(ADC_ERR_SAMPLE_UNDERFLOW, 18, "Sample underflow") \
-    /* Hardware errors */ \
-    X(ADC_ERR_HARDWARE_FAULT, 19, "Hardware fault") \
-    X(ADC_ERR_COMMUNICATION_FAILURE, 20, "Communication failure") \
-    X(ADC_ERR_DEVICE_NOT_RESPONDING, 21, "Device not responding") \
-    X(ADC_ERR_CALIBRATION_FAILURE, 22, "Calibration failure") \
-    X(ADC_ERR_VOLTAGE_OUT_OF_RANGE, 23, "Voltage out of range") \
-    /* Configuration errors */ \
-    X(ADC_ERR_INVALID_CONFIGURATION, 24, "Invalid configuration") \
-    X(ADC_ERR_UNSUPPORTED_OPERATION, 25, "Unsupported operation") \
-    X(ADC_ERR_RESOURCE_BUSY, 26, "Resource busy") \
-    X(ADC_ERR_RESOURCE_UNAVAILABLE, 27, "Resource unavailable") \
-    /* Calibration specific errors */ \
-    X(ADC_ERR_CALIBRATION_NOT_FOUND, 28, "Calibration data not found") \
-    X(ADC_ERR_CALIBRATION_INVALID, 29, "Invalid calibration data") \
-    X(ADC_ERR_CALIBRATION_EXPIRED, 30, "Calibration has expired") \
-    X(ADC_ERR_CALIBRATION_DRIFT, 31, "Calibration drift detected") \
-    X(ADC_ERR_CALIBRATION_POINTS_INSUFFICIENT, 32, "Insufficient calibration points") \
-    X(ADC_ERR_CALIBRATION_POINTS_INVALID, 33, "Invalid calibration points") \
-    X(ADC_ERR_CALIBRATION_LINEARITY_ERROR, 34, "Calibration linearity error") \
-    X(ADC_ERR_CALIBRATION_STORAGE_FAILURE, 35, "Calibration storage failure") \
-    X(ADC_ERR_CALIBRATION_LOAD_FAILURE, 36, "Calibration load failure") \
-    X(ADC_ERR_CALIBRATION_VERIFICATION_FAILED, 37, "Calibration verification failed") \
-    X(ADC_ERR_CALIBRATION_TEMPERATURE_ERROR, 38, "Temperature compensation error") \
-    X(ADC_ERR_CALIBRATION_POLYNOMIAL_ERROR, 39, "Polynomial calibration error") \
-    /* System errors */ \
-    X(ADC_ERR_SYSTEM_ERROR, 40, "System error") \
-    X(ADC_ERR_PERMISSION_DENIED, 41, "Permission denied") \
-    X(ADC_ERR_OPERATION_ABORTED, 42, "Operation aborted")
+#define HF_ADC_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(ADC_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(ADC_ERR_FAILURE, 1, "General failure")                                                         \
+  X(ADC_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(ADC_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(ADC_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(ADC_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(ADC_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Channel errors */                                                                             \
+  X(ADC_ERR_CHANNEL_NOT_FOUND, 7, "Channel not found")                                             \
+  X(ADC_ERR_CHANNEL_NOT_ENABLED, 8, "Channel not enabled")                                         \
+  X(ADC_ERR_CHANNEL_NOT_CONFIGURED, 9, "Channel not configured")                                   \
+  X(ADC_ERR_CHANNEL_ALREADY_REGISTERED, 10, "Channel already registered")                          \
+  X(ADC_ERR_CHANNEL_READ_ERR, 11, "Channel read error")                                            \
+  X(ADC_ERR_CHANNEL_WRITE_ERR, 12, "Channel write error")                                          \
+  X(ADC_ERR_INVALID_CHANNEL, 13, "Invalid channel")                                                \
+  X(ADC_ERR_CHANNEL_BUSY, 14, "Channel busy")                                                      \
+  /* Sampling errors */                                                                            \
+  X(ADC_ERR_INVALID_SAMPLE_COUNT, 15, "Invalid sample count")                                      \
+  X(ADC_ERR_SAMPLE_TIMEOUT, 16, "Sample timeout")                                                  \
+  X(ADC_ERR_SAMPLE_OVERFLOW, 17, "Sample overflow")                                                \
+  X(ADC_ERR_SAMPLE_UNDERFLOW, 18, "Sample underflow")                                              \
+  /* Hardware errors */                                                                            \
+  X(ADC_ERR_HARDWARE_FAULT, 19, "Hardware fault")                                                  \
+  X(ADC_ERR_COMMUNICATION_FAILURE, 20, "Communication failure")                                    \
+  X(ADC_ERR_DEVICE_NOT_RESPONDING, 21, "Device not responding")                                    \
+  X(ADC_ERR_CALIBRATION_FAILURE, 22, "Calibration failure")                                        \
+  X(ADC_ERR_VOLTAGE_OUT_OF_RANGE, 23, "Voltage out of range")                                      \
+  /* Configuration errors */                                                                       \
+  X(ADC_ERR_INVALID_CONFIGURATION, 24, "Invalid configuration")                                    \
+  X(ADC_ERR_UNSUPPORTED_OPERATION, 25, "Unsupported operation")                                    \
+  X(ADC_ERR_RESOURCE_BUSY, 26, "Resource busy")                                                    \
+  X(ADC_ERR_RESOURCE_UNAVAILABLE, 27, "Resource unavailable")                                      \
+  /* Calibration specific errors */                                                                \
+  X(ADC_ERR_CALIBRATION_NOT_FOUND, 28, "Calibration data not found")                               \
+  X(ADC_ERR_CALIBRATION_INVALID, 29, "Invalid calibration data")                                   \
+  X(ADC_ERR_CALIBRATION_EXPIRED, 30, "Calibration has expired")                                    \
+  X(ADC_ERR_CALIBRATION_DRIFT, 31, "Calibration drift detected")                                   \
+  X(ADC_ERR_CALIBRATION_POINTS_INSUFFICIENT, 32, "Insufficient calibration points")                \
+  X(ADC_ERR_CALIBRATION_POINTS_INVALID, 33, "Invalid calibration points")                          \
+  X(ADC_ERR_CALIBRATION_LINEARITY_ERROR, 34, "Calibration linearity error")                        \
+  X(ADC_ERR_CALIBRATION_STORAGE_FAILURE, 35, "Calibration storage failure")                        \
+  X(ADC_ERR_CALIBRATION_LOAD_FAILURE, 36, "Calibration load failure")                              \
+  X(ADC_ERR_CALIBRATION_VERIFICATION_FAILED, 37, "Calibration verification failed")                \
+  X(ADC_ERR_CALIBRATION_TEMPERATURE_ERROR, 38, "Temperature compensation error")                   \
+  X(ADC_ERR_CALIBRATION_POLYNOMIAL_ERROR, 39, "Polynomial calibration error")                      \
+  /* System errors */                                                                              \
+  X(ADC_ERR_SYSTEM_ERROR, 40, "System error")                                                      \
+  X(ADC_ERR_PERMISSION_DENIED, 41, "Permission denied")                                            \
+  X(ADC_ERR_OPERATION_ABORTED, 42, "Operation aborted")
 
 enum class HfAdcErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
-    HF_ADC_ERR_LIST(X)
+  HF_ADC_ERR_LIST(X)
 #undef X
 };
 
@@ -94,15 +94,15 @@ enum class HfAdcErr : uint8_t {
  * @return String view of the error description
  */
 constexpr std::string_view HfAdcErrToString(HfAdcErr err) noexcept {
-    switch (err) {
-#define X(NAME, VALUE, DESC) \
-    case HfAdcErr::NAME: \
-        return DESC;
-        HF_ADC_ERR_LIST(X)
+  switch (err) {
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfAdcErr::NAME:                                                                             \
+    return DESC;
+    HF_ADC_ERR_LIST(X)
 #undef X
-    default:
-        return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 /**
@@ -114,500 +114,468 @@ constexpr std::string_view HfAdcErrToString(HfAdcErr err) noexcept {
  */
 class BaseAdc {
 public:
-    /**
-     * @brief Constructor
-     */
-    BaseAdc() noexcept : initialized_(false) {}
+  /**
+   * @brief Constructor
+   */
+  BaseAdc() noexcept : initialized_(false) {}
 
-    /**
-     * @brief Virtual destructor
-     */
-    virtual ~BaseAdc() noexcept = default;
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~BaseAdc() noexcept = default;
 
-    // Disable copy constructor and assignment operator for safety
-    BaseAdc(const BaseAdc&) = delete;
-    BaseAdc& operator=(const BaseAdc&) = delete;
+  // Disable copy constructor and assignment operator for safety
+  BaseAdc(const BaseAdc &) = delete;
+  BaseAdc &operator=(const BaseAdc &) = delete;
 
-    // Allow move operations
-    BaseAdc(BaseAdc&&) noexcept = default;
-    BaseAdc& operator=(BaseAdc&&) noexcept = default;
+  // Allow move operations
+  BaseAdc(BaseAdc &&) noexcept = default;
+  BaseAdc &operator=(BaseAdc &&) noexcept = default;
 
-    /**
-     * @brief Ensures that the ADC is initialized (lazy initialization).
-     * @return true if the ADC is initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized_) {
-            initialized_ = Initialize();
-        }
-        return initialized_;
+  /**
+   * @brief Ensures that the ADC is initialized (lazy initialization).
+   * @return true if the ADC is initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized_) {
+      initialized_ = Initialize();
+    }
+    return initialized_;
+  }
+
+  /**
+   * @brief Checks if the class is initialized.
+   * @return true if initialized, false otherwise
+   */
+  [[nodiscard]] bool IsInitialized() const noexcept {
+    return initialized_;
+  }
+
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
+  //==============================================//
+
+  /**
+   * @brief Initializes the ADC peripheral (must be implemented by derived classes).
+   * @return True if the initialization is successful, false otherwise.
+   */
+  virtual bool Initialize() noexcept = 0;
+
+  /**
+   * @brief Deinitializes the ADC peripheral.
+   * @return True if deinitialization is successful, false otherwise.
+   */
+  virtual bool Deinitialize() noexcept {
+    initialized_ = false;
+    return true;
+  }
+
+  /**
+   * @brief Get the maximum number of channels supported by this ADC.
+   * @return Maximum channel count
+   */
+  [[nodiscard]] virtual uint8_t GetMaxChannels() const noexcept = 0;
+
+  /**
+   * @brief Check if a specific channel is available.
+   * @param channel_id Channel ID to check
+   * @return true if channel is available, false otherwise
+   */
+  [[nodiscard]] virtual bool IsChannelAvailable(HfChannelId channel_id) const noexcept = 0;
+
+  /**
+   * @brief Read channel voltage.
+   * @param channel_id Channel ID to read from
+   * @param channel_reading_v Reference to store voltage reading
+   * @param numOfSamplesToAvg Number of samples to average (default 1)
+   * @param timeBetweenSamples Time between samples in milliseconds (default 0)
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr ReadChannelV(HfChannelId channel_id, float &channel_reading_v,
+                                uint8_t numOfSamplesToAvg = 1,
+                                HfTimeoutMs timeBetweenSamples = 0) noexcept = 0;
+
+  /**
+   * @brief Read channel count (raw ADC value).
+   * @param channel_id Channel ID to read from
+   * @param channel_reading_count Reference to store count reading
+   * @param numOfSamplesToAvg Number of samples to average (default 1)
+   * @param timeBetweenSamples Time between samples in milliseconds (default 0)
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr ReadChannelCount(HfChannelId channel_id, uint32_t &channel_reading_count,
+                                    uint8_t numOfSamplesToAvg = 1,
+                                    HfTimeoutMs timeBetweenSamples = 0) noexcept = 0;
+
+  /**
+   * @brief Read both channel count and voltage.
+   * @param channel_id Channel ID to read from
+   * @param channel_reading_count Reference to store count reading
+   * @param channel_reading_v Reference to store voltage reading
+   * @param numOfSamplesToAvg Number of samples to average (default 1)
+   * @param timeBetweenSamples Time between samples in milliseconds (default 0)
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr ReadChannel(HfChannelId channel_id, uint32_t &channel_reading_count,
+                               float &channel_reading_v, uint8_t numOfSamplesToAvg = 1,
+                               HfTimeoutMs timeBetweenSamples = 0) noexcept = 0;
+
+  /**
+   * @brief ADC trigger source enumeration for advanced sampling
+   */
+  enum class TriggerSource : uint8_t {
+    Software = 0, ///< Software trigger (manual)
+    Timer = 1,    ///< Timer-based trigger
+    GPIO = 2,     ///< GPIO edge trigger
+    PWM = 3,      ///< PWM sync trigger
+    External = 4  ///< External trigger signal
+  };
+
+  /**
+   * @brief ADC sampling mode configuration
+   */
+  enum class SamplingMode : uint8_t {
+    Single = 0,     ///< Single conversion
+    Continuous = 1, ///< Continuous conversion
+    Burst = 2,      ///< Burst mode (fixed number)
+    DMA = 3         ///< DMA-driven continuous
+  };
+
+  /**
+   * @brief Advanced ADC configuration structure
+   */
+  struct AdcAdvancedConfig {
+    TriggerSource trigger_source; ///< Trigger source
+    SamplingMode sampling_mode;   ///< Sampling mode
+    uint32_t sample_rate_hz;      ///< Desired sample rate
+    uint16_t buffer_size;         ///< DMA buffer size
+    bool enable_oversampling;     ///< Enable oversampling
+    uint8_t oversample_ratio;     ///< Oversampling ratio (2^n)
+    bool enable_filtering;        ///< Enable digital filtering
+    float filter_cutoff_hz;       ///< Filter cutoff frequency
+
+    AdcAdvancedConfig() noexcept
+        : trigger_source(TriggerSource::Software), sampling_mode(SamplingMode::Single),
+          sample_rate_hz(1000), buffer_size(512), enable_oversampling(false), oversample_ratio(4),
+          enable_filtering(false), filter_cutoff_hz(100.0f) {}
+  };
+
+  /**
+   * @brief ADC callback for continuous/DMA operations
+   * @param channel_id Channel that completed conversion
+   * @param samples Pointer to sample data
+   * @param num_samples Number of samples in buffer
+   * @param user_data User-provided data
+   */
+  using AdcCallback = std::function<void(HfChannelId channel_id, const uint16_t *samples,
+                                         size_t num_samples, void *user_data)>;
+
+  //==============================================//
+  // ADVANCED FEATURES (OPTIONAL IMPLEMENTATIONS) //
+  //==============================================//
+
+  /**
+   * @brief Configure advanced ADC features (DMA, triggering)
+   * @param channel_id Channel to configure
+   * @param config Advanced configuration
+   * @return HfAdcErr error code
+   * @note Default implementation returns unsupported operation
+   */
+  virtual HfAdcErr ConfigureAdvanced(HfChannelId channel_id,
+                                     const AdcAdvancedConfig &config) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Start continuous/DMA sampling with callback
+   * @param channel_id Channel to sample
+   * @param callback Callback for sample data
+   * @param user_data User data for callback
+   * @return HfAdcErr error code
+   * @note Default implementation returns unsupported operation
+   */
+  virtual HfAdcErr StartContinuousSampling(HfChannelId channel_id, AdcCallback callback,
+                                           void *user_data = nullptr) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Stop continuous/DMA sampling
+   * @param channel_id Channel to stop
+   * @return HfAdcErr error code
+   * @note Default implementation returns unsupported operation
+   */
+  virtual HfAdcErr StopContinuousSampling(HfChannelId channel_id) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Read multiple channels simultaneously
+   * @param channel_ids Array of channel IDs
+   * @param num_channels Number of channels
+   * @param readings Array to store raw readings
+   * @param voltages Array to store voltage readings
+   * @return HfAdcErr error code
+   * @note Default implementation reads channels sequentially
+   */
+  virtual HfAdcErr ReadMultipleChannels(const HfChannelId *channel_ids, uint8_t num_channels,
+                                        uint32_t *readings, float *voltages) noexcept {
+    if (!channel_ids || !readings || !voltages) {
+      return HfAdcErr::ADC_ERR_NULL_POINTER;
     }
 
-    /**
-     * @brief Checks if the class is initialized.
-     * @return true if initialized, false otherwise
-     */
-    [[nodiscard]] bool IsInitialized() const noexcept {
-        return initialized_;
+    for (uint8_t i = 0; i < num_channels; ++i) {
+      HfAdcErr err = ReadChannel(channel_ids[i], readings[i], voltages[i]);
+      if (err != HfAdcErr::ADC_SUCCESS) {
+        return err;
+      }
+    }
+    return HfAdcErr::ADC_SUCCESS;
+  }
+
+  //==============================================//
+  // CALIBRATION SUPPORT                         //
+  //==============================================//
+
+  /**
+   * @brief ADC calibration types
+   */
+  enum class CalibrationType : uint8_t {
+    None = 0,       ///< No calibration
+    TwoPoint = 1,   ///< Two-point linear calibration
+    MultiPoint = 2, ///< Multi-point interpolation calibration
+    Polynomial = 3, ///< Polynomial calibration
+    Factory = 4,    ///< Factory/hardware calibration
+    UserDefined = 5 ///< User-defined calibration algorithm
+  };
+
+  /**
+   * @brief Calibration point structure for two-point and multi-point calibration
+   */
+  struct CalibrationPoint {
+    float input_voltage;    ///< Known input voltage
+    uint32_t raw_reading;   ///< ADC raw reading for this voltage
+    float temperature_c;    ///< Temperature when calibration was performed
+    uint32_t timestamp_sec; ///< Unix timestamp of calibration
+
+    CalibrationPoint() noexcept
+        : input_voltage(0.0f), raw_reading(0), temperature_c(25.0f), timestamp_sec(0) {}
+
+    CalibrationPoint(float voltage, uint32_t raw, float temp = 25.0f) noexcept
+        : input_voltage(voltage), raw_reading(raw), temperature_c(temp), timestamp_sec(0) {
+    } // Implementation should set actual timestamp
+  };
+
+  /**
+   * @brief Calibration configuration structure
+   */
+  struct CalibrationConfig {
+    CalibrationType type;          ///< Calibration type
+    uint8_t num_points;            ///< Number of calibration points (max 16)
+    CalibrationPoint points[16];   ///< Calibration points array
+    float polynomial_coeffs[8];    ///< Polynomial coefficients (for polynomial type)
+    uint8_t polynomial_order;      ///< Polynomial order (2-7)
+    bool temperature_compensation; ///< Enable temperature compensation
+    float temp_coefficient_ppm_c;  ///< Temperature coefficient (ppm/°C)
+    bool enable_drift_detection;   ///< Enable calibration drift detection
+    float max_drift_threshold;     ///< Maximum allowed drift before re-cal needed
+
+    CalibrationConfig() noexcept
+        : type(CalibrationType::None), num_points(0), points{}, polynomial_coeffs{},
+          polynomial_order(2), temperature_compensation(false), temp_coefficient_ppm_c(0.0f),
+          enable_drift_detection(false), max_drift_threshold(0.05f) {}
+  };
+
+  /**
+   * @brief Calibration status and statistics
+   */
+  struct CalibrationStatus {
+    bool is_calibrated;               ///< Channel has valid calibration
+    CalibrationType active_type;      ///< Currently active calibration type
+    uint32_t calibration_timestamp;   ///< When calibration was performed
+    float accuracy_estimate;          ///< Estimated accuracy (% full scale)
+    float linearity_error;            ///< Linearity error (% full scale)
+    float drift_amount;               ///< Detected drift since last calibration
+    bool needs_recalibration;         ///< Calibration drift exceeded threshold
+    uint32_t successful_calibrations; ///< Count of successful calibrations
+    uint32_t failed_calibrations;     ///< Count of failed calibration attempts
+
+    CalibrationStatus() noexcept
+        : is_calibrated(false), active_type(CalibrationType::None), calibration_timestamp(0),
+          accuracy_estimate(0.0f), linearity_error(0.0f), drift_amount(0.0f),
+          needs_recalibration(false), successful_calibrations(0), failed_calibrations(0) {}
+  };
+
+  /**
+   * @brief Calibration progress callback for long operations
+   * @param channel_id Channel being calibrated
+   * @param progress_percent Progress percentage (0-100)
+   * @param current_step Description of current calibration step
+   * @param user_data User-provided data
+   */
+  using CalibrationProgressCallback = std::function<void(
+      HfChannelId channel_id, float progress_percent, const char *current_step, void *user_data)>;
+
+  /**
+   * @brief Perform ADC calibration for a specific channel
+   * @param channel_id Channel to calibrate
+   * @param config Calibration configuration
+   * @param progress_callback Optional progress callback for long operations
+   * @param user_data User data for progress callback
+   * @return HfAdcErr error code
+   * @note Default implementation returns unsupported operation
+   */
+  virtual HfAdcErr CalibrateChannel(HfChannelId channel_id, const CalibrationConfig &config,
+                                    CalibrationProgressCallback progress_callback = nullptr,
+                                    void *user_data = nullptr) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Perform automatic calibration using known reference voltages
+   * @param channel_id Channel to calibrate
+   * @param reference_voltages Array of known reference voltages
+   * @param num_references Number of reference voltages
+   * @param calibration_type Type of calibration to perform
+   * @return HfAdcErr error code
+   * @note Implementation should prompt user to apply each reference voltage
+   */
+  virtual HfAdcErr
+  AutoCalibrate(HfChannelId channel_id, const float *reference_voltages, uint8_t num_references,
+                CalibrationType calibration_type = CalibrationType::TwoPoint) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Save calibration data to non-volatile storage
+   * @param channel_id Channel calibration to save
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr SaveCalibration(HfChannelId channel_id) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Load calibration data from non-volatile storage
+   * @param channel_id Channel calibration to load
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr LoadCalibration(HfChannelId channel_id) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Clear/reset calibration for a channel
+   * @param channel_id Channel to reset
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr ClearCalibration(HfChannelId channel_id) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Get calibration status and information
+   * @param channel_id Channel to query
+   * @param status Structure to fill with calibration status
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr GetCalibrationStatus(HfChannelId channel_id,
+                                        CalibrationStatus &status) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Verify calibration accuracy using known reference
+   * @param channel_id Channel to verify
+   * @param reference_voltage Known reference voltage to test
+   * @param measured_voltage Output: voltage measured by ADC
+   * @param error_percent Output: percentage error from reference
+   * @return HfAdcErr error code
+   */
+  virtual HfAdcErr VerifyCalibration(HfChannelId channel_id, float reference_voltage,
+                                     float &measured_voltage, float &error_percent) noexcept {
+    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  }
+
+  /**
+   * @brief Apply temperature compensation to a reading
+   * @param raw_reading Raw ADC reading
+   * @param current_temp_c Current temperature in Celsius
+   * @param calibration_temp_c Temperature when calibration was performed
+   * @param temp_coefficient Temperature coefficient (ppm/°C)
+   * @return Temperature-compensated reading
+   */
+  static uint32_t ApplyTemperatureCompensation(uint32_t raw_reading, float current_temp_c,
+                                               float calibration_temp_c,
+                                               float temp_coefficient) noexcept {
+    float temp_delta = current_temp_c - calibration_temp_c;
+    float compensation_factor = 1.0f + (temp_coefficient * temp_delta / 1000000.0f);
+    return static_cast<uint32_t>(raw_reading * compensation_factor);
+  }
+
+  /**
+   * @brief Validate calibration configuration
+   * @param config Configuration to validate
+   * @return true if configuration is valid, false otherwise
+   */
+  static bool ValidateCalibrationConfig(const CalibrationConfig &config) noexcept {
+    if (config.type == CalibrationType::None) {
+      return true;
     }
 
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
-    //==============================================//
-
-    /**
-     * @brief Initializes the ADC peripheral (must be implemented by derived classes).
-     * @return True if the initialization is successful, false otherwise.
-     */
-    virtual bool Initialize() noexcept = 0;
-
-    /**
-     * @brief Deinitializes the ADC peripheral.
-     * @return True if deinitialization is successful, false otherwise.
-     */
-    virtual bool Deinitialize() noexcept {
-        initialized_ = false;
-        return true;
+    if (config.type == CalibrationType::TwoPoint && config.num_points < 2) {
+      return false;
     }
 
-    /**
-     * @brief Get the maximum number of channels supported by this ADC.
-     * @return Maximum channel count
-     */
-    [[nodiscard]] virtual uint8_t GetMaxChannels() const noexcept = 0;
-
-    /**
-     * @brief Check if a specific channel is available.
-     * @param channel_id Channel ID to check
-     * @return true if channel is available, false otherwise
-     */
-    [[nodiscard]] virtual bool IsChannelAvailable(HfChannelId channel_id) const noexcept = 0;
-    
-    /**
-     * @brief Read channel voltage.
-     * @param channel_id Channel ID to read from
-     * @param channel_reading_v Reference to store voltage reading
-     * @param numOfSamplesToAvg Number of samples to average (default 1)
-     * @param timeBetweenSamples Time between samples in milliseconds (default 0)
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr ReadChannelV(HfChannelId channel_id, float &channel_reading_v,
-                                  uint8_t numOfSamplesToAvg = 1,
-                                  HfTimeoutMs timeBetweenSamples = 0) noexcept = 0;
-    
-    /**
-     * @brief Read channel count (raw ADC value).
-     * @param channel_id Channel ID to read from
-     * @param channel_reading_count Reference to store count reading
-     * @param numOfSamplesToAvg Number of samples to average (default 1)
-     * @param timeBetweenSamples Time between samples in milliseconds (default 0)
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr ReadChannelCount(HfChannelId channel_id, uint32_t &channel_reading_count,
-                                      uint8_t numOfSamplesToAvg = 1,
-                                      HfTimeoutMs timeBetweenSamples = 0) noexcept = 0;
-    
-    /**
-     * @brief Read both channel count and voltage.
-     * @param channel_id Channel ID to read from
-     * @param channel_reading_count Reference to store count reading
-     * @param channel_reading_v Reference to store voltage reading
-     * @param numOfSamplesToAvg Number of samples to average (default 1)
-     * @param timeBetweenSamples Time between samples in milliseconds (default 0)
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr ReadChannel(HfChannelId channel_id, uint32_t &channel_reading_count,
-                                 float &channel_reading_v, uint8_t numOfSamplesToAvg = 1,
-                                 HfTimeoutMs timeBetweenSamples = 0) noexcept = 0;
-
-    /**
-     * @brief ADC trigger source enumeration for advanced sampling
-     */
-    enum class TriggerSource : uint8_t {
-        Software = 0,       ///< Software trigger (manual)
-        Timer = 1,          ///< Timer-based trigger
-        GPIO = 2,           ///< GPIO edge trigger
-        PWM = 3,            ///< PWM sync trigger
-        External = 4        ///< External trigger signal
-    };
-
-    /**
-     * @brief ADC sampling mode configuration
-     */
-    enum class SamplingMode : uint8_t {
-        Single = 0,         ///< Single conversion
-        Continuous = 1,     ///< Continuous conversion
-        Burst = 2,          ///< Burst mode (fixed number)
-        DMA = 3             ///< DMA-driven continuous
-    };
-
-    /**
-     * @brief Advanced ADC configuration structure
-     */
-    struct AdcAdvancedConfig {
-        TriggerSource trigger_source;   ///< Trigger source
-        SamplingMode sampling_mode;     ///< Sampling mode
-        uint32_t sample_rate_hz;        ///< Desired sample rate
-        uint16_t buffer_size;           ///< DMA buffer size
-        bool enable_oversampling;       ///< Enable oversampling
-        uint8_t oversample_ratio;       ///< Oversampling ratio (2^n)
-        bool enable_filtering;          ///< Enable digital filtering
-        float filter_cutoff_hz;         ///< Filter cutoff frequency
-        
-        AdcAdvancedConfig() noexcept
-            : trigger_source(TriggerSource::Software)
-            , sampling_mode(SamplingMode::Single)
-            , sample_rate_hz(1000)
-            , buffer_size(512)
-            , enable_oversampling(false)
-            , oversample_ratio(4)
-            , enable_filtering(false)
-            , filter_cutoff_hz(100.0f) {}
-    };
-
-    /**
-     * @brief ADC callback for continuous/DMA operations
-     * @param channel_id Channel that completed conversion
-     * @param samples Pointer to sample data
-     * @param num_samples Number of samples in buffer
-     * @param user_data User-provided data
-     */
-    using AdcCallback = std::function<void(HfChannelId channel_id, const uint16_t* samples, 
-                                          size_t num_samples, void* user_data)>;
-
-    //==============================================//
-    // ADVANCED FEATURES (OPTIONAL IMPLEMENTATIONS) //
-    //==============================================//
-
-    /**
-     * @brief Configure advanced ADC features (DMA, triggering)
-     * @param channel_id Channel to configure
-     * @param config Advanced configuration
-     * @return HfAdcErr error code
-     * @note Default implementation returns unsupported operation
-     */
-    virtual HfAdcErr ConfigureAdvanced(HfChannelId channel_id, 
-                                       const AdcAdvancedConfig& config) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+    if (config.type == CalibrationType::MultiPoint && config.num_points < 3) {
+      return false;
     }
 
-    /**
-     * @brief Start continuous/DMA sampling with callback
-     * @param channel_id Channel to sample
-     * @param callback Callback for sample data
-     * @param user_data User data for callback
-     * @return HfAdcErr error code
-     * @note Default implementation returns unsupported operation
-     */
-    virtual HfAdcErr StartContinuousSampling(HfChannelId channel_id,
-                                             AdcCallback callback,
-                                             void* user_data = nullptr) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+    if (config.type == CalibrationType::Polynomial &&
+        (config.polynomial_order < 2 || config.polynomial_order > 7)) {
+      return false;
     }
 
-    /**
-     * @brief Stop continuous/DMA sampling
-     * @param channel_id Channel to stop
-     * @return HfAdcErr error code
-     * @note Default implementation returns unsupported operation
-     */
-    virtual HfAdcErr StopContinuousSampling(HfChannelId channel_id) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+    // Validate that calibration points are in ascending voltage order
+    for (uint8_t i = 1; i < config.num_points; ++i) {
+      if (config.points[i].input_voltage <= config.points[i - 1].input_voltage) {
+        return false;
+      }
     }
 
-    /**
-     * @brief Read multiple channels simultaneously
-     * @param channel_ids Array of channel IDs
-     * @param num_channels Number of channels
-     * @param readings Array to store raw readings
-     * @param voltages Array to store voltage readings
-     * @return HfAdcErr error code
-     * @note Default implementation reads channels sequentially
-     */
-    virtual HfAdcErr ReadMultipleChannels(const HfChannelId* channel_ids,
-                                          uint8_t num_channels,
-                                          uint32_t* readings,
-                                          float* voltages) noexcept {
-        if (!channel_ids || !readings || !voltages) {
-            return HfAdcErr::ADC_ERR_NULL_POINTER;
-        }
-
-        for (uint8_t i = 0; i < num_channels; ++i) {
-            HfAdcErr err = ReadChannel(channel_ids[i], readings[i], voltages[i]);
-            if (err != HfAdcErr::ADC_SUCCESS) {
-                return err;
-            }
-        }
-        return HfAdcErr::ADC_SUCCESS;
-    }
-
-    //==============================================//
-    // CALIBRATION SUPPORT                         //
-    //==============================================//
-
-    /**
-     * @brief ADC calibration types
-     */
-    enum class CalibrationType : uint8_t {
-        None = 0,           ///< No calibration
-        TwoPoint = 1,       ///< Two-point linear calibration
-        MultiPoint = 2,     ///< Multi-point interpolation calibration
-        Polynomial = 3,     ///< Polynomial calibration
-        Factory = 4,        ///< Factory/hardware calibration
-        UserDefined = 5     ///< User-defined calibration algorithm
-    };
-
-    /**
-     * @brief Calibration point structure for two-point and multi-point calibration
-     */
-    struct CalibrationPoint {
-        float input_voltage;        ///< Known input voltage
-        uint32_t raw_reading;       ///< ADC raw reading for this voltage
-        float temperature_c;        ///< Temperature when calibration was performed
-        uint32_t timestamp_sec;     ///< Unix timestamp of calibration
-        
-        CalibrationPoint() noexcept
-            : input_voltage(0.0f)
-            , raw_reading(0)
-            , temperature_c(25.0f)
-            , timestamp_sec(0) {}
-            
-        CalibrationPoint(float voltage, uint32_t raw, float temp = 25.0f) noexcept
-            : input_voltage(voltage)
-            , raw_reading(raw)
-            , temperature_c(temp)
-            , timestamp_sec(0) {}  // Implementation should set actual timestamp
-    };
-
-    /**
-     * @brief Calibration configuration structure
-     */
-    struct CalibrationConfig {
-        CalibrationType type;               ///< Calibration type
-        uint8_t num_points;                 ///< Number of calibration points (max 16)
-        CalibrationPoint points[16];        ///< Calibration points array
-        float polynomial_coeffs[8];         ///< Polynomial coefficients (for polynomial type)
-        uint8_t polynomial_order;           ///< Polynomial order (2-7)
-        bool temperature_compensation;      ///< Enable temperature compensation
-        float temp_coefficient_ppm_c;       ///< Temperature coefficient (ppm/°C)
-        bool enable_drift_detection;        ///< Enable calibration drift detection
-        float max_drift_threshold;          ///< Maximum allowed drift before re-cal needed
-        
-        CalibrationConfig() noexcept
-            : type(CalibrationType::None)
-            , num_points(0)
-            , points{}
-            , polynomial_coeffs{}
-            , polynomial_order(2)
-            , temperature_compensation(false)
-            , temp_coefficient_ppm_c(0.0f)
-            , enable_drift_detection(false)
-            , max_drift_threshold(0.05f) {}
-    };
-
-    /**
-     * @brief Calibration status and statistics
-     */
-    struct CalibrationStatus {
-        bool is_calibrated;                 ///< Channel has valid calibration
-        CalibrationType active_type;        ///< Currently active calibration type
-        uint32_t calibration_timestamp;     ///< When calibration was performed
-        float accuracy_estimate;            ///< Estimated accuracy (% full scale)
-        float linearity_error;              ///< Linearity error (% full scale)
-        float drift_amount;                 ///< Detected drift since last calibration
-        bool needs_recalibration;           ///< Calibration drift exceeded threshold
-        uint32_t successful_calibrations;   ///< Count of successful calibrations
-        uint32_t failed_calibrations;       ///< Count of failed calibration attempts
-        
-        CalibrationStatus() noexcept
-            : is_calibrated(false)
-            , active_type(CalibrationType::None)
-            , calibration_timestamp(0)
-            , accuracy_estimate(0.0f)
-            , linearity_error(0.0f)
-            , drift_amount(0.0f)
-            , needs_recalibration(false)
-            , successful_calibrations(0)
-            , failed_calibrations(0) {}
-    };
-
-    /**
-     * @brief Calibration progress callback for long operations
-     * @param channel_id Channel being calibrated
-     * @param progress_percent Progress percentage (0-100)
-     * @param current_step Description of current calibration step
-     * @param user_data User-provided data
-     */
-    using CalibrationProgressCallback = std::function<void(HfChannelId channel_id, 
-                                                           float progress_percent,
-                                                           const char* current_step,
-                                                           void* user_data)>;
-
-    /**
-     * @brief Perform ADC calibration for a specific channel
-     * @param channel_id Channel to calibrate
-     * @param config Calibration configuration
-     * @param progress_callback Optional progress callback for long operations
-     * @param user_data User data for progress callback
-     * @return HfAdcErr error code
-     * @note Default implementation returns unsupported operation
-     */
-    virtual HfAdcErr CalibrateChannel(HfChannelId channel_id,
-                                      const CalibrationConfig& config,
-                                      CalibrationProgressCallback progress_callback = nullptr,
-                                      void* user_data = nullptr) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Perform automatic calibration using known reference voltages
-     * @param channel_id Channel to calibrate
-     * @param reference_voltages Array of known reference voltages
-     * @param num_references Number of reference voltages
-     * @param calibration_type Type of calibration to perform
-     * @return HfAdcErr error code
-     * @note Implementation should prompt user to apply each reference voltage
-     */
-    virtual HfAdcErr AutoCalibrate(HfChannelId channel_id,
-                                   const float* reference_voltages,
-                                   uint8_t num_references,
-                                   CalibrationType calibration_type = CalibrationType::TwoPoint) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Save calibration data to non-volatile storage
-     * @param channel_id Channel calibration to save
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr SaveCalibration(HfChannelId channel_id) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Load calibration data from non-volatile storage
-     * @param channel_id Channel calibration to load
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr LoadCalibration(HfChannelId channel_id) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Clear/reset calibration for a channel
-     * @param channel_id Channel to reset
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr ClearCalibration(HfChannelId channel_id) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Get calibration status and information
-     * @param channel_id Channel to query
-     * @param status Structure to fill with calibration status
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr GetCalibrationStatus(HfChannelId channel_id, 
-                                          CalibrationStatus& status) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Verify calibration accuracy using known reference
-     * @param channel_id Channel to verify
-     * @param reference_voltage Known reference voltage to test
-     * @param measured_voltage Output: voltage measured by ADC
-     * @param error_percent Output: percentage error from reference
-     * @return HfAdcErr error code
-     */
-    virtual HfAdcErr VerifyCalibration(HfChannelId channel_id,
-                                       float reference_voltage,
-                                       float& measured_voltage,
-                                       float& error_percent) noexcept {
-        return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
-    }
-
-    /**
-     * @brief Apply temperature compensation to a reading
-     * @param raw_reading Raw ADC reading
-     * @param current_temp_c Current temperature in Celsius
-     * @param calibration_temp_c Temperature when calibration was performed
-     * @param temp_coefficient Temperature coefficient (ppm/°C)
-     * @return Temperature-compensated reading
-     */
-    static uint32_t ApplyTemperatureCompensation(uint32_t raw_reading,
-                                                  float current_temp_c,
-                                                  float calibration_temp_c,
-                                                  float temp_coefficient) noexcept {
-        float temp_delta = current_temp_c - calibration_temp_c;
-        float compensation_factor = 1.0f + (temp_coefficient * temp_delta / 1000000.0f);
-        return static_cast<uint32_t>(raw_reading * compensation_factor);
-    }
-
-    /**
-     * @brief Validate calibration configuration
-     * @param config Configuration to validate
-     * @return true if configuration is valid, false otherwise
-     */
-    static bool ValidateCalibrationConfig(const CalibrationConfig& config) noexcept {
-        if (config.type == CalibrationType::None) {
-            return true;
-        }
-        
-        if (config.type == CalibrationType::TwoPoint && config.num_points < 2) {
-            return false;
-        }
-        
-        if (config.type == CalibrationType::MultiPoint && config.num_points < 3) {
-            return false;
-        }
-        
-        if (config.type == CalibrationType::Polynomial && 
-            (config.polynomial_order < 2 || config.polynomial_order > 7)) {
-            return false;
-        }
-        
-        // Validate that calibration points are in ascending voltage order
-        for (uint8_t i = 1; i < config.num_points; ++i) {
-            if (config.points[i].input_voltage <= config.points[i-1].input_voltage) {
-                return false;
-            }
-        }
-        
-        return true;
-    }
+    return true;
+  }
 
 protected:
-    /**
-     * @brief Validate input parameters for read operations.
-     * @param channel_id Channel ID to validate
-     * @param numOfSamplesToAvg Number of samples to validate
-     * @return HfAdcErr validation result
-     */
-    [[nodiscard]] HfAdcErr ValidateReadParameters(HfChannelId channel_id, 
-                                                  uint8_t numOfSamplesToAvg) const noexcept {
-        if (!initialized_) {
-            return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
-        }
-        
-        if (numOfSamplesToAvg == 0 || numOfSamplesToAvg > 255) {
-            return HfAdcErr::ADC_ERR_INVALID_SAMPLE_COUNT;
-        }
-        
-        if (channel_id >= GetMaxChannels()) {
-            return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-        }
-        
-        if (!IsChannelAvailable(channel_id)) {
-            return HfAdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
-        }
-        
-        return HfAdcErr::ADC_SUCCESS;
+  /**
+   * @brief Validate input parameters for read operations.
+   * @param channel_id Channel ID to validate
+   * @param numOfSamplesToAvg Number of samples to validate
+   * @return HfAdcErr validation result
+   */
+  [[nodiscard]] HfAdcErr ValidateReadParameters(HfChannelId channel_id,
+                                                uint8_t numOfSamplesToAvg) const noexcept {
+    if (!initialized_) {
+      return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
     }
 
+    if (numOfSamplesToAvg == 0 || numOfSamplesToAvg > 255) {
+      return HfAdcErr::ADC_ERR_INVALID_SAMPLE_COUNT;
+    }
+
+    if (channel_id >= GetMaxChannels()) {
+      return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+    }
+
+    if (!IsChannelAvailable(channel_id)) {
+      return HfAdcErr::ADC_ERR_CHANNEL_NOT_FOUND;
+    }
+
+    return HfAdcErr::ADC_SUCCESS;
+  }
+
 private:
-    bool initialized_;  ///< Initialization status
+  bool initialized_; ///< Initialization status
 };
 
 #endif /* HAL_INTERNAL_INTERFACE_DRIVERS_BASEADC_H_ */

--- a/inc/base/BaseCan.h
+++ b/inc/base/BaseCan.h
@@ -1,11 +1,11 @@
 /**
  * @file BaseCan.h
  * @brief Abstract base class for CAN bus implementations in the HardFOC system.
- * 
+ *
  * This header-only file defines the abstract base class for CAN bus communication
  * that provides a consistent API across different CAN controller implementations.
  * Concrete implementations (like McuCan for ESP32 TWAI) inherit from this class.
- * 
+ *
  * @note This is a header-only abstract base class following the same pattern as BaseAdc.
  * @note Users should program against this interface, not specific implementations.
  */
@@ -28,46 +28,46 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_CAN_ERR_LIST(X) \
-    /* Success codes */ \
-    X(CAN_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(CAN_ERR_FAILURE, 1, "General failure") \
-    X(CAN_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(CAN_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(CAN_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(CAN_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(CAN_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Bus errors */ \
-    X(CAN_ERR_BUS_OFF, 7, "Bus off state") \
-    X(CAN_ERR_BUS_ERROR, 8, "Bus error") \
-    X(CAN_ERR_BUS_BUSY, 9, "Bus busy") \
-    X(CAN_ERR_BUS_NOT_AVAILABLE, 10, "Bus not available") \
-    /* Message errors */ \
-    X(CAN_ERR_MESSAGE_TIMEOUT, 11, "Message timeout") \
-    X(CAN_ERR_MESSAGE_LOST, 12, "Message lost") \
-    X(CAN_ERR_MESSAGE_INVALID, 13, "Invalid message") \
-    X(CAN_ERR_MESSAGE_TOO_LONG, 14, "Message too long") \
-    X(CAN_ERR_QUEUE_FULL, 15, "Queue full") \
-    X(CAN_ERR_QUEUE_EMPTY, 16, "Queue empty") \
-    /* Hardware errors */ \
-    X(CAN_ERR_HARDWARE_FAULT, 17, "Hardware fault") \
-    X(CAN_ERR_COMMUNICATION_FAILURE, 18, "Communication failure") \
-    X(CAN_ERR_DEVICE_NOT_RESPONDING, 19, "Device not responding") \
-    X(CAN_ERR_VOLTAGE_OUT_OF_RANGE, 20, "Voltage out of range") \
-    /* Configuration errors */ \
-    X(CAN_ERR_INVALID_CONFIGURATION, 21, "Invalid configuration") \
-    X(CAN_ERR_UNSUPPORTED_OPERATION, 22, "Unsupported operation") \
-    X(CAN_ERR_INVALID_BAUD_RATE, 23, "Invalid baud rate") \
-    X(CAN_ERR_FILTER_ERROR, 24, "Filter error") \
-    /* System errors */ \
-    X(CAN_ERR_SYSTEM_ERROR, 25, "System error") \
-    X(CAN_ERR_PERMISSION_DENIED, 26, "Permission denied") \
-    X(CAN_ERR_OPERATION_ABORTED, 27, "Operation aborted")
+#define HF_CAN_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(CAN_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(CAN_ERR_FAILURE, 1, "General failure")                                                         \
+  X(CAN_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(CAN_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(CAN_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(CAN_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(CAN_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Bus errors */                                                                                 \
+  X(CAN_ERR_BUS_OFF, 7, "Bus off state")                                                           \
+  X(CAN_ERR_BUS_ERROR, 8, "Bus error")                                                             \
+  X(CAN_ERR_BUS_BUSY, 9, "Bus busy")                                                               \
+  X(CAN_ERR_BUS_NOT_AVAILABLE, 10, "Bus not available")                                            \
+  /* Message errors */                                                                             \
+  X(CAN_ERR_MESSAGE_TIMEOUT, 11, "Message timeout")                                                \
+  X(CAN_ERR_MESSAGE_LOST, 12, "Message lost")                                                      \
+  X(CAN_ERR_MESSAGE_INVALID, 13, "Invalid message")                                                \
+  X(CAN_ERR_MESSAGE_TOO_LONG, 14, "Message too long")                                              \
+  X(CAN_ERR_QUEUE_FULL, 15, "Queue full")                                                          \
+  X(CAN_ERR_QUEUE_EMPTY, 16, "Queue empty")                                                        \
+  /* Hardware errors */                                                                            \
+  X(CAN_ERR_HARDWARE_FAULT, 17, "Hardware fault")                                                  \
+  X(CAN_ERR_COMMUNICATION_FAILURE, 18, "Communication failure")                                    \
+  X(CAN_ERR_DEVICE_NOT_RESPONDING, 19, "Device not responding")                                    \
+  X(CAN_ERR_VOLTAGE_OUT_OF_RANGE, 20, "Voltage out of range")                                      \
+  /* Configuration errors */                                                                       \
+  X(CAN_ERR_INVALID_CONFIGURATION, 21, "Invalid configuration")                                    \
+  X(CAN_ERR_UNSUPPORTED_OPERATION, 22, "Unsupported operation")                                    \
+  X(CAN_ERR_INVALID_BAUD_RATE, 23, "Invalid baud rate")                                            \
+  X(CAN_ERR_FILTER_ERROR, 24, "Filter error")                                                      \
+  /* System errors */                                                                              \
+  X(CAN_ERR_SYSTEM_ERROR, 25, "System error")                                                      \
+  X(CAN_ERR_PERMISSION_DENIED, 26, "Permission denied")                                            \
+  X(CAN_ERR_OPERATION_ABORTED, 27, "Operation aborted")
 
 enum class HfCanErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
-    HF_CAN_ERR_LIST(X)
+  HF_CAN_ERR_LIST(X)
 #undef X
 };
 
@@ -77,15 +77,15 @@ enum class HfCanErr : uint8_t {
  * @return String view of the error description
  */
 constexpr std::string_view HfCanErrToString(HfCanErr err) noexcept {
-    switch (err) {
-#define X(NAME, VALUE, DESC) \
-    case HfCanErr::NAME: \
-        return DESC;
-        HF_CAN_ERR_LIST(X)
+  switch (err) {
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfCanErr::NAME:                                                                             \
+    return DESC;
+    HF_CAN_ERR_LIST(X)
 #undef X
-    default:
-        return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 /**
@@ -94,18 +94,17 @@ constexpr std::string_view HfCanErrToString(HfCanErr err) noexcept {
  *          without exposing MCU-specific types.
  */
 struct CanBusConfig {
-    HfPinNumber tx_pin;                   ///< CAN TX pin
-    HfPinNumber rx_pin;                   ///< CAN RX pin
-    HfBaudRate baudrate;                  ///< CAN baudrate (bps)
-    bool loopback_mode;                 ///< Enable loopback mode for testing
-    bool silent_mode;                   ///< Enable silent mode (listen-only)
-    uint16_t tx_queue_size;             ///< TX queue size (implementation-dependent)
-    uint16_t rx_queue_size;             ///< RX queue size (implementation-dependent)
-    
-    CanBusConfig() noexcept 
-        : tx_pin(HF_INVALID_PIN), rx_pin(HF_INVALID_PIN), baudrate(500000)
-        , loopback_mode(false), silent_mode(false)
-        , tx_queue_size(10), rx_queue_size(10) {}
+  HfPinNumber tx_pin;     ///< CAN TX pin
+  HfPinNumber rx_pin;     ///< CAN RX pin
+  HfBaudRate baudrate;    ///< CAN baudrate (bps)
+  bool loopback_mode;     ///< Enable loopback mode for testing
+  bool silent_mode;       ///< Enable silent mode (listen-only)
+  uint16_t tx_queue_size; ///< TX queue size (implementation-dependent)
+  uint16_t rx_queue_size; ///< RX queue size (implementation-dependent)
+
+  CanBusConfig() noexcept
+      : tx_pin(HF_INVALID_PIN), rx_pin(HF_INVALID_PIN), baudrate(500000), loopback_mode(false),
+        silent_mode(false), tx_queue_size(10), rx_queue_size(10) {}
 };
 
 /**
@@ -114,33 +113,32 @@ struct CanBusConfig {
  *          Supports both standard (11-bit) and extended (29-bit) identifiers.
  */
 struct CanMessage {
-    uint32_t id;                        ///< CAN identifier (11 or 29-bit)
-    bool extended_id;                   ///< Extended (29-bit) ID flag
-    bool remote_frame;                  ///< Remote transmission request flag
-    uint8_t dlc;                        ///< Data length code (0-8)
-    uint8_t data[8];                    ///< Message data (max 8 bytes for classic CAN)
-    uint32_t timestamp;                 ///< Reception timestamp (implementation-specific)
-    
-    CanMessage() noexcept
-        : id(0), extended_id(false), remote_frame(false)
-        , dlc(0), data{}, timestamp(0) {}
-        
-    /**
-     * @brief Get maximum data length for classic CAN
-     * @return Maximum allowed data length (8 bytes)
-     */
-    constexpr uint8_t GetMaxDataLength() const noexcept {
-        return 8;
-    }
-    
-    /**
-     * @brief Validate DLC for classic CAN
-     * @param dlc Data length code to validate
-     * @return true if valid (0-8), false otherwise
-     */
-    static constexpr bool IsValidDLC(uint8_t dlc) noexcept {
-        return dlc <= 8;
-    }
+  uint32_t id;        ///< CAN identifier (11 or 29-bit)
+  bool extended_id;   ///< Extended (29-bit) ID flag
+  bool remote_frame;  ///< Remote transmission request flag
+  uint8_t dlc;        ///< Data length code (0-8)
+  uint8_t data[8];    ///< Message data (max 8 bytes for classic CAN)
+  uint32_t timestamp; ///< Reception timestamp (implementation-specific)
+
+  CanMessage() noexcept
+      : id(0), extended_id(false), remote_frame(false), dlc(0), data{}, timestamp(0) {}
+
+  /**
+   * @brief Get maximum data length for classic CAN
+   * @return Maximum allowed data length (8 bytes)
+   */
+  constexpr uint8_t GetMaxDataLength() const noexcept {
+    return 8;
+  }
+
+  /**
+   * @brief Validate DLC for classic CAN
+   * @param dlc Data length code to validate
+   * @return true if valid (0-8), false otherwise
+   */
+  static constexpr bool IsValidDLC(uint8_t dlc) noexcept {
+    return dlc <= 8;
+  }
 };
 
 // For backward compatibility with existing code
@@ -150,44 +148,42 @@ using hf_can_message_t = CanMessage;
  * @brief Enhanced CAN bus status information including CAN-FD metrics
  */
 struct CanBusStatus {
-    uint32_t tx_error_count;            ///< Transmit error counter
-    uint32_t rx_error_count;            ///< Receive error counter
-    uint32_t tx_failed_count;           ///< Failed transmission count
-    uint32_t rx_missed_count;           ///< Missed reception count
-    bool bus_off;                       ///< Bus-off state
-    bool error_warning;                 ///< Error warning state
-    bool error_passive;                 ///< Error passive state
-    
-    // CAN-FD specific status
-    bool canfd_enabled;                 ///< CAN-FD mode is active
-    bool canfd_brs_enabled;             ///< Bit Rate Switching is enabled
-    uint32_t nominal_baudrate;          ///< Nominal bit rate (arbitration phase)
-    uint32_t data_baudrate;             ///< Data bit rate (data phase for CAN-FD)
-    uint32_t canfd_tx_count;            ///< Number of CAN-FD frames transmitted
-    uint32_t canfd_rx_count;            ///< Number of CAN-FD frames received
-    uint32_t brs_tx_count;              ///< Number of BRS frames transmitted
-    uint32_t brs_rx_count;              ///< Number of BRS frames received
-    uint32_t form_errors;               ///< CAN-FD form errors
-    uint32_t stuff_errors;              ///< Stuff errors
-    uint32_t crc_errors;                ///< CRC errors
-    uint32_t bit_errors;                ///< Bit errors
-    uint32_t ack_errors;                ///< Acknowledgment errors
-    
-    CanBusStatus() noexcept
-        : tx_error_count(0), rx_error_count(0), tx_failed_count(0), rx_missed_count(0)
-        , bus_off(false), error_warning(false), error_passive(false)
-        , canfd_enabled(false), canfd_brs_enabled(false)
-        , nominal_baudrate(0), data_baudrate(0)
-        , canfd_tx_count(0), canfd_rx_count(0)
-        , brs_tx_count(0), brs_rx_count(0)
-        , form_errors(0), stuff_errors(0), crc_errors(0), bit_errors(0), ack_errors(0) {}
+  uint32_t tx_error_count;  ///< Transmit error counter
+  uint32_t rx_error_count;  ///< Receive error counter
+  uint32_t tx_failed_count; ///< Failed transmission count
+  uint32_t rx_missed_count; ///< Missed reception count
+  bool bus_off;             ///< Bus-off state
+  bool error_warning;       ///< Error warning state
+  bool error_passive;       ///< Error passive state
+
+  // CAN-FD specific status
+  bool canfd_enabled;        ///< CAN-FD mode is active
+  bool canfd_brs_enabled;    ///< Bit Rate Switching is enabled
+  uint32_t nominal_baudrate; ///< Nominal bit rate (arbitration phase)
+  uint32_t data_baudrate;    ///< Data bit rate (data phase for CAN-FD)
+  uint32_t canfd_tx_count;   ///< Number of CAN-FD frames transmitted
+  uint32_t canfd_rx_count;   ///< Number of CAN-FD frames received
+  uint32_t brs_tx_count;     ///< Number of BRS frames transmitted
+  uint32_t brs_rx_count;     ///< Number of BRS frames received
+  uint32_t form_errors;      ///< CAN-FD form errors
+  uint32_t stuff_errors;     ///< Stuff errors
+  uint32_t crc_errors;       ///< CRC errors
+  uint32_t bit_errors;       ///< Bit errors
+  uint32_t ack_errors;       ///< Acknowledgment errors
+
+  CanBusStatus() noexcept
+      : tx_error_count(0), rx_error_count(0), tx_failed_count(0), rx_missed_count(0),
+        bus_off(false), error_warning(false), error_passive(false), canfd_enabled(false),
+        canfd_brs_enabled(false), nominal_baudrate(0), data_baudrate(0), canfd_tx_count(0),
+        canfd_rx_count(0), brs_tx_count(0), brs_rx_count(0), form_errors(0), stuff_errors(0),
+        crc_errors(0), bit_errors(0), ack_errors(0) {}
 };
 
 /**
  * @brief CAN message receive callback function type.
  * @note Updated to use new CanMessage structure
  */
-using CanReceiveCallback = std::function<void(const CanMessage& message)>;
+using CanReceiveCallback = std::function<void(const CanMessage &message)>;
 
 /**
  * @brief CAN-FD specific receive callback with enhanced information
@@ -195,289 +191,294 @@ using CanReceiveCallback = std::function<void(const CanMessage& message)>;
  * @param reception_info Additional reception information (timing, errors, etc.)
  */
 struct CanReceptionInfo {
-    uint32_t timestamp_us;              ///< Reception timestamp in microseconds
-    uint8_t rx_fifo_level;              ///< RX FIFO level when received
-    bool data_phase_error;              ///< Error occurred in data phase
-    bool arbitration_lost;              ///< Arbitration was lost during transmission
-    float bit_timing_tolerance;         ///< Measured bit timing tolerance
+  uint32_t timestamp_us;      ///< Reception timestamp in microseconds
+  uint8_t rx_fifo_level;      ///< RX FIFO level when received
+  bool data_phase_error;      ///< Error occurred in data phase
+  bool arbitration_lost;      ///< Arbitration was lost during transmission
+  float bit_timing_tolerance; ///< Measured bit timing tolerance
 };
-using CanFdReceiveCallback = std::function<void(const CanMessage& message, 
-                                                const CanReceptionInfo& info)>;
+using CanFdReceiveCallback =
+    std::function<void(const CanMessage &message, const CanReceptionInfo &info)>;
 
 /**
  * @class BaseCan
  * @brief Abstract base class defining the unified CAN bus API.
- * 
+ *
  * This abstract class defines the interface that all CAN controller implementations
  * must provide. It ensures a consistent API across different platforms and CAN
  * controller types, making the system extensible and maintainable.
- * 
+ *
  * Concrete implementations Examples:
  * - McuCan: For microcontrollers with built-in CAN peripherals (ESP32 TWAI, STM32 CAN, etc.)
  * - ExtCanCan: For external CAN controllers via SPI (MCP2515, etc.)
- * 
+ *
  * Features:
  * - Lazy initialization support (initialize on first use)
  * - Comprehensive error handling with detailed error codes
  * - Thread-safe operations (implementation dependent)
  * - Consistent API across different CAN hardware
- * 
+ *
  * @note This is a header-only abstract base class - instantiate concrete implementations instead.
  */
 class BaseCan {
 public:
-    /**
-     * @brief Constructor
-     */
-    BaseCan() noexcept : initialized_(false) {}
+  /**
+   * @brief Constructor
+   */
+  BaseCan() noexcept : initialized_(false) {}
 
-    /**
-     * @brief Virtual destructor ensures proper cleanup in derived classes.
-     */
-    virtual ~BaseCan() noexcept = default;
-    
-    // Non-copyable, non-movable (can be changed in derived classes if needed)
-    BaseCan(const BaseCan&) = delete;
-    BaseCan& operator=(const BaseCan&) = delete;
-    BaseCan(BaseCan&&) = delete;
-    BaseCan& operator=(BaseCan&&) = delete;
+  /**
+   * @brief Virtual destructor ensures proper cleanup in derived classes.
+   */
+  virtual ~BaseCan() noexcept = default;
 
-    /**
-     * @brief Ensures that the CAN bus is initialized (lazy initialization).
-     * @return true if the CAN bus is initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized_) {
-            initialized_ = Initialize();
-        }
-        return initialized_;
+  // Non-copyable, non-movable (can be changed in derived classes if needed)
+  BaseCan(const BaseCan &) = delete;
+  BaseCan &operator=(const BaseCan &) = delete;
+  BaseCan(BaseCan &&) = delete;
+  BaseCan &operator=(BaseCan &&) = delete;
+
+  /**
+   * @brief Ensures that the CAN bus is initialized (lazy initialization).
+   * @return true if the CAN bus is initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized_) {
+      initialized_ = Initialize();
+    }
+    return initialized_;
+  }
+
+  /**
+   * @brief Checks if the class is initialized.
+   * @return true if initialized, false otherwise
+   */
+  [[nodiscard]] bool IsInitialized() const noexcept {
+    return initialized_;
+  }
+
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
+  //==============================================//
+
+  /**
+   * @brief Initialize the CAN bus.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Initialize() noexcept = 0;
+
+  /**
+   * @brief Deinitialize the CAN bus.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Deinitialize() noexcept = 0;
+
+  /**
+   * @brief Send a CAN/CAN-FD message.
+   * @param message Message to send (supports both classic CAN and CAN-FD)
+   * @param timeout_ms Timeout in milliseconds (0 = no wait)
+   * @return true if sent successfully, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool SendMessage(const CanMessage &message, uint32_t timeout_ms = 1000) noexcept = 0;
+
+  /**
+   * @brief Receive a CAN/CAN-FD message.
+   * @param message Buffer to store received message
+   * @param timeout_ms Timeout in milliseconds (0 = no wait)
+   * @return true if received successfully, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool ReceiveMessage(CanMessage &message, uint32_t timeout_ms = 0) noexcept = 0;
+
+  // Backward compatibility methods
+  virtual bool SendMessage(const hf_can_message_t &message, uint32_t timeout_ms = 1000) noexcept {
+    return SendMessage(static_cast<const CanMessage &>(message), timeout_ms);
+  }
+
+  virtual bool ReceiveMessage(hf_can_message_t &message, uint32_t timeout_ms = 0) noexcept {
+    return ReceiveMessage(static_cast<CanMessage &>(message), timeout_ms);
+  }
+
+  /**
+   * @brief Set receive callback for interrupt-driven reception.
+   * @param callback Callback function to call when message is received
+   * @return true if callback set successfully, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool SetReceiveCallback(CanReceiveCallback callback) noexcept = 0;
+
+  /**
+   * @brief Set enhanced CAN-FD receive callback with additional information.
+   * @param callback Enhanced callback with reception information
+   * @return true if callback set successfully, false otherwise
+   * @note Default implementation falls back to standard callback
+   */
+  virtual bool SetReceiveCallbackFD(CanFdReceiveCallback callback) noexcept {
+    // Default implementation: convert to standard callback
+    if (!callback) {
+      return SetReceiveCallback(nullptr);
     }
 
-    /**
-     * @brief Checks if the class is initialized.
-     * @return true if initialized, false otherwise
-     */
-    [[nodiscard]] bool IsInitialized() const noexcept {
-        return initialized_;
-    }
-    
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
-    //==============================================//
-    
-    /**
-     * @brief Initialize the CAN bus.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Initialize() noexcept = 0;
-    
-    /**
-     * @brief Deinitialize the CAN bus.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Deinitialize() noexcept = 0;
-    
-    /**
-     * @brief Send a CAN/CAN-FD message.
-     * @param message Message to send (supports both classic CAN and CAN-FD)
-     * @param timeout_ms Timeout in milliseconds (0 = no wait)
-     * @return true if sent successfully, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool SendMessage(const CanMessage& message, uint32_t timeout_ms = 1000) noexcept = 0;
-    
-    /**
-     * @brief Receive a CAN/CAN-FD message.
-     * @param message Buffer to store received message
-     * @param timeout_ms Timeout in milliseconds (0 = no wait)
-     * @return true if received successfully, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool ReceiveMessage(CanMessage& message, uint32_t timeout_ms = 0) noexcept = 0;
-    
-    // Backward compatibility methods
-    virtual bool SendMessage(const hf_can_message_t& message, uint32_t timeout_ms = 1000) noexcept {
-        return SendMessage(static_cast<const CanMessage&>(message), timeout_ms);
-    }
-    
-    virtual bool ReceiveMessage(hf_can_message_t& message, uint32_t timeout_ms = 0) noexcept {
-        return ReceiveMessage(static_cast<CanMessage&>(message), timeout_ms);
-    }
-    
-    /**
-     * @brief Set receive callback for interrupt-driven reception.
-     * @param callback Callback function to call when message is received
-     * @return true if callback set successfully, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool SetReceiveCallback(CanReceiveCallback callback) noexcept = 0;
-    
-    /**
-     * @brief Set enhanced CAN-FD receive callback with additional information.
-     * @param callback Enhanced callback with reception information
-     * @return true if callback set successfully, false otherwise
-     * @note Default implementation falls back to standard callback
-     */
-    virtual bool SetReceiveCallbackFD(CanFdReceiveCallback callback) noexcept {
-        // Default implementation: convert to standard callback
-        if (!callback) {
-            return SetReceiveCallback(nullptr);
-        }
-        
-        auto standard_callback = [callback](const CanMessage& msg) {
-            CanReceptionInfo info{};  // Default/empty info
-            callback(msg, info);
-        };
-        
-        return SetReceiveCallback(standard_callback);
-    }
-    
-    /**
-     * @brief Clear the receive callback.
-     * @note Must be implemented by concrete classes.
-     */
-    virtual void ClearReceiveCallback() noexcept = 0;
-    
-    /**
-     * @brief Get current bus status including CAN-FD metrics.
-     * @param status Buffer to store status information
-     * @return true if status retrieved successfully, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool GetStatus(CanBusStatus& status) noexcept = 0;
-    
-    /**
-     * @brief Reset the CAN controller (clear errors, restart).
-     * @return true if reset successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Reset() noexcept = 0;
-    
-    /**
-     * @brief Set acceptance filter for incoming messages.
-     * @param id CAN ID to accept
-     * @param mask Acceptance mask (0 = don't care bits)
-     * @param extended true for extended frames, false for standard
-     * @return true if filter set successfully, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended = false) noexcept = 0;
-    
-    /**
-     * @brief Clear all acceptance filters (accept all messages).
-     * @return true if cleared successfully, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool ClearAcceptanceFilter() noexcept = 0;
+    auto standard_callback = [callback](const CanMessage &msg) {
+      CanReceptionInfo info{}; // Default/empty info
+      callback(msg, info);
+    };
 
-    //==============================================//
-    // CAN-FD SPECIFIC METHODS (OPTIONAL)          //
-    //==============================================//
-    
-    /**
-     * @brief Check if CAN-FD is supported by this implementation.
-     * @return true if CAN-FD is supported, false otherwise
-     * @note Default implementation returns false for backward compatibility
-     */
-    virtual bool SupportsCanFD() const noexcept {
-        return false;
+    return SetReceiveCallback(standard_callback);
+  }
+
+  /**
+   * @brief Clear the receive callback.
+   * @note Must be implemented by concrete classes.
+   */
+  virtual void ClearReceiveCallback() noexcept = 0;
+
+  /**
+   * @brief Get current bus status including CAN-FD metrics.
+   * @param status Buffer to store status information
+   * @return true if status retrieved successfully, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool GetStatus(CanBusStatus &status) noexcept = 0;
+
+  /**
+   * @brief Reset the CAN controller (clear errors, restart).
+   * @return true if reset successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Reset() noexcept = 0;
+
+  /**
+   * @brief Set acceptance filter for incoming messages.
+   * @param id CAN ID to accept
+   * @param mask Acceptance mask (0 = don't care bits)
+   * @param extended true for extended frames, false for standard
+   * @return true if filter set successfully, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended = false) noexcept = 0;
+
+  /**
+   * @brief Clear all acceptance filters (accept all messages).
+   * @return true if cleared successfully, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool ClearAcceptanceFilter() noexcept = 0;
+
+  //==============================================//
+  // CAN-FD SPECIFIC METHODS (OPTIONAL)          //
+  //==============================================//
+
+  /**
+   * @brief Check if CAN-FD is supported by this implementation.
+   * @return true if CAN-FD is supported, false otherwise
+   * @note Default implementation returns false for backward compatibility
+   */
+  virtual bool SupportsCanFD() const noexcept {
+    return false;
+  }
+
+  /**
+   * @brief Enable/disable CAN-FD mode.
+   * @param enable true to enable CAN-FD, false for classic CAN
+   * @param data_baudrate Data phase baudrate (for BRS)
+   * @param enable_brs Enable Bit Rate Switching
+   * @return true if mode set successfully, false otherwise
+   * @note Default implementation returns false (not supported)
+   */
+  virtual bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000,
+                            bool enable_brs = true) noexcept {
+    return false; // Not supported by default
+  }
+
+  /**
+   * @brief Configure CAN-FD timing parameters.
+   * @param nominal_prescaler Prescaler for nominal bit timing
+   * @param nominal_tseg1 Time segment 1 for nominal bit timing
+   * @param nominal_tseg2 Time segment 2 for nominal bit timing
+   * @param data_prescaler Prescaler for data bit timing
+   * @param data_tseg1 Time segment 1 for data bit timing
+   * @param data_tseg2 Time segment 2 for data bit timing
+   * @param sjw Synchronization jump width
+   * @return true if configuration successful, false otherwise
+   */
+  virtual bool ConfigureCanFDTiming(uint16_t nominal_prescaler, uint8_t nominal_tseg1,
+                                    uint8_t nominal_tseg2, uint16_t data_prescaler,
+                                    uint8_t data_tseg1, uint8_t data_tseg2,
+                                    uint8_t sjw = 1) noexcept {
+    return false; // Not supported by default
+  }
+
+  /**
+   * @brief Set Transmitter Delay Compensation for CAN-FD.
+   * @param tdc_offset Transmitter Delay Compensation Offset
+   * @param tdc_filter Transmitter Delay Compensation Filter
+   * @return true if TDC set successfully, false otherwise
+   */
+  virtual bool SetTransmitterDelayCompensation(uint8_t tdc_offset, uint8_t tdc_filter) noexcept {
+    return false; // Not supported by default
+  }
+
+  /**
+   * @brief Get CAN-FD specific capabilities and limits.
+   * @param max_data_bytes Maximum data bytes per frame
+   * @param max_nominal_baudrate Maximum nominal baudrate
+   * @param max_data_baudrate Maximum data baudrate
+   * @param supports_brs Supports Bit Rate Switching
+   * @param supports_esi Supports Error State Indicator
+   * @return true if capabilities retrieved successfully
+   */
+  virtual bool GetCanFDCapabilities(uint8_t &max_data_bytes, uint32_t &max_nominal_baudrate,
+                                    uint32_t &max_data_baudrate, bool &supports_brs,
+                                    bool &supports_esi) noexcept {
+    return false; // Not supported by default
+  }
+
+  /**
+   * @brief Send multiple CAN-FD messages in a batch for improved performance.
+   * @param messages Array of messages to send
+   * @param count Number of messages in array
+   * @param timeout_ms Timeout for the entire batch operation
+   * @return Number of messages successfully sent
+   */
+  virtual uint32_t SendMessageBatch(const CanMessage *messages, uint32_t count,
+                                    uint32_t timeout_ms = 1000) noexcept {
+    uint32_t sent_count = 0;
+    for (uint32_t i = 0; i < count; ++i) {
+      if (SendMessage(messages[i], timeout_ms)) {
+        sent_count++;
+      } else {
+        break; // Stop on first failure
+      }
     }
-    
-    /**
-     * @brief Enable/disable CAN-FD mode.
-     * @param enable true to enable CAN-FD, false for classic CAN
-     * @param data_baudrate Data phase baudrate (for BRS)
-     * @param enable_brs Enable Bit Rate Switching
-     * @return true if mode set successfully, false otherwise
-     * @note Default implementation returns false (not supported)
-     */
-    virtual bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000, bool enable_brs = true) noexcept {
-        return false;  // Not supported by default
+    return sent_count;
+  }
+
+  /**
+   * @brief Receive multiple CAN-FD messages in a batch.
+   * @param messages Array to store received messages
+   * @param max_count Maximum number of messages to receive
+   * @param timeout_ms Timeout for the batch operation
+   * @return Number of messages actually received
+   */
+  virtual uint32_t ReceiveMessageBatch(CanMessage *messages, uint32_t max_count,
+                                       uint32_t timeout_ms = 100) noexcept {
+    uint32_t received_count = 0;
+    for (uint32_t i = 0; i < max_count; ++i) {
+      if (ReceiveMessage(messages[i], timeout_ms)) {
+        received_count++;
+      } else {
+        break; // Stop on timeout or no more messages
+      }
     }
-    
-    /**
-     * @brief Configure CAN-FD timing parameters.
-     * @param nominal_prescaler Prescaler for nominal bit timing
-     * @param nominal_tseg1 Time segment 1 for nominal bit timing
-     * @param nominal_tseg2 Time segment 2 for nominal bit timing
-     * @param data_prescaler Prescaler for data bit timing
-     * @param data_tseg1 Time segment 1 for data bit timing
-     * @param data_tseg2 Time segment 2 for data bit timing
-     * @param sjw Synchronization jump width
-     * @return true if configuration successful, false otherwise
-     */
-    virtual bool ConfigureCanFDTiming(uint16_t nominal_prescaler, uint8_t nominal_tseg1, uint8_t nominal_tseg2,
-                                      uint16_t data_prescaler, uint8_t data_tseg1, uint8_t data_tseg2,
-                                      uint8_t sjw = 1) noexcept {
-        return false;  // Not supported by default
-    }
-    
-    /**
-     * @brief Set Transmitter Delay Compensation for CAN-FD.
-     * @param tdc_offset Transmitter Delay Compensation Offset
-     * @param tdc_filter Transmitter Delay Compensation Filter
-     * @return true if TDC set successfully, false otherwise
-     */
-    virtual bool SetTransmitterDelayCompensation(uint8_t tdc_offset, uint8_t tdc_filter) noexcept {
-        return false;  // Not supported by default
-    }
-    
-    /**
-     * @brief Get CAN-FD specific capabilities and limits.
-     * @param max_data_bytes Maximum data bytes per frame
-     * @param max_nominal_baudrate Maximum nominal baudrate
-     * @param max_data_baudrate Maximum data baudrate
-     * @param supports_brs Supports Bit Rate Switching
-     * @param supports_esi Supports Error State Indicator
-     * @return true if capabilities retrieved successfully
-     */
-    virtual bool GetCanFDCapabilities(uint8_t& max_data_bytes, uint32_t& max_nominal_baudrate,
-                                      uint32_t& max_data_baudrate, bool& supports_brs, bool& supports_esi) noexcept {
-        return false;  // Not supported by default
-    }
-    
-    /**
-     * @brief Send multiple CAN-FD messages in a batch for improved performance.
-     * @param messages Array of messages to send
-     * @param count Number of messages in array
-     * @param timeout_ms Timeout for the entire batch operation
-     * @return Number of messages successfully sent
-     */
-    virtual uint32_t SendMessageBatch(const CanMessage* messages, uint32_t count, uint32_t timeout_ms = 1000) noexcept {
-        uint32_t sent_count = 0;
-        for (uint32_t i = 0; i < count; ++i) {
-            if (SendMessage(messages[i], timeout_ms)) {
-                sent_count++;
-            } else {
-                break;  // Stop on first failure
-            }
-        }
-        return sent_count;
-    }
-    
-    /**
-     * @brief Receive multiple CAN-FD messages in a batch.
-     * @param messages Array to store received messages
-     * @param max_count Maximum number of messages to receive
-     * @param timeout_ms Timeout for the batch operation
-     * @return Number of messages actually received
-     */
-    virtual uint32_t ReceiveMessageBatch(CanMessage* messages, uint32_t max_count, uint32_t timeout_ms = 100) noexcept {
-        uint32_t received_count = 0;
-        for (uint32_t i = 0; i < max_count; ++i) {
-            if (ReceiveMessage(messages[i], timeout_ms)) {
-                received_count++;
-            } else {
-                break;  // Stop on timeout or no more messages
-            }
-        }
-        return received_count;
-    }
+    return received_count;
+  }
 
 protected:
-    bool initialized_;  ///< Initialization state
+  bool initialized_; ///< Initialization state
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASECAN_H_

--- a/inc/base/BaseGpio.h
+++ b/inc/base/BaseGpio.h
@@ -3,10 +3,10 @@
  * @brief Unified GPIO base class for all digital GPIO implementations.
  *
  * @details This file contains the declaration of the BaseGpio abstract class, which provides
- *          a comprehensive GPIO abstraction that serves as the base for all GPIO 
+ *          a comprehensive GPIO abstraction that serves as the base for all GPIO
  *          implementations in the HardFOC system. It supports dynamic mode switching,
  *          configurable polarity, pull resistors, interrupt handling, and works across
- *          different hardware platforms including MCU GPIOs, I2C GPIO expanders, 
+ *          different hardware platforms including MCU GPIOs, I2C GPIO expanders,
  *          SPI GPIO expanders, and other GPIO hardware.
  *
  * @note This class is not thread-safe. Use appropriate synchronization if
@@ -24,54 +24,54 @@
  * @details X-macro pattern for comprehensive error enumeration. Each entry contains:
  *          X(NAME, VALUE, DESCRIPTION)
  */
-#define HF_GPIO_ERR_LIST(X) \
-  /* Success codes */ \
-  X(GPIO_SUCCESS, 0, "Success") \
-  \
-  /* General errors */ \
-  X(GPIO_ERR_FAILURE, 1, "General failure") \
-  X(GPIO_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-  X(GPIO_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-  X(GPIO_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-  X(GPIO_ERR_NULL_POINTER, 5, "Null pointer") \
-  X(GPIO_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-  \
-  /* Pin errors */ \
-  X(GPIO_ERR_INVALID_PIN, 7, "Invalid pin") \
-  X(GPIO_ERR_PIN_NOT_FOUND, 8, "Pin not found") \
-  X(GPIO_ERR_PIN_NOT_CONFIGURED, 9, "Pin not configured") \
-  X(GPIO_ERR_PIN_ALREADY_REGISTERED, 10, "Pin already registered") \
-  X(GPIO_ERR_PIN_ACCESS_DENIED, 11, "Pin access denied") \
-  X(GPIO_ERR_PIN_BUSY, 12, "Pin busy") \
-  \
-  /* Hardware errors */ \
-  X(GPIO_ERR_HARDWARE_FAULT, 13, "Hardware fault") \
-  X(GPIO_ERR_COMMUNICATION_FAILURE, 14, "Communication failure") \
-  X(GPIO_ERR_DEVICE_NOT_RESPONDING, 15, "Device not responding") \
-  X(GPIO_ERR_TIMEOUT, 16, "Timeout") \
-  X(GPIO_ERR_VOLTAGE_OUT_OF_RANGE, 17, "Voltage out of range") \
-  \
-  /* Configuration errors */ \
-  X(GPIO_ERR_INVALID_CONFIGURATION, 18, "Invalid configuration") \
-  X(GPIO_ERR_UNSUPPORTED_OPERATION, 19, "Unsupported operation") \
-  X(GPIO_ERR_RESOURCE_BUSY, 20, "Resource busy") \
-  X(GPIO_ERR_RESOURCE_UNAVAILABLE, 21, "Resource unavailable") \
-  \
-  /* I/O errors */ \
-  X(GPIO_ERR_READ_FAILURE, 22, "Read failure") \
-  X(GPIO_ERR_WRITE_FAILURE, 23, "Write failure") \
-  X(GPIO_ERR_DIRECTION_MISMATCH, 24, "Direction mismatch") \
-  X(GPIO_ERR_PULL_RESISTOR_FAILURE, 25, "Pull resistor failure") \
-  \
-  /* Interrupt errors */ \
-  X(GPIO_ERR_INTERRUPT_NOT_SUPPORTED, 26, "Interrupt not supported") \
-  X(GPIO_ERR_INTERRUPT_ALREADY_ENABLED, 27, "Interrupt already enabled") \
-  X(GPIO_ERR_INTERRUPT_NOT_ENABLED, 28, "Interrupt not enabled") \
-  X(GPIO_ERR_INTERRUPT_HANDLER_FAILED, 29, "Interrupt handler failed") \
-  \
-  /* System errors */ \
-  X(GPIO_ERR_SYSTEM_ERROR, 30, "System error") \
-  X(GPIO_ERR_PERMISSION_DENIED, 31, "Permission denied") \
+#define HF_GPIO_ERR_LIST(X)                                                                        \
+  /* Success codes */                                                                              \
+  X(GPIO_SUCCESS, 0, "Success")                                                                    \
+                                                                                                   \
+  /* General errors */                                                                             \
+  X(GPIO_ERR_FAILURE, 1, "General failure")                                                        \
+  X(GPIO_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                \
+  X(GPIO_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                        \
+  X(GPIO_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                            \
+  X(GPIO_ERR_NULL_POINTER, 5, "Null pointer")                                                      \
+  X(GPIO_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                    \
+                                                                                                   \
+  /* Pin errors */                                                                                 \
+  X(GPIO_ERR_INVALID_PIN, 7, "Invalid pin")                                                        \
+  X(GPIO_ERR_PIN_NOT_FOUND, 8, "Pin not found")                                                    \
+  X(GPIO_ERR_PIN_NOT_CONFIGURED, 9, "Pin not configured")                                          \
+  X(GPIO_ERR_PIN_ALREADY_REGISTERED, 10, "Pin already registered")                                 \
+  X(GPIO_ERR_PIN_ACCESS_DENIED, 11, "Pin access denied")                                           \
+  X(GPIO_ERR_PIN_BUSY, 12, "Pin busy")                                                             \
+                                                                                                   \
+  /* Hardware errors */                                                                            \
+  X(GPIO_ERR_HARDWARE_FAULT, 13, "Hardware fault")                                                 \
+  X(GPIO_ERR_COMMUNICATION_FAILURE, 14, "Communication failure")                                   \
+  X(GPIO_ERR_DEVICE_NOT_RESPONDING, 15, "Device not responding")                                   \
+  X(GPIO_ERR_TIMEOUT, 16, "Timeout")                                                               \
+  X(GPIO_ERR_VOLTAGE_OUT_OF_RANGE, 17, "Voltage out of range")                                     \
+                                                                                                   \
+  /* Configuration errors */                                                                       \
+  X(GPIO_ERR_INVALID_CONFIGURATION, 18, "Invalid configuration")                                   \
+  X(GPIO_ERR_UNSUPPORTED_OPERATION, 19, "Unsupported operation")                                   \
+  X(GPIO_ERR_RESOURCE_BUSY, 20, "Resource busy")                                                   \
+  X(GPIO_ERR_RESOURCE_UNAVAILABLE, 21, "Resource unavailable")                                     \
+                                                                                                   \
+  /* I/O errors */                                                                                 \
+  X(GPIO_ERR_READ_FAILURE, 22, "Read failure")                                                     \
+  X(GPIO_ERR_WRITE_FAILURE, 23, "Write failure")                                                   \
+  X(GPIO_ERR_DIRECTION_MISMATCH, 24, "Direction mismatch")                                         \
+  X(GPIO_ERR_PULL_RESISTOR_FAILURE, 25, "Pull resistor failure")                                   \
+                                                                                                   \
+  /* Interrupt errors */                                                                           \
+  X(GPIO_ERR_INTERRUPT_NOT_SUPPORTED, 26, "Interrupt not supported")                               \
+  X(GPIO_ERR_INTERRUPT_ALREADY_ENABLED, 27, "Interrupt already enabled")                           \
+  X(GPIO_ERR_INTERRUPT_NOT_ENABLED, 28, "Interrupt not enabled")                                   \
+  X(GPIO_ERR_INTERRUPT_HANDLER_FAILED, 29, "Interrupt handler failed")                             \
+                                                                                                   \
+  /* System errors */                                                                              \
+  X(GPIO_ERR_SYSTEM_ERROR, 30, "System error")                                                     \
+  X(GPIO_ERR_PERMISSION_DENIED, 31, "Permission denied")                                           \
   X(GPIO_ERR_OPERATION_ABORTED, 32, "Operation aborted")
 
 /**
@@ -82,7 +82,7 @@ enum class HfGpioErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
   HF_GPIO_ERR_LIST(X)
 #undef X
-  GPIO_ERR_COUNT  // Automatically calculated count
+      GPIO_ERR_COUNT // Automatically calculated count
 };
 
 /**
@@ -90,12 +90,15 @@ enum class HfGpioErr : uint8_t {
  * @param err The error code to convert
  * @return Pointer to error description string
  */
-constexpr const char* HfGpioErrToString(HfGpioErr err) noexcept {
+constexpr const char *HfGpioErrToString(HfGpioErr err) noexcept {
   switch (err) {
-#define X(NAME, VALUE, DESC) case HfGpioErr::NAME: return DESC;
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfGpioErr::NAME:                                                                            \
+    return DESC;
     HF_GPIO_ERR_LIST(X)
 #undef X
-    default: return "Unknown error";
+  default:
+    return "Unknown error";
   }
 }
 
@@ -110,7 +113,7 @@ constexpr const char* HfGpioErrToString(HfGpioErr err) noexcept {
  *          - Push-pull and open-drain output modes
  *          - Comprehensive error handling and validation
  *          - Lazy initialization pattern
- *          
+ *
  *          Derived classes implement platform-specific details for:
  *          - MCU GPIOs (ESP32C6, STM32, etc.)
  *          - I2C GPIO expanders (PCAL95555, etc.)
@@ -124,8 +127,8 @@ public:
    * @details Represents the logical state of a GPIO pin, independent of electrical polarity.
    */
   enum class State : uint8_t {
-    Inactive = 0,    ///< Logical inactive state
-    Active = 1       ///< Logical active state
+    Inactive = 0, ///< Logical inactive state
+    Active = 1    ///< Logical active state
   };
 
   /**
@@ -133,8 +136,8 @@ public:
    * @details Defines which electrical level corresponds to the logical "active" state.
    */
   enum class ActiveState : uint8_t {
-    Low = 0,         ///< Active state is electrical low
-    High = 1         ///< Active state is electrical high
+    Low = 0, ///< Active state is electrical low
+    High = 1 ///< Active state is electrical high
   };
 
   /**
@@ -142,8 +145,8 @@ public:
    * @details Defines whether the pin is configured as input or output.
    */
   enum class Direction : uint8_t {
-    Input = 0,       ///< Pin configured as input
-    Output = 1       ///< Pin configured as output
+    Input = 0, ///< Pin configured as input
+    Output = 1 ///< Pin configured as output
   };
 
   /**
@@ -151,8 +154,8 @@ public:
    * @details Defines the electrical characteristics of GPIO output pins.
    */
   enum class OutputMode : uint8_t {
-    PushPull = 0,    ///< Push-pull output (strong high and low)
-    OpenDrain = 1    ///< Open-drain output (strong low, high-impedance high)
+    PushPull = 0, ///< Push-pull output (strong high and low)
+    OpenDrain = 1 ///< Open-drain output (strong low, high-impedance high)
   };
 
   /**
@@ -160,9 +163,9 @@ public:
    * @details Defines the internal pull resistor configuration for GPIO pins.
    */
   enum class PullMode : uint8_t {
-    Floating = 0,    ///< No pull resistor (floating/high-impedance)
-    PullUp = 1,      ///< Internal pull-up resistor enabled
-    PullDown = 2     ///< Internal pull-down resistor enabled
+    Floating = 0, ///< No pull resistor (floating/high-impedance)
+    PullUp = 1,   ///< Internal pull-up resistor enabled
+    PullDown = 2  ///< Internal pull-down resistor enabled
   };
 
   /**
@@ -185,22 +188,23 @@ public:
    * @param trigger The trigger type that caused the interrupt
    * @param user_data User-provided data passed to callback
    */
-  using InterruptCallback = std::function<void(BaseGpio* gpio, InterruptTrigger trigger, void* user_data)>;
+  using InterruptCallback =
+      std::function<void(BaseGpio *gpio, InterruptTrigger trigger, void *user_data)>;
 
   /**
    * @brief GPIO interrupt status structure.
    */
   struct InterruptStatus {
-    bool is_enabled;                ///< Interrupt currently enabled
-    InterruptTrigger trigger_type;  ///< Current trigger configuration
-    uint32_t interrupt_count;       ///< Number of interrupts occurred
-    bool has_callback;              ///< Callback function is registered
+    bool is_enabled;               ///< Interrupt currently enabled
+    InterruptTrigger trigger_type; ///< Current trigger configuration
+    uint32_t interrupt_count;      ///< Number of interrupts occurred
+    bool has_callback;             ///< Callback function is registered
   };
 
   //==============================================================//
   // CONSTRUCTORS AND DESTRUCTOR
   //==============================================================//
-  
+
   /**
    * @brief Constructor for BaseGpio with full configuration.
    * @param pin_num Platform-agnostic GPIO pin identifier
@@ -208,22 +212,16 @@ public:
    * @param active_state Polarity configuration (High or Low active)
    * @param output_mode Output drive mode (PushPull or OpenDrain)
    * @param pull_mode Pull resistor configuration (Floating, PullUp, or PullDown)
-   * @details Initializes the GPIO with specified configuration. The pin is not 
+   * @details Initializes the GPIO with specified configuration. The pin is not
    *          physically configured until Initialize() is called.
    */
-  explicit BaseGpio(HfPinNumber pin_num, 
-                    Direction direction = Direction::Input,
+  explicit BaseGpio(HfPinNumber pin_num, Direction direction = Direction::Input,
                     ActiveState active_state = ActiveState::High,
                     OutputMode output_mode = OutputMode::PushPull,
                     PullMode pull_mode = PullMode::Floating) noexcept
-      : pin_(pin_num)
-      , initialized_(false)
-      , current_direction_(direction)
-      , active_state_(active_state)
-      , output_mode_(output_mode)
-      , pull_mode_(pull_mode)
-      , current_state_(State::Inactive) {
-  }
+      : pin_(pin_num), initialized_(false), current_direction_(direction),
+        active_state_(active_state), output_mode_(output_mode), pull_mode_(pull_mode),
+        current_state_(State::Inactive) {}
 
   /**
    * @brief Copy constructor is deleted to avoid copying instances.
@@ -469,7 +467,7 @@ public:
    * @param is_active Reference to store the result
    * @return HfGpioErr error code
    */
-  HfGpioErr IsActive(bool& is_active) noexcept {
+  HfGpioErr IsActive(bool &is_active) noexcept {
     HfGpioErr validation = ValidateBasicOperation();
     if (validation != HfGpioErr::GPIO_SUCCESS) {
       return validation;
@@ -501,7 +499,7 @@ public:
    * @brief Get human-readable description of this GPIO instance.
    * @return Pointer to description string
    */
-  [[nodiscard]] virtual const char* GetDescription() const noexcept = 0;
+  [[nodiscard]] virtual const char *GetDescription() const noexcept = 0;
 
   //==============================================================//
   // INTERRUPT FUNCTIONALITY
@@ -526,9 +524,9 @@ public:
    * @details Sets up interrupt configuration but does not enable it.
    *          Call EnableInterrupt() to actually start interrupt generation.
    */
-  virtual HfGpioErr ConfigureInterrupt(InterruptTrigger trigger, 
-                                       InterruptCallback callback = nullptr, 
-                                       void* user_data = nullptr) noexcept {
+  virtual HfGpioErr ConfigureInterrupt(InterruptTrigger trigger,
+                                       InterruptCallback callback = nullptr,
+                                       void *user_data = nullptr) noexcept {
     return HfGpioErr::GPIO_ERR_INTERRUPT_NOT_SUPPORTED;
   }
 
@@ -567,7 +565,7 @@ public:
    * @param status Reference to store interrupt status
    * @return HfGpioErr::GPIO_SUCCESS if successful, error code otherwise
    */
-  virtual HfGpioErr GetInterruptStatus(InterruptStatus& status) noexcept {
+  virtual HfGpioErr GetInterruptStatus(InterruptStatus &status) noexcept {
     return HfGpioErr::GPIO_ERR_INTERRUPT_NOT_SUPPORTED;
   }
 
@@ -582,12 +580,12 @@ public:
   //==============================================================//
   // STRING CONVERSION UTILITIES
   //==============================================================//
-  static const char* ToString(State state) noexcept;
-  static const char* ToString(ActiveState active_state) noexcept;
-  static const char* ToString(Direction direction) noexcept;
-  static const char* ToString(OutputMode output_mode) noexcept;
-  static const char* ToString(PullMode pull_mode) noexcept;
-  static const char* ToString(InterruptTrigger trigger) noexcept;
+  static const char *ToString(State state) noexcept;
+  static const char *ToString(ActiveState active_state) noexcept;
+  static const char *ToString(Direction direction) noexcept;
+  static const char *ToString(OutputMode output_mode) noexcept;
+  static const char *ToString(PullMode pull_mode) noexcept;
+  static const char *ToString(InterruptTrigger trigger) noexcept;
 
   //==============================================================//
   // PURE VIRTUAL FUNCTIONS - MUST BE IMPLEMENTED BY DERIVED CLASSES
@@ -657,76 +655,99 @@ protected:
   virtual HfGpioErr SetActiveImpl() noexcept = 0;
   virtual HfGpioErr SetInactiveImpl() noexcept = 0;
   virtual HfGpioErr ToggleImpl() noexcept = 0;
-  virtual HfGpioErr IsActiveImpl(bool& is_active) noexcept = 0;
+  virtual HfGpioErr IsActiveImpl(bool &is_active) noexcept = 0;
 
 protected:
   //==============================================================//
   // MEMBER VARIABLES
   //==============================================================//
 
-  const HfPinNumber pin_;               ///< GPIO pin number/identifier
-  bool initialized_;                  ///< Initialization state flag
-  Direction current_direction_;       ///< Current pin direction
-  ActiveState active_state_;          ///< Active state polarity
-  OutputMode output_mode_;            ///< Output drive mode
-  PullMode pull_mode_;                ///< Pull resistor configuration
-  State current_state_;               ///< Current logical state
+  const HfPinNumber pin_;       ///< GPIO pin number/identifier
+  bool initialized_;            ///< Initialization state flag
+  Direction current_direction_; ///< Current pin direction
+  ActiveState active_state_;    ///< Active state polarity
+  OutputMode output_mode_;      ///< Output drive mode
+  PullMode pull_mode_;          ///< Pull resistor configuration
+  State current_state_;         ///< Current logical state
 };
 
 //==============================================================//
 // STRING CONVERSION IMPLEMENTATIONS
 //==============================================================//
 
-inline const char* BaseGpio::ToString(State state) noexcept {
+inline const char *BaseGpio::ToString(State state) noexcept {
   switch (state) {
-    case State::Active:   return "Active";
-    case State::Inactive: return "Inactive";
-    default:              return "Unknown";
+  case State::Active:
+    return "Active";
+  case State::Inactive:
+    return "Inactive";
+  default:
+    return "Unknown";
   }
 }
 
-inline const char* BaseGpio::ToString(ActiveState active_state) noexcept {
+inline const char *BaseGpio::ToString(ActiveState active_state) noexcept {
   switch (active_state) {
-    case ActiveState::High: return "ActiveHigh";
-    case ActiveState::Low:  return "ActiveLow";
-    default:                return "Unknown";
+  case ActiveState::High:
+    return "ActiveHigh";
+  case ActiveState::Low:
+    return "ActiveLow";
+  default:
+    return "Unknown";
   }
 }
 
-inline const char* BaseGpio::ToString(Direction direction) noexcept {
+inline const char *BaseGpio::ToString(Direction direction) noexcept {
   switch (direction) {
-    case Direction::Input:  return "Input";
-    case Direction::Output: return "Output";
-    default:                return "Unknown";
+  case Direction::Input:
+    return "Input";
+  case Direction::Output:
+    return "Output";
+  default:
+    return "Unknown";
   }
 }
 
-inline const char* BaseGpio::ToString(OutputMode output_mode) noexcept {
+inline const char *BaseGpio::ToString(OutputMode output_mode) noexcept {
   switch (output_mode) {
-    case OutputMode::PushPull:  return "PushPull";
-    case OutputMode::OpenDrain: return "OpenDrain";
-    default:                    return "Unknown";
+  case OutputMode::PushPull:
+    return "PushPull";
+  case OutputMode::OpenDrain:
+    return "OpenDrain";
+  default:
+    return "Unknown";
   }
 }
 
-inline const char* BaseGpio::ToString(PullMode pull_mode) noexcept {
+inline const char *BaseGpio::ToString(PullMode pull_mode) noexcept {
   switch (pull_mode) {
-    case PullMode::Floating: return "Floating";
-    case PullMode::PullUp:   return "PullUp";
-    case PullMode::PullDown: return "PullDown";
-    default:                 return "Unknown";
+  case PullMode::Floating:
+    return "Floating";
+  case PullMode::PullUp:
+    return "PullUp";
+  case PullMode::PullDown:
+    return "PullDown";
+  default:
+    return "Unknown";
   }
 }
 
-inline const char* BaseGpio::ToString(InterruptTrigger trigger) noexcept {
+inline const char *BaseGpio::ToString(InterruptTrigger trigger) noexcept {
   switch (trigger) {
-    case InterruptTrigger::None:        return "None";
-    case InterruptTrigger::RisingEdge:  return "RisingEdge";
-    case InterruptTrigger::FallingEdge: return "FallingEdge";
-    case InterruptTrigger::BothEdges:   return "BothEdges";
-    case InterruptTrigger::LowLevel:    return "LowLevel";
-    case InterruptTrigger::HighLevel:   return "HighLevel";
-    default:                            return "Unknown";
+  case InterruptTrigger::None:
+    return "None";
+  case InterruptTrigger::RisingEdge:
+    return "RisingEdge";
+  case InterruptTrigger::FallingEdge:
+    return "FallingEdge";
+  case InterruptTrigger::BothEdges:
+    return "BothEdges";
+  case InterruptTrigger::LowLevel:
+    return "LowLevel";
+  case InterruptTrigger::HighLevel:
+    return "HighLevel";
+  default:
+    return "Unknown";
   }
 }
 

--- a/inc/base/BaseI2c.h
+++ b/inc/base/BaseI2c.h
@@ -28,50 +28,50 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_I2C_ERR_LIST(X) \
-    /* Success codes */ \
-    X(I2C_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(I2C_ERR_FAILURE, 1, "General failure") \
-    X(I2C_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(I2C_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(I2C_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(I2C_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(I2C_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Bus errors */ \
-    X(I2C_ERR_BUS_BUSY, 7, "Bus busy") \
-    X(I2C_ERR_BUS_ERROR, 8, "Bus error") \
-    X(I2C_ERR_BUS_ARBITRATION_LOST, 9, "Arbitration lost") \
-    X(I2C_ERR_BUS_NOT_AVAILABLE, 10, "Bus not available") \
-    X(I2C_ERR_BUS_TIMEOUT, 11, "Bus timeout") \
-    /* Device errors */ \
-    X(I2C_ERR_DEVICE_NOT_FOUND, 12, "Device not found") \
-    X(I2C_ERR_DEVICE_NACK, 13, "Device NACK") \
-    X(I2C_ERR_DEVICE_NOT_RESPONDING, 14, "Device not responding") \
-    X(I2C_ERR_INVALID_ADDRESS, 15, "Invalid device address") \
-    /* Data errors */ \
-    X(I2C_ERR_DATA_TOO_LONG, 16, "Data too long") \
-    X(I2C_ERR_READ_FAILURE, 17, "Read failure") \
-    X(I2C_ERR_WRITE_FAILURE, 18, "Write failure") \
-    X(I2C_ERR_TIMEOUT, 19, "Operation timeout") \
-    /* Hardware errors */ \
-    X(I2C_ERR_HARDWARE_FAULT, 20, "Hardware fault") \
-    X(I2C_ERR_COMMUNICATION_FAILURE, 21, "Communication failure") \
-    X(I2C_ERR_VOLTAGE_OUT_OF_RANGE, 22, "Voltage out of range") \
-    X(I2C_ERR_CLOCK_STRETCH_TIMEOUT, 23, "Clock stretch timeout") \
-    /* Configuration errors */ \
-    X(I2C_ERR_INVALID_CONFIGURATION, 24, "Invalid configuration") \
-    X(I2C_ERR_UNSUPPORTED_OPERATION, 25, "Unsupported operation") \
-    X(I2C_ERR_INVALID_CLOCK_SPEED, 26, "Invalid clock speed") \
-    X(I2C_ERR_PIN_CONFIGURATION_ERROR, 27, "Pin configuration error") \
-    /* System errors */ \
-    X(I2C_ERR_SYSTEM_ERROR, 28, "System error") \
-    X(I2C_ERR_PERMISSION_DENIED, 29, "Permission denied") \
-    X(I2C_ERR_OPERATION_ABORTED, 30, "Operation aborted")
+#define HF_I2C_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(I2C_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(I2C_ERR_FAILURE, 1, "General failure")                                                         \
+  X(I2C_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(I2C_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(I2C_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(I2C_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(I2C_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Bus errors */                                                                                 \
+  X(I2C_ERR_BUS_BUSY, 7, "Bus busy")                                                               \
+  X(I2C_ERR_BUS_ERROR, 8, "Bus error")                                                             \
+  X(I2C_ERR_BUS_ARBITRATION_LOST, 9, "Arbitration lost")                                           \
+  X(I2C_ERR_BUS_NOT_AVAILABLE, 10, "Bus not available")                                            \
+  X(I2C_ERR_BUS_TIMEOUT, 11, "Bus timeout")                                                        \
+  /* Device errors */                                                                              \
+  X(I2C_ERR_DEVICE_NOT_FOUND, 12, "Device not found")                                              \
+  X(I2C_ERR_DEVICE_NACK, 13, "Device NACK")                                                        \
+  X(I2C_ERR_DEVICE_NOT_RESPONDING, 14, "Device not responding")                                    \
+  X(I2C_ERR_INVALID_ADDRESS, 15, "Invalid device address")                                         \
+  /* Data errors */                                                                                \
+  X(I2C_ERR_DATA_TOO_LONG, 16, "Data too long")                                                    \
+  X(I2C_ERR_READ_FAILURE, 17, "Read failure")                                                      \
+  X(I2C_ERR_WRITE_FAILURE, 18, "Write failure")                                                    \
+  X(I2C_ERR_TIMEOUT, 19, "Operation timeout")                                                      \
+  /* Hardware errors */                                                                            \
+  X(I2C_ERR_HARDWARE_FAULT, 20, "Hardware fault")                                                  \
+  X(I2C_ERR_COMMUNICATION_FAILURE, 21, "Communication failure")                                    \
+  X(I2C_ERR_VOLTAGE_OUT_OF_RANGE, 22, "Voltage out of range")                                      \
+  X(I2C_ERR_CLOCK_STRETCH_TIMEOUT, 23, "Clock stretch timeout")                                    \
+  /* Configuration errors */                                                                       \
+  X(I2C_ERR_INVALID_CONFIGURATION, 24, "Invalid configuration")                                    \
+  X(I2C_ERR_UNSUPPORTED_OPERATION, 25, "Unsupported operation")                                    \
+  X(I2C_ERR_INVALID_CLOCK_SPEED, 26, "Invalid clock speed")                                        \
+  X(I2C_ERR_PIN_CONFIGURATION_ERROR, 27, "Pin configuration error")                                \
+  /* System errors */                                                                              \
+  X(I2C_ERR_SYSTEM_ERROR, 28, "System error")                                                      \
+  X(I2C_ERR_PERMISSION_DENIED, 29, "Permission denied")                                            \
+  X(I2C_ERR_OPERATION_ABORTED, 30, "Operation aborted")
 
 enum class HfI2cErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
-    HF_I2C_ERR_LIST(X)
+  HF_I2C_ERR_LIST(X)
 #undef X
 };
 
@@ -81,12 +81,15 @@ enum class HfI2cErr : uint8_t {
  * @return String view of the error description
  */
 constexpr std::string_view HfI2cErrToString(HfI2cErr err) noexcept {
-    switch (err) {
-#define X(NAME, VALUE, DESC) case HfI2cErr::NAME: return DESC;
-        HF_I2C_ERR_LIST(X)
+  switch (err) {
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfI2cErr::NAME:                                                                             \
+    return DESC;
+    HF_I2C_ERR_LIST(X)
 #undef X
-        default: return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 //--------------------------------------
@@ -99,28 +102,23 @@ constexpr std::string_view HfI2cErrToString(HfI2cErr err) noexcept {
  *          supporting various platforms and I2C modes without MCU-specific types.
  */
 struct I2cBusConfig {
-    HfPortNumber port;                    ///< I2C port number
-    HfPinNumber sda_pin;                  ///< SDA pin number
-    HfPinNumber scl_pin;                  ///< SCL pin number
-    HfFrequencyHz clock_speed_hz;         ///< Clock speed in Hz (typically 100kHz or 400kHz)
-    bool enable_pullups;                ///< Enable internal pull-up resistors
-    HfTimeoutMs timeout_ms;               ///< Default timeout for operations in milliseconds
-    uint16_t tx_buffer_size;            ///< Transmit buffer size (0 = no buffer/blocking mode)
-    uint16_t rx_buffer_size;            ///< Receive buffer size (0 = no buffer/blocking mode)
-    
-    /**
-     * @brief Default constructor with sensible defaults.
-     */
-    I2cBusConfig() noexcept :
-        port(HF_INVALID_PORT),
-        sda_pin(HF_INVALID_PIN),
-        scl_pin(HF_INVALID_PIN),
-        clock_speed_hz(100000),  // 100kHz standard mode
-        enable_pullups(true),
-        timeout_ms(1000),
-        tx_buffer_size(0),       // Blocking mode by default
-        rx_buffer_size(0)
-    {}
+  HfPortNumber port;            ///< I2C port number
+  HfPinNumber sda_pin;          ///< SDA pin number
+  HfPinNumber scl_pin;          ///< SCL pin number
+  HfFrequencyHz clock_speed_hz; ///< Clock speed in Hz (typically 100kHz or 400kHz)
+  bool enable_pullups;          ///< Enable internal pull-up resistors
+  HfTimeoutMs timeout_ms;       ///< Default timeout for operations in milliseconds
+  uint16_t tx_buffer_size;      ///< Transmit buffer size (0 = no buffer/blocking mode)
+  uint16_t rx_buffer_size;      ///< Receive buffer size (0 = no buffer/blocking mode)
+
+  /**
+   * @brief Default constructor with sensible defaults.
+   */
+  I2cBusConfig() noexcept
+      : port(HF_INVALID_PORT), sda_pin(HF_INVALID_PIN), scl_pin(HF_INVALID_PIN),
+        clock_speed_hz(100000),                                    // 100kHz standard mode
+        enable_pullups(true), timeout_ms(1000), tx_buffer_size(0), // Blocking mode by default
+        rx_buffer_size(0) {}
 };
 
 //--------------------------------------
@@ -139,300 +137,303 @@ struct I2cBusConfig {
  *          - Device scanning and presence detection
  *          - Register-based communication utilities
  *          - Lazy initialization pattern
- *          
+ *
  *          Derived classes implement platform-specific details for:
  *          - MCU I2C controllers (ESP32, STM32, etc.)
  *          - Bit-banged I2C implementations
  *          - I2C bridge/adapter hardware
- * 
+ *
  * @note This is a header-only abstract base class - instantiate concrete implementations instead.
  * @note This class is not inherently thread-safe. Use appropriate synchronization if
  *       accessed from multiple contexts.
  */
 class BaseI2c {
 public:
-    /**
-     * @brief Constructor with configuration.
-     * @param config I2C bus configuration parameters
-     */
-    explicit BaseI2c(const I2cBusConfig& config) noexcept :
-        config_(config), initialized_(false) {}
+  /**
+   * @brief Constructor with configuration.
+   * @param config I2C bus configuration parameters
+   */
+  explicit BaseI2c(const I2cBusConfig &config) noexcept : config_(config), initialized_(false) {}
 
-    /**
-     * @brief Virtual destructor ensures proper cleanup in derived classes.
-     */
-    virtual ~BaseI2c() noexcept = default;
-    
-    // Non-copyable, non-movable (can be changed in derived classes if needed)
-    BaseI2c(const BaseI2c&) = delete;
-    BaseI2c& operator=(const BaseI2c&) = delete;
-    BaseI2c(BaseI2c&&) = delete;
-    BaseI2c& operator=(BaseI2c&&) = delete;
+  /**
+   * @brief Virtual destructor ensures proper cleanup in derived classes.
+   */
+  virtual ~BaseI2c() noexcept = default;
 
-    /**
-     * @brief Ensures that the I2C bus is initialized (lazy initialization).
-     * @return true if the I2C bus is initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized_) {
-            initialized_ = Initialize();
-        }
-        return initialized_;
+  // Non-copyable, non-movable (can be changed in derived classes if needed)
+  BaseI2c(const BaseI2c &) = delete;
+  BaseI2c &operator=(const BaseI2c &) = delete;
+  BaseI2c(BaseI2c &&) = delete;
+  BaseI2c &operator=(BaseI2c &&) = delete;
+
+  /**
+   * @brief Ensures that the I2C bus is initialized (lazy initialization).
+   * @return true if the I2C bus is initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized_) {
+      initialized_ = Initialize();
+    }
+    return initialized_;
+  }
+
+  /**
+   * @brief Checks if the bus is initialized.
+   * @return true if initialized, false otherwise
+   */
+  [[nodiscard]] bool IsInitialized() const noexcept {
+    return initialized_;
+  }
+
+  /**
+   * @brief Get the bus configuration.
+   * @return Reference to the current configuration
+   */
+  [[nodiscard]] const I2cBusConfig &GetConfig() const noexcept {
+    return config_;
+  }
+
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
+  //==============================================//
+
+  /**
+   * @brief Initialize the I2C bus.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Initialize() noexcept = 0;
+
+  /**
+   * @brief Deinitialize the I2C bus.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Deinitialize() noexcept = 0;
+
+  /**
+   * @brief Write data to a slave device.
+   * @param device_addr 7-bit device address
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfI2cErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfI2cErr Write(uint8_t device_addr, const uint8_t *data, uint16_t length,
+                         uint32_t timeout_ms = 0) noexcept = 0;
+
+  /**
+   * @brief Read data from a slave device.
+   * @param device_addr 7-bit device address
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfI2cErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfI2cErr Read(uint8_t device_addr, uint8_t *data, uint16_t length,
+                        uint32_t timeout_ms = 0) noexcept = 0;
+
+  /**
+   * @brief Write then read from a slave device without releasing the bus.
+   * @param device_addr 7-bit device address
+   * @param tx_data Data buffer to send
+   * @param tx_length Number of bytes to send
+   * @param rx_data Buffer to store received data
+   * @param rx_length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfI2cErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfI2cErr WriteRead(uint8_t device_addr, const uint8_t *tx_data, uint16_t tx_length,
+                             uint8_t *rx_data, uint16_t rx_length,
+                             uint32_t timeout_ms = 0) noexcept = 0;
+
+  //==============================================//
+  // CONVENIENCE METHODS WITH DEFAULT IMPLEMENTATIONS //
+  //==============================================//
+
+  /**
+   * @brief Legacy compatibility: Open and initialize the I2C port.
+   * @return true if open, false otherwise.
+   */
+  virtual bool Open() noexcept {
+    return EnsureInitialized();
+  }
+
+  /**
+   * @brief Legacy compatibility: Close and de-initialize the I2C port.
+   * @return true if closed, false otherwise.
+   */
+  virtual bool Close() noexcept {
+    if (initialized_) {
+      initialized_ = !Deinitialize();
+      return !initialized_;
+    }
+    return true;
+  }
+
+  /**
+   * @brief Legacy compatibility: Write with boolean return.
+   * @param addr 7-bit device address
+   * @param data Data buffer to transmit
+   * @param sizeBytes Number of bytes to write
+   * @param timeoutMsec Timeout in milliseconds
+   * @return true if transmission succeeded
+   */
+  virtual bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
+                     uint32_t timeoutMsec = 1000) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
+    }
+    return Write(addr, data, sizeBytes, timeoutMsec) == HfI2cErr::I2C_SUCCESS;
+  }
+
+  /**
+   * @brief Legacy compatibility: Read with boolean return.
+   * @param addr 7-bit device address
+   * @param data Buffer to store received data
+   * @param sizeBytes Number of bytes to read
+   * @param timeoutMsec Timeout in milliseconds
+   * @return true if read succeeded
+   */
+  virtual bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
+                    uint32_t timeoutMsec = 1000) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
+    }
+    return Read(addr, data, sizeBytes, timeoutMsec) == HfI2cErr::I2C_SUCCESS;
+  }
+
+  /**
+   * @brief Legacy compatibility: WriteRead with boolean return.
+   * @param addr 7-bit device address
+   * @param txData Data buffer to send
+   * @param txSizeBytes Number of bytes to send
+   * @param rxData Buffer to store received data
+   * @param rxSizeBytes Number of bytes to read
+   * @param timeoutMsec Timeout in milliseconds
+   * @return true if transaction succeeded
+   */
+  virtual bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes, uint8_t *rxData,
+                         uint16_t rxSizeBytes, uint32_t timeoutMsec = 1000) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
+    }
+    return WriteRead(addr, txData, txSizeBytes, rxData, rxSizeBytes, timeoutMsec) ==
+           HfI2cErr::I2C_SUCCESS;
+  }
+
+  /**
+   * @brief Get the configured clock speed.
+   * @return Clock speed in Hz
+   */
+  [[nodiscard]] virtual uint32_t GetClockHz() const noexcept {
+    return config_.clock_speed_hz;
+  }
+
+  /**
+   * @brief Check if a device is present at given address.
+   * @param device_addr 7-bit device address
+   * @return true if device responds, false otherwise
+   */
+  virtual bool IsDevicePresent(uint8_t device_addr) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
+    }
+    // Try to write 0 bytes to the device - this will generate only the address
+    return Write(device_addr, nullptr, 0) == HfI2cErr::I2C_SUCCESS;
+  }
+
+  /**
+   * @brief Scan for devices on the I2C bus.
+   * @param addresses Buffer to store found device addresses
+   * @param max_addresses Maximum number of addresses to find
+   * @return Number of devices found
+   */
+  virtual uint8_t ScanBus(uint8_t *addresses, uint8_t max_addresses) noexcept {
+    if (!EnsureInitialized() || !addresses || max_addresses == 0) {
+      return 0;
     }
 
-    /**
-     * @brief Checks if the bus is initialized.
-     * @return true if initialized, false otherwise
-     */
-    [[nodiscard]] bool IsInitialized() const noexcept {
-        return initialized_;
+    uint8_t found = 0;
+    // Scan 7-bit addresses from 0x08 to 0x77 (avoiding reserved addresses)
+    for (uint8_t addr = 0x08; addr <= 0x77 && found < max_addresses; ++addr) {
+      if (IsDevicePresent(addr)) {
+        addresses[found++] = addr;
+      }
     }
-    
-    /**
-     * @brief Get the bus configuration.
-     * @return Reference to the current configuration
-     */
-    [[nodiscard]] const I2cBusConfig& GetConfig() const noexcept {
-        return config_;
-    }
-    
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
-    //==============================================//
-    
-    /**
-     * @brief Initialize the I2C bus.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Initialize() noexcept = 0;
-    
-    /**
-     * @brief Deinitialize the I2C bus.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Deinitialize() noexcept = 0;
-    
-    /**
-     * @brief Write data to a slave device.
-     * @param device_addr 7-bit device address
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfI2cErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfI2cErr Write(uint8_t device_addr, const uint8_t* data, 
-                          uint16_t length, uint32_t timeout_ms = 0) noexcept = 0;
+    return found;
+  }
 
-    /**
-     * @brief Read data from a slave device.
-     * @param device_addr 7-bit device address
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfI2cErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfI2cErr Read(uint8_t device_addr, uint8_t* data, 
-                         uint16_t length, uint32_t timeout_ms = 0) noexcept = 0;
+  /**
+   * @brief Write single byte to device.
+   * @param device_addr 7-bit device address
+   * @param data Byte to write
+   * @return true if successful, false otherwise
+   */
+  virtual bool WriteByte(uint8_t device_addr, uint8_t data) noexcept {
+    return Write(device_addr, &data, 1) == HfI2cErr::I2C_SUCCESS;
+  }
 
-    /**
-     * @brief Write then read from a slave device without releasing the bus.
-     * @param device_addr 7-bit device address
-     * @param tx_data Data buffer to send
-     * @param tx_length Number of bytes to send
-     * @param rx_data Buffer to store received data
-     * @param rx_length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfI2cErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfI2cErr WriteRead(uint8_t device_addr, const uint8_t* tx_data, uint16_t tx_length,
-                              uint8_t* rx_data, uint16_t rx_length, uint32_t timeout_ms = 0) noexcept = 0;
-    
-    //==============================================//
-    // CONVENIENCE METHODS WITH DEFAULT IMPLEMENTATIONS //
-    //==============================================//
-    
-    /**
-     * @brief Legacy compatibility: Open and initialize the I2C port.
-     * @return true if open, false otherwise.
-     */
-    virtual bool Open() noexcept {
-        return EnsureInitialized();
-    }
+  /**
+   * @brief Read single byte from device.
+   * @param device_addr 7-bit device address
+   * @param data Output: byte read
+   * @return true if successful, false otherwise
+   */
+  virtual bool ReadByte(uint8_t device_addr, uint8_t &data) noexcept {
+    return Read(device_addr, &data, 1) == HfI2cErr::I2C_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: Close and de-initialize the I2C port.
-     * @return true if closed, false otherwise.
-     */
-    virtual bool Close() noexcept {
-        if (initialized_) {
-            initialized_ = !Deinitialize();
-            return !initialized_;
-        }
-        return true;
-    }
+  /**
+   * @brief Write to register (register address + data).
+   * @param device_addr 7-bit device address
+   * @param reg_addr Register address
+   * @param data Data to write
+   * @return true if successful, false otherwise
+   */
+  virtual bool WriteRegister(uint8_t device_addr, uint8_t reg_addr, uint8_t data) noexcept {
+    uint8_t buffer[2] = {reg_addr, data};
+    return Write(device_addr, buffer, 2) == HfI2cErr::I2C_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: Write with boolean return.
-     * @param addr 7-bit device address
-     * @param data Data buffer to transmit
-     * @param sizeBytes Number of bytes to write
-     * @param timeoutMsec Timeout in milliseconds
-     * @return true if transmission succeeded
-     */
-    virtual bool Write(uint8_t addr, const uint8_t *data, uint16_t sizeBytes,
-                      uint32_t timeoutMsec = 1000) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return Write(addr, data, sizeBytes, timeoutMsec) == HfI2cErr::I2C_SUCCESS;
-    }
+  /**
+   * @brief Read from register.
+   * @param device_addr 7-bit device address
+   * @param reg_addr Register address
+   * @param data Output: data read
+   * @return true if successful, false otherwise
+   */
+  virtual bool ReadRegister(uint8_t device_addr, uint8_t reg_addr, uint8_t &data) noexcept {
+    return WriteRead(device_addr, &reg_addr, 1, &data, 1) == HfI2cErr::I2C_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: Read with boolean return.
-     * @param addr 7-bit device address
-     * @param data Buffer to store received data
-     * @param sizeBytes Number of bytes to read
-     * @param timeoutMsec Timeout in milliseconds
-     * @return true if read succeeded
-     */
-    virtual bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes, uint32_t timeoutMsec = 1000) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return Read(addr, data, sizeBytes, timeoutMsec) == HfI2cErr::I2C_SUCCESS;
-    }
+  /**
+   * @brief Read multiple bytes from register.
+   * @param device_addr 7-bit device address
+   * @param reg_addr Register address
+   * @param data Buffer to store data
+   * @param length Number of bytes to read
+   * @return true if successful, false otherwise
+   */
+  virtual bool ReadRegisters(uint8_t device_addr, uint8_t reg_addr, uint8_t *data,
+                             uint16_t length) noexcept {
+    return WriteRead(device_addr, &reg_addr, 1, data, length) == HfI2cErr::I2C_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: WriteRead with boolean return.
-     * @param addr 7-bit device address
-     * @param txData Data buffer to send
-     * @param txSizeBytes Number of bytes to send
-     * @param rxData Buffer to store received data
-     * @param rxSizeBytes Number of bytes to read
-     * @param timeoutMsec Timeout in milliseconds
-     * @return true if transaction succeeded
-     */
-    virtual bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes, uint8_t *rxData,
-                          uint16_t rxSizeBytes, uint32_t timeoutMsec = 1000) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return WriteRead(addr, txData, txSizeBytes, rxData, rxSizeBytes, timeoutMsec) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Get the configured clock speed.
-     * @return Clock speed in Hz
-     */
-    [[nodiscard]] virtual uint32_t GetClockHz() const noexcept {
-        return config_.clock_speed_hz;
-    }
-
-    /**
-     * @brief Check if a device is present at given address.
-     * @param device_addr 7-bit device address
-     * @return true if device responds, false otherwise
-     */
-    virtual bool IsDevicePresent(uint8_t device_addr) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        // Try to write 0 bytes to the device - this will generate only the address
-        return Write(device_addr, nullptr, 0) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Scan for devices on the I2C bus.
-     * @param addresses Buffer to store found device addresses
-     * @param max_addresses Maximum number of addresses to find
-     * @return Number of devices found
-     */
-    virtual uint8_t ScanBus(uint8_t* addresses, uint8_t max_addresses) noexcept {
-        if (!EnsureInitialized() || !addresses || max_addresses == 0) {
-            return 0;
-        }
-        
-        uint8_t found = 0;
-        // Scan 7-bit addresses from 0x08 to 0x77 (avoiding reserved addresses)
-        for (uint8_t addr = 0x08; addr <= 0x77 && found < max_addresses; ++addr) {
-            if (IsDevicePresent(addr)) {
-                addresses[found++] = addr;
-            }
-        }
-        return found;
-    }
-
-    /**
-     * @brief Write single byte to device.
-     * @param device_addr 7-bit device address
-     * @param data Byte to write
-     * @return true if successful, false otherwise
-     */
-    virtual bool WriteByte(uint8_t device_addr, uint8_t data) noexcept {
-        return Write(device_addr, &data, 1) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Read single byte from device.
-     * @param device_addr 7-bit device address
-     * @param data Output: byte read
-     * @return true if successful, false otherwise
-     */
-    virtual bool ReadByte(uint8_t device_addr, uint8_t& data) noexcept {
-        return Read(device_addr, &data, 1) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Write to register (register address + data).
-     * @param device_addr 7-bit device address
-     * @param reg_addr Register address
-     * @param data Data to write
-     * @return true if successful, false otherwise
-     */
-    virtual bool WriteRegister(uint8_t device_addr, uint8_t reg_addr, uint8_t data) noexcept {
-        uint8_t buffer[2] = {reg_addr, data};
-        return Write(device_addr, buffer, 2) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Read from register.
-     * @param device_addr 7-bit device address
-     * @param reg_addr Register address
-     * @param data Output: data read
-     * @return true if successful, false otherwise
-     */
-    virtual bool ReadRegister(uint8_t device_addr, uint8_t reg_addr, uint8_t& data) noexcept {
-        return WriteRead(device_addr, &reg_addr, 1, &data, 1) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Read multiple bytes from register.
-     * @param device_addr 7-bit device address
-     * @param reg_addr Register address
-     * @param data Buffer to store data
-     * @param length Number of bytes to read
-     * @return true if successful, false otherwise
-     */
-    virtual bool ReadRegisters(uint8_t device_addr, uint8_t reg_addr, uint8_t* data, uint16_t length) noexcept {
-        return WriteRead(device_addr, &reg_addr, 1, data, length) == HfI2cErr::I2C_SUCCESS;
-    }
-
-    /**
-     * @brief Get port number.
-     * @return I2C port number
-     */
-    [[nodiscard]] virtual HfPortNumber GetPort() const noexcept { 
-        return config_.port; 
-    }
+  /**
+   * @brief Get port number.
+   * @return I2C port number
+   */
+  [[nodiscard]] virtual HfPortNumber GetPort() const noexcept {
+    return config_.port;
+  }
 
 protected:
-    I2cBusConfig config_;                ///< Bus configuration
-    bool initialized_;                   ///< Initialization state
+  I2cBusConfig config_; ///< Bus configuration
+  bool initialized_;    ///< Initialization state
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BaseI2c_H_

--- a/inc/base/BaseNvsStorage.h
+++ b/inc/base/BaseNvsStorage.h
@@ -4,7 +4,8 @@
  *
  * This header-only file defines the abstract base class for non-volatile storage
  * that provides a consistent API across different storage implementations.
- * Concrete implementations (like McuNvsStorage for ESP32 NVS, external EEPROM) inherit from this class.
+ * Concrete implementations (like McuNvsStorage for ESP32 NVS, external EEPROM) inherit from this
+ * class.
  *
  * @note This is a header-only abstract base class following the same pattern as BaseCan.
  * @note Users should program against this interface, not specific implementations.
@@ -27,41 +28,44 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_NVS_ERR_LIST(X) \
-    /* Success codes */ \
-    X(NVS_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(NVS_ERR_FAILURE, 1, "General failure") \
-    X(NVS_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(NVS_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(NVS_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(NVS_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(NVS_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Storage specific errors */ \
-    X(NVS_ERR_KEY_NOT_FOUND, 7, "Key not found") \
-    X(NVS_ERR_KEY_TOO_LONG, 8, "Key too long") \
-    X(NVS_ERR_VALUE_TOO_LARGE, 9, "Value too large") \
-    X(NVS_ERR_NAMESPACE_NOT_FOUND, 10, "Namespace not found") \
-    X(NVS_ERR_STORAGE_FULL, 11, "Storage full") \
-    X(NVS_ERR_INVALID_DATA, 12, "Invalid data") \
-    X(NVS_ERR_READ_ONLY, 13, "Read only mode") \
-    X(NVS_ERR_CORRUPTED, 14, "Data corrupted") \
+#define HF_NVS_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(NVS_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(NVS_ERR_FAILURE, 1, "General failure")                                                         \
+  X(NVS_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(NVS_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(NVS_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(NVS_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(NVS_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Storage specific errors */                                                                    \
+  X(NVS_ERR_KEY_NOT_FOUND, 7, "Key not found")                                                     \
+  X(NVS_ERR_KEY_TOO_LONG, 8, "Key too long")                                                       \
+  X(NVS_ERR_VALUE_TOO_LARGE, 9, "Value too large")                                                 \
+  X(NVS_ERR_NAMESPACE_NOT_FOUND, 10, "Namespace not found")                                        \
+  X(NVS_ERR_STORAGE_FULL, 11, "Storage full")                                                      \
+  X(NVS_ERR_INVALID_DATA, 12, "Invalid data")                                                      \
+  X(NVS_ERR_READ_ONLY, 13, "Read only mode")                                                       \
+  X(NVS_ERR_CORRUPTED, 14, "Data corrupted")
 
 // Generate enum class from X-macro
 enum class HfNvsErr : int32_t {
 #define X(name, value, desc) name = value,
-    HF_NVS_ERR_LIST(X)
+  HF_NVS_ERR_LIST(X)
 #undef X
 };
 
 // Generate error description function
-constexpr const char* HfNvsErrToString(HfNvsErr err) noexcept {
-    switch (err) {
-#define X(name, value, desc) case HfNvsErr::name: return desc;
-        HF_NVS_ERR_LIST(X)
+constexpr const char *HfNvsErrToString(HfNvsErr err) noexcept {
+  switch (err) {
+#define X(name, value, desc)                                                                       \
+  case HfNvsErr::name:                                                                             \
+    return desc;
+    HF_NVS_ERR_LIST(X)
 #undef X
-        default: return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 /**
@@ -84,165 +88,171 @@ constexpr const char* HfNvsErrToString(HfNvsErr err) noexcept {
  */
 class BaseNvsStorage {
 public:
-    /**
-     * @brief Constructor with namespace specification.
-     * @param namespace_name Name of the storage namespace
-     */
-    explicit BaseNvsStorage(const char* namespace_name) noexcept 
-        : namespace_name_(namespace_name), initialized_(false) {}
+  /**
+   * @brief Constructor with namespace specification.
+   * @param namespace_name Name of the storage namespace
+   */
+  explicit BaseNvsStorage(const char *namespace_name) noexcept
+      : namespace_name_(namespace_name), initialized_(false) {}
 
-    /**
-     * @brief Virtual destructor to ensure proper cleanup.
-     */
-    virtual ~BaseNvsStorage() noexcept = default;
+  /**
+   * @brief Virtual destructor to ensure proper cleanup.
+   */
+  virtual ~BaseNvsStorage() noexcept = default;
 
-    // Disable copy constructor and assignment operator for safety
-    BaseNvsStorage(const BaseNvsStorage&) = delete;
-    BaseNvsStorage& operator=(const BaseNvsStorage&) = delete;
+  // Disable copy constructor and assignment operator for safety
+  BaseNvsStorage(const BaseNvsStorage &) = delete;
+  BaseNvsStorage &operator=(const BaseNvsStorage &) = delete;
 
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS (MUST BE IMPLEMENTED) //
-    //==============================================//
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS (MUST BE IMPLEMENTED) //
+  //==============================================//
 
-    /**
-     * @brief Initialize the storage system and open the namespace.
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr Initialize() noexcept = 0;
+  /**
+   * @brief Initialize the storage system and open the namespace.
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr Initialize() noexcept = 0;
 
-    /**
-     * @brief Deinitialize the storage system and close the namespace.
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr Deinitialize() noexcept = 0;
+  /**
+   * @brief Deinitialize the storage system and close the namespace.
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr Deinitialize() noexcept = 0;
 
-    /**
-     * @brief Store a 32-bit unsigned integer value.
-     * @param key Storage key (null-terminated string)
-     * @param value Value to store
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr SetU32(const char* key, uint32_t value) noexcept = 0;
+  /**
+   * @brief Store a 32-bit unsigned integer value.
+   * @param key Storage key (null-terminated string)
+   * @param value Value to store
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr SetU32(const char *key, uint32_t value) noexcept = 0;
 
-    /**
-     * @brief Retrieve a 32-bit unsigned integer value.
-     * @param key Storage key (null-terminated string)
-     * @param value Reference to store the retrieved value
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr GetU32(const char* key, uint32_t& value) noexcept = 0;
+  /**
+   * @brief Retrieve a 32-bit unsigned integer value.
+   * @param key Storage key (null-terminated string)
+   * @param value Reference to store the retrieved value
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr GetU32(const char *key, uint32_t &value) noexcept = 0;
 
-    /**
-     * @brief Store a string value.
-     * @param key Storage key (null-terminated string)
-     * @param value String value to store
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr SetString(const char* key, const char* value) noexcept = 0;
+  /**
+   * @brief Store a string value.
+   * @param key Storage key (null-terminated string)
+   * @param value String value to store
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr SetString(const char *key, const char *value) noexcept = 0;
 
-    /**
-     * @brief Retrieve a string value.
-     * @param key Storage key (null-terminated string)
-     * @param buffer Buffer to store the retrieved string
-     * @param buffer_size Size of the buffer in bytes
-     * @param actual_size Actual size of the string (optional)
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr GetString(const char* key, char* buffer, size_t buffer_size, 
-                               size_t* actual_size = nullptr) noexcept = 0;
+  /**
+   * @brief Retrieve a string value.
+   * @param key Storage key (null-terminated string)
+   * @param buffer Buffer to store the retrieved string
+   * @param buffer_size Size of the buffer in bytes
+   * @param actual_size Actual size of the string (optional)
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr GetString(const char *key, char *buffer, size_t buffer_size,
+                             size_t *actual_size = nullptr) noexcept = 0;
 
-    /**
-     * @brief Store binary data (blob).
-     * @param key Storage key (null-terminated string)
-     * @param data Pointer to data to store
-     * @param data_size Size of data in bytes
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr SetBlob(const char* key, const void* data, size_t data_size) noexcept = 0;
+  /**
+   * @brief Store binary data (blob).
+   * @param key Storage key (null-terminated string)
+   * @param data Pointer to data to store
+   * @param data_size Size of data in bytes
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr SetBlob(const char *key, const void *data, size_t data_size) noexcept = 0;
 
-    /**
-     * @brief Retrieve binary data (blob).
-     * @param key Storage key (null-terminated string)
-     * @param buffer Buffer to store the retrieved data
-     * @param buffer_size Size of the buffer in bytes
-     * @param actual_size Actual size of the data (optional)
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr GetBlob(const char* key, void* buffer, size_t buffer_size,
-                             size_t* actual_size = nullptr) noexcept = 0;
+  /**
+   * @brief Retrieve binary data (blob).
+   * @param key Storage key (null-terminated string)
+   * @param buffer Buffer to store the retrieved data
+   * @param buffer_size Size of the buffer in bytes
+   * @param actual_size Actual size of the data (optional)
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr GetBlob(const char *key, void *buffer, size_t buffer_size,
+                           size_t *actual_size = nullptr) noexcept = 0;
 
-    /**
-     * @brief Remove a key from storage.
-     * @param key Storage key to remove
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr EraseKey(const char* key) noexcept = 0;
+  /**
+   * @brief Remove a key from storage.
+   * @param key Storage key to remove
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr EraseKey(const char *key) noexcept = 0;
 
-    /**
-     * @brief Commit any pending writes to non-volatile storage.
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr Commit() noexcept = 0;
+  /**
+   * @brief Commit any pending writes to non-volatile storage.
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr Commit() noexcept = 0;
 
-    /**
-     * @brief Check if a key exists in storage.
-     * @param key Storage key to check
-     * @return true if key exists, false otherwise
-     */
-    virtual bool KeyExists(const char* key) noexcept = 0;
+  /**
+   * @brief Check if a key exists in storage.
+   * @param key Storage key to check
+   * @return true if key exists, false otherwise
+   */
+  virtual bool KeyExists(const char *key) noexcept = 0;
 
-    /**
-     * @brief Get the size of a stored value.
-     * @param key Storage key
-     * @param size Reference to store the size
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    virtual HfNvsErr GetSize(const char* key, size_t& size) noexcept = 0;
+  /**
+   * @brief Get the size of a stored value.
+   * @param key Storage key
+   * @param size Reference to store the size
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  virtual HfNvsErr GetSize(const char *key, size_t &size) noexcept = 0;
 
-    //==============================================//
-    // PUBLIC INTERFACE (IMPLEMENTED)               //
-    //==============================================//
+  //==============================================//
+  // PUBLIC INTERFACE (IMPLEMENTED)               //
+  //==============================================//
 
-    /**
-     * @brief Check if storage is initialized.
-     * @return true if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept { return initialized_; }
+  /**
+   * @brief Check if storage is initialized.
+   * @return true if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept {
+    return initialized_;
+  }
 
-    /**
-     * @brief Get the namespace name.
-     * @return Namespace name string
-     */
-    const char* GetNamespace() const noexcept { return namespace_name_; }
+  /**
+   * @brief Get the namespace name.
+   * @return Namespace name string
+   */
+  const char *GetNamespace() const noexcept {
+    return namespace_name_;
+  }
 
-    /**
-     * @brief Get description of this storage implementation.
-     * @return Description string
-     */
-    virtual const char* GetDescription() const noexcept = 0;
+  /**
+   * @brief Get description of this storage implementation.
+   * @return Description string
+   */
+  virtual const char *GetDescription() const noexcept = 0;
 
-    /**
-     * @brief Get maximum key length supported.
-     * @return Maximum key length in characters
-     */
-    virtual size_t GetMaxKeyLength() const noexcept = 0;
+  /**
+   * @brief Get maximum key length supported.
+   * @return Maximum key length in characters
+   */
+  virtual size_t GetMaxKeyLength() const noexcept = 0;
 
-    /**
-     * @brief Get maximum value size supported.
-     * @return Maximum value size in bytes
-     */
-    virtual size_t GetMaxValueSize() const noexcept = 0;
+  /**
+   * @brief Get maximum value size supported.
+   * @return Maximum value size in bytes
+   */
+  virtual size_t GetMaxValueSize() const noexcept = 0;
 
 protected:
-    /**
-     * @brief Set the initialized state.
-     * @param initialized New initialization state
-     */
-    void SetInitialized(bool initialized) noexcept { initialized_ = initialized; }
+  /**
+   * @brief Set the initialized state.
+   * @param initialized New initialization state
+   */
+  void SetInitialized(bool initialized) noexcept {
+    initialized_ = initialized;
+  }
 
 private:
-    const char* namespace_name_;  ///< Storage namespace name
-    bool initialized_;            ///< Initialization state flag
+  const char *namespace_name_; ///< Storage namespace name
+  bool initialized_;           ///< Initialization state flag
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASENVSSTORAGE_H_

--- a/inc/base/BasePeriodicTimer.h
+++ b/inc/base/BasePeriodicTimer.h
@@ -4,7 +4,8 @@
  *
  * This header-only file defines the abstract base class for periodic timer functionality
  * that provides a consistent API across different timer implementations.
- * Concrete implementations (like McuPeriodicTimer for ESP32 timers, OS timers) inherit from this class.
+ * Concrete implementations (like McuPeriodicTimer for ESP32 timers, OS timers) inherit from this
+ * class.
  *
  * @note This is a header-only abstract base class following the same pattern as BaseCan.
  * @note Users should program against this interface, not specific implementations.
@@ -27,45 +28,48 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_TIMER_ERR_LIST(X) \
-    /* Success codes */ \
-    X(TIMER_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(TIMER_ERR_FAILURE, 1, "General failure") \
-    X(TIMER_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(TIMER_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(TIMER_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(TIMER_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(TIMER_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Timer specific errors */ \
-    X(TIMER_ERR_ALREADY_RUNNING, 7, "Timer already running") \
-    X(TIMER_ERR_NOT_RUNNING, 8, "Timer not running") \
-    X(TIMER_ERR_INVALID_PERIOD, 9, "Invalid period") \
-    X(TIMER_ERR_RESOURCE_BUSY, 10, "Timer resource busy") \
-    X(TIMER_ERR_HARDWARE_FAULT, 11, "Timer hardware fault") \
+#define HF_TIMER_ERR_LIST(X)                                                                       \
+  /* Success codes */                                                                              \
+  X(TIMER_SUCCESS, 0, "Success")                                                                   \
+  /* General errors */                                                                             \
+  X(TIMER_ERR_FAILURE, 1, "General failure")                                                       \
+  X(TIMER_ERR_NOT_INITIALIZED, 2, "Not initialized")                                               \
+  X(TIMER_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                       \
+  X(TIMER_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                           \
+  X(TIMER_ERR_NULL_POINTER, 5, "Null pointer")                                                     \
+  X(TIMER_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                   \
+  /* Timer specific errors */                                                                      \
+  X(TIMER_ERR_ALREADY_RUNNING, 7, "Timer already running")                                         \
+  X(TIMER_ERR_NOT_RUNNING, 8, "Timer not running")                                                 \
+  X(TIMER_ERR_INVALID_PERIOD, 9, "Invalid period")                                                 \
+  X(TIMER_ERR_RESOURCE_BUSY, 10, "Timer resource busy")                                            \
+  X(TIMER_ERR_HARDWARE_FAULT, 11, "Timer hardware fault")
 
 // Generate enum class from X-macro
 enum class HfTimerErr : int32_t {
 #define X(name, value, desc) name = value,
-    HF_TIMER_ERR_LIST(X)
+  HF_TIMER_ERR_LIST(X)
 #undef X
 };
 
 // Generate error description function
-constexpr const char* HfTimerErrToString(HfTimerErr err) noexcept {
-    switch (err) {
-#define X(name, value, desc) case HfTimerErr::name: return desc;
-        HF_TIMER_ERR_LIST(X)
+constexpr const char *HfTimerErrToString(HfTimerErr err) noexcept {
+  switch (err) {
+#define X(name, value, desc)                                                                       \
+  case HfTimerErr::name:                                                                           \
+    return desc;
+    HF_TIMER_ERR_LIST(X)
 #undef X
-        default: return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 /**
  * @brief Timer callback function type.
  * @param user_data User-provided data passed to callback
  */
-using TimerCallback = std::function<void(void* user_data)>;
+using TimerCallback = std::function<void(void *user_data)>;
 
 /**
  * @class BasePeriodicTimer
@@ -88,176 +92,188 @@ using TimerCallback = std::function<void(void* user_data)>;
  */
 class BasePeriodicTimer {
 public:
-    /**
-     * @brief Constructor with callback specification.
-     * @param callback Timer callback function
-     * @param user_data User data passed to callback
-     */
-    explicit BasePeriodicTimer(TimerCallback callback, void* user_data = nullptr) noexcept 
-        : callback_(callback), user_data_(user_data), initialized_(false), running_(false) {}
+  /**
+   * @brief Constructor with callback specification.
+   * @param callback Timer callback function
+   * @param user_data User data passed to callback
+   */
+  explicit BasePeriodicTimer(TimerCallback callback, void *user_data = nullptr) noexcept
+      : callback_(callback), user_data_(user_data), initialized_(false), running_(false) {}
 
-    /**
-     * @brief Virtual destructor to ensure proper cleanup.
-     */
-    virtual ~BasePeriodicTimer() noexcept = default;
+  /**
+   * @brief Virtual destructor to ensure proper cleanup.
+   */
+  virtual ~BasePeriodicTimer() noexcept = default;
 
-    // Disable copy constructor and assignment operator for safety
-    BasePeriodicTimer(const BasePeriodicTimer&) = delete;
-    BasePeriodicTimer& operator=(const BasePeriodicTimer&) = delete;
+  // Disable copy constructor and assignment operator for safety
+  BasePeriodicTimer(const BasePeriodicTimer &) = delete;
+  BasePeriodicTimer &operator=(const BasePeriodicTimer &) = delete;
 
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS (MUST BE IMPLEMENTED) //
-    //==============================================//
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS (MUST BE IMPLEMENTED) //
+  //==============================================//
 
-    /**
-     * @brief Initialize the timer hardware/resources.
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr Initialize() noexcept = 0;
+  /**
+   * @brief Initialize the timer hardware/resources.
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr Initialize() noexcept = 0;
 
-    /**
-     * @brief Deinitialize the timer and free resources.
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr Deinitialize() noexcept = 0;
+  /**
+   * @brief Deinitialize the timer and free resources.
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr Deinitialize() noexcept = 0;
 
-    /**
-     * @brief Start the periodic timer with specified period.
-     * @param period_us Timer period in microseconds
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr Start(uint64_t period_us) noexcept = 0;
+  /**
+   * @brief Start the periodic timer with specified period.
+   * @param period_us Timer period in microseconds
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr Start(uint64_t period_us) noexcept = 0;
 
-    /**
-     * @brief Stop the periodic timer.
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr Stop() noexcept = 0;
+  /**
+   * @brief Stop the periodic timer.
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr Stop() noexcept = 0;
 
-    /**
-     * @brief Change the timer period while running.
-     * @param period_us New timer period in microseconds
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr SetPeriod(uint64_t period_us) noexcept = 0;
+  /**
+   * @brief Change the timer period while running.
+   * @param period_us New timer period in microseconds
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr SetPeriod(uint64_t period_us) noexcept = 0;
 
-    /**
-     * @brief Get the current timer period.
-     * @param period_us Reference to store the current period
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr GetPeriod(uint64_t& period_us) noexcept = 0;
+  /**
+   * @brief Get the current timer period.
+   * @param period_us Reference to store the current period
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr GetPeriod(uint64_t &period_us) noexcept = 0;
 
-    /**
-     * @brief Get timer statistics and status information.
-     * @param callback_count Number of callbacks executed
-     * @param missed_callbacks Number of missed callbacks (if supported)
-     * @param last_error Last error that occurred
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr GetStats(uint64_t& callback_count, uint64_t& missed_callbacks,
-                                HfTimerErr& last_error) noexcept = 0;
+  /**
+   * @brief Get timer statistics and status information.
+   * @param callback_count Number of callbacks executed
+   * @param missed_callbacks Number of missed callbacks (if supported)
+   * @param last_error Last error that occurred
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr GetStats(uint64_t &callback_count, uint64_t &missed_callbacks,
+                              HfTimerErr &last_error) noexcept = 0;
 
-    /**
-     * @brief Reset timer statistics.
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    virtual HfTimerErr ResetStats() noexcept = 0;
+  /**
+   * @brief Reset timer statistics.
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  virtual HfTimerErr ResetStats() noexcept = 0;
 
-    //==============================================//
-    // PUBLIC INTERFACE (IMPLEMENTED)               //
-    //==============================================//
+  //==============================================//
+  // PUBLIC INTERFACE (IMPLEMENTED)               //
+  //==============================================//
 
-    /**
-     * @brief Check if timer is initialized.
-     * @return true if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept { return initialized_; }
+  /**
+   * @brief Check if timer is initialized.
+   * @return true if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept {
+    return initialized_;
+  }
 
-    /**
-     * @brief Check if timer is currently running.
-     * @return true if running, false otherwise
-     */
-    bool IsRunning() const noexcept { return running_; }
+  /**
+   * @brief Check if timer is currently running.
+   * @return true if running, false otherwise
+   */
+  bool IsRunning() const noexcept {
+    return running_;
+  }
 
-    /**
-     * @brief Get description of this timer implementation.
-     * @return Description string
-     */
-    virtual const char* GetDescription() const noexcept = 0;
+  /**
+   * @brief Get description of this timer implementation.
+   * @return Description string
+   */
+  virtual const char *GetDescription() const noexcept = 0;
 
-    /**
-     * @brief Get minimum supported timer period.
-     * @return Minimum period in microseconds
-     */
-    virtual uint64_t GetMinPeriod() const noexcept = 0;
+  /**
+   * @brief Get minimum supported timer period.
+   * @return Minimum period in microseconds
+   */
+  virtual uint64_t GetMinPeriod() const noexcept = 0;
 
-    /**
-     * @brief Get maximum supported timer period.
-     * @return Maximum period in microseconds
-     */
-    virtual uint64_t GetMaxPeriod() const noexcept = 0;
+  /**
+   * @brief Get maximum supported timer period.
+   * @return Maximum period in microseconds
+   */
+  virtual uint64_t GetMaxPeriod() const noexcept = 0;
 
-    /**
-     * @brief Get timer resolution.
-     * @return Timer resolution in microseconds
-     */
-    virtual uint64_t GetResolution() const noexcept = 0;
+  /**
+   * @brief Get timer resolution.
+   * @return Timer resolution in microseconds
+   */
+  virtual uint64_t GetResolution() const noexcept = 0;
 
-    /**
-     * @brief Set new callback function.
-     * @param callback New callback function
-     * @param user_data New user data
-     * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
-     */
-    HfTimerErr SetCallback(TimerCallback callback, void* user_data = nullptr) noexcept {
-        if (IsRunning()) {
-            return HfTimerErr::TIMER_ERR_ALREADY_RUNNING;
-        }
-        callback_ = callback;
-        user_data_ = user_data;
-        return HfTimerErr::TIMER_SUCCESS;
+  /**
+   * @brief Set new callback function.
+   * @param callback New callback function
+   * @param user_data New user data
+   * @return HfTimerErr::TIMER_SUCCESS if successful, error code otherwise
+   */
+  HfTimerErr SetCallback(TimerCallback callback, void *user_data = nullptr) noexcept {
+    if (IsRunning()) {
+      return HfTimerErr::TIMER_ERR_ALREADY_RUNNING;
     }
+    callback_ = callback;
+    user_data_ = user_data;
+    return HfTimerErr::TIMER_SUCCESS;
+  }
 
-    /**
-     * @brief Get current user data pointer.
-     * @return User data pointer
-     */
-    void* GetUserData() const noexcept { return user_data_; }
+  /**
+   * @brief Get current user data pointer.
+   * @return User data pointer
+   */
+  void *GetUserData() const noexcept {
+    return user_data_;
+  }
 
 protected:
-    /**
-     * @brief Set the initialized state.
-     * @param initialized New initialization state
-     */
-    void SetInitialized(bool initialized) noexcept { initialized_ = initialized; }
+  /**
+   * @brief Set the initialized state.
+   * @param initialized New initialization state
+   */
+  void SetInitialized(bool initialized) noexcept {
+    initialized_ = initialized;
+  }
 
-    /**
-     * @brief Set the running state.
-     * @param running New running state
-     */
-    void SetRunning(bool running) noexcept { running_ = running; }
+  /**
+   * @brief Set the running state.
+   * @param running New running state
+   */
+  void SetRunning(bool running) noexcept {
+    running_ = running;
+  }
 
-    /**
-     * @brief Execute the timer callback (called by implementations).
-     */
-    void ExecuteCallback() noexcept {
-        if (callback_) {
-            callback_(user_data_);
-        }
+  /**
+   * @brief Execute the timer callback (called by implementations).
+   */
+  void ExecuteCallback() noexcept {
+    if (callback_) {
+      callback_(user_data_);
     }
+  }
 
-    /**
-     * @brief Check if callback is valid.
-     * @return true if callback is set, false otherwise
-     */
-    bool HasValidCallback() const noexcept { return static_cast<bool>(callback_); }
+  /**
+   * @brief Check if callback is valid.
+   * @return true if callback is set, false otherwise
+   */
+  bool HasValidCallback() const noexcept {
+    return static_cast<bool>(callback_);
+  }
 
 private:
-    TimerCallback callback_;  ///< Timer callback function
-    void* user_data_;         ///< User data passed to callback
-    bool initialized_;        ///< Initialization state flag
-    bool running_;            ///< Running state flag
+  TimerCallback callback_; ///< Timer callback function
+  void *user_data_;        ///< User data passed to callback
+  bool initialized_;       ///< Initialization state flag
+  bool running_;           ///< Running state flag
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASEPERIODICTIMER_H_

--- a/inc/base/BasePio.h
+++ b/inc/base/BasePio.h
@@ -1,12 +1,14 @@
 /**
  * @file BasePio.h
  * @brief Abstract base class for Programmable IO Channel implementations in the HardFOC system.
- * 
+ *
  * This header defines the abstract base class for precise, buffered digital signal I/O
  * that provides a consistent API across different PIO implementations.
- * Concrete implementations (like McuPio for ESP32 RMT, RP2040 PIO, STM32 TIM+DMA) inherit from this class.
- * 
- * @note This is a header-only abstract base class following the same pattern as BaseCan/BaseAdc/BasePwm.
+ * Concrete implementations (like McuPio for ESP32 RMT, RP2040 PIO, STM32 TIM+DMA) inherit from this
+ * class.
+ *
+ * @note This is a header-only abstract base class following the same pattern as
+ * BaseCan/BaseAdc/BasePwm.
  * @note Users should program against this interface, not specific implementations.
  */
 
@@ -28,50 +30,50 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_PIO_ERR_LIST(X) \
-    /* Success codes */ \
-    X(PIO_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(PIO_ERR_FAILURE, 1, "General failure") \
-    X(PIO_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(PIO_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(PIO_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(PIO_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(PIO_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Channel errors */ \
-    X(PIO_ERR_INVALID_CHANNEL, 7, "Invalid PIO channel") \
-    X(PIO_ERR_CHANNEL_BUSY, 8, "Channel already in use") \
-    X(PIO_ERR_CHANNEL_NOT_AVAILABLE, 9, "Channel not available") \
-    X(PIO_ERR_INSUFFICIENT_CHANNELS, 10, "Insufficient channels available") \
-    /* Timing errors */ \
-    X(PIO_ERR_INVALID_RESOLUTION, 11, "Invalid time resolution") \
-    X(PIO_ERR_RESOLUTION_TOO_HIGH, 12, "Time resolution too high") \
-    X(PIO_ERR_RESOLUTION_TOO_LOW, 13, "Time resolution too low") \
-    X(PIO_ERR_DURATION_TOO_LONG, 14, "Duration too long") \
-    X(PIO_ERR_DURATION_TOO_SHORT, 15, "Duration too short") \
-    /* Buffer errors */ \
-    X(PIO_ERR_BUFFER_OVERFLOW, 16, "Buffer overflow") \
-    X(PIO_ERR_BUFFER_UNDERFLOW, 17, "Buffer underflow") \
-    X(PIO_ERR_BUFFER_TOO_SMALL, 18, "Buffer too small") \
-    X(PIO_ERR_BUFFER_TOO_LARGE, 19, "Buffer too large") \
-    /* Hardware errors */ \
-    X(PIO_ERR_HARDWARE_FAULT, 20, "Hardware fault") \
-    X(PIO_ERR_COMMUNICATION_TIMEOUT, 21, "Communication timeout") \
-    X(PIO_ERR_COMMUNICATION_FAILURE, 22, "Communication failure") \
-    X(PIO_ERR_DEVICE_NOT_RESPONDING, 23, "Device not responding") \
-    /* Configuration errors */ \
-    X(PIO_ERR_INVALID_CONFIGURATION, 24, "Invalid configuration") \
-    X(PIO_ERR_UNSUPPORTED_OPERATION, 25, "Unsupported operation") \
-    X(PIO_ERR_PIN_CONFLICT, 26, "Pin already in use") \
-    X(PIO_ERR_RESOURCE_BUSY, 27, "Resource busy") \
-    /* System errors */ \
-    X(PIO_ERR_SYSTEM_ERROR, 28, "System error") \
-    X(PIO_ERR_PERMISSION_DENIED, 29, "Permission denied") \
-    X(PIO_ERR_OPERATION_ABORTED, 30, "Operation aborted")
+#define HF_PIO_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(PIO_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(PIO_ERR_FAILURE, 1, "General failure")                                                         \
+  X(PIO_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(PIO_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(PIO_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(PIO_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(PIO_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Channel errors */                                                                             \
+  X(PIO_ERR_INVALID_CHANNEL, 7, "Invalid PIO channel")                                             \
+  X(PIO_ERR_CHANNEL_BUSY, 8, "Channel already in use")                                             \
+  X(PIO_ERR_CHANNEL_NOT_AVAILABLE, 9, "Channel not available")                                     \
+  X(PIO_ERR_INSUFFICIENT_CHANNELS, 10, "Insufficient channels available")                          \
+  /* Timing errors */                                                                              \
+  X(PIO_ERR_INVALID_RESOLUTION, 11, "Invalid time resolution")                                     \
+  X(PIO_ERR_RESOLUTION_TOO_HIGH, 12, "Time resolution too high")                                   \
+  X(PIO_ERR_RESOLUTION_TOO_LOW, 13, "Time resolution too low")                                     \
+  X(PIO_ERR_DURATION_TOO_LONG, 14, "Duration too long")                                            \
+  X(PIO_ERR_DURATION_TOO_SHORT, 15, "Duration too short")                                          \
+  /* Buffer errors */                                                                              \
+  X(PIO_ERR_BUFFER_OVERFLOW, 16, "Buffer overflow")                                                \
+  X(PIO_ERR_BUFFER_UNDERFLOW, 17, "Buffer underflow")                                              \
+  X(PIO_ERR_BUFFER_TOO_SMALL, 18, "Buffer too small")                                              \
+  X(PIO_ERR_BUFFER_TOO_LARGE, 19, "Buffer too large")                                              \
+  /* Hardware errors */                                                                            \
+  X(PIO_ERR_HARDWARE_FAULT, 20, "Hardware fault")                                                  \
+  X(PIO_ERR_COMMUNICATION_TIMEOUT, 21, "Communication timeout")                                    \
+  X(PIO_ERR_COMMUNICATION_FAILURE, 22, "Communication failure")                                    \
+  X(PIO_ERR_DEVICE_NOT_RESPONDING, 23, "Device not responding")                                    \
+  /* Configuration errors */                                                                       \
+  X(PIO_ERR_INVALID_CONFIGURATION, 24, "Invalid configuration")                                    \
+  X(PIO_ERR_UNSUPPORTED_OPERATION, 25, "Unsupported operation")                                    \
+  X(PIO_ERR_PIN_CONFLICT, 26, "Pin already in use")                                                \
+  X(PIO_ERR_RESOURCE_BUSY, 27, "Resource busy")                                                    \
+  /* System errors */                                                                              \
+  X(PIO_ERR_SYSTEM_ERROR, 28, "System error")                                                      \
+  X(PIO_ERR_PERMISSION_DENIED, 29, "Permission denied")                                            \
+  X(PIO_ERR_OPERATION_ABORTED, 30, "Operation aborted")
 
 enum class HfPioErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
-    HF_PIO_ERR_LIST(X)
+  HF_PIO_ERR_LIST(X)
 #undef X
 };
 
@@ -81,15 +83,15 @@ enum class HfPioErr : uint8_t {
  * @return String view of the error description
  */
 constexpr std::string_view HfPioErrToString(HfPioErr err) noexcept {
-    switch (err) {
-#define X(NAME, VALUE, DESC) \
-    case HfPioErr::NAME: \
-        return DESC;
-        HF_PIO_ERR_LIST(X)
+  switch (err) {
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfPioErr::NAME:                                                                             \
+    return DESC;
+    HF_PIO_ERR_LIST(X)
 #undef X
-    default:
-        return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 //--------------------------------------
@@ -100,83 +102,82 @@ constexpr std::string_view HfPioErrToString(HfPioErr err) noexcept {
  * @brief PIO channel direction
  */
 enum class PioDirection : uint8_t {
-    Transmit = 0,     ///< Transmit mode (output)
-    Receive = 1,      ///< Receive mode (input)
-    Bidirectional = 2 ///< Bidirectional mode (if supported)
+  Transmit = 0,     ///< Transmit mode (output)
+  Receive = 1,      ///< Receive mode (input)
+  Bidirectional = 2 ///< Bidirectional mode (if supported)
 };
 
 /**
  * @brief PIO signal polarity
  */
 enum class PioPolarity : uint8_t {
-    Normal = 0,       ///< Normal polarity (idle low, active high)
-    Inverted = 1      ///< Inverted polarity (idle high, active low)
+  Normal = 0,  ///< Normal polarity (idle low, active high)
+  Inverted = 1 ///< Inverted polarity (idle high, active low)
 };
 
 /**
  * @brief PIO idle state
  */
 enum class PioIdleState : uint8_t {
-    Low = 0,          ///< Idle state is low
-    High = 1          ///< Idle state is high
+  Low = 0, ///< Idle state is low
+  High = 1 ///< Idle state is high
 };
 
 /**
  * @brief PIO channel configuration structure
  */
 struct PioChannelConfig {
-    HfPinNumber gpio_pin;               ///< GPIO pin for PIO signal
-    PioDirection direction;           ///< Channel direction
-    uint32_t resolution_ns;           ///< Time resolution in nanoseconds
-    PioPolarity polarity;             ///< Signal polarity
-    PioIdleState idle_state;          ///< Idle state
-    uint32_t timeout_us;              ///< Operation timeout in microseconds
-    size_t buffer_size;               ///< Buffer size for symbols/durations
-    
-    PioChannelConfig() noexcept
-        : gpio_pin(-1), direction(PioDirection::Transmit)
-        , resolution_ns(1000), polarity(PioPolarity::Normal)
-        , idle_state(PioIdleState::Low), timeout_us(10000)
-        , buffer_size(64) {}
+  HfPinNumber gpio_pin;    ///< GPIO pin for PIO signal
+  PioDirection direction;  ///< Channel direction
+  uint32_t resolution_ns;  ///< Time resolution in nanoseconds
+  PioPolarity polarity;    ///< Signal polarity
+  PioIdleState idle_state; ///< Idle state
+  uint32_t timeout_us;     ///< Operation timeout in microseconds
+  size_t buffer_size;      ///< Buffer size for symbols/durations
+
+  PioChannelConfig() noexcept
+      : gpio_pin(-1), direction(PioDirection::Transmit), resolution_ns(1000),
+        polarity(PioPolarity::Normal), idle_state(PioIdleState::Low), timeout_us(10000),
+        buffer_size(64) {}
 };
 
 /**
  * @brief PIO symbol structure for precise timing
  */
 struct PioSymbol {
-    uint32_t duration;                ///< Duration in resolution units
-    bool level;                       ///< Signal level (true = high, false = low)
-    
-    PioSymbol() noexcept : duration(0), level(false) {}
-    PioSymbol(uint32_t dur, bool lvl) noexcept : duration(dur), level(lvl) {}
+  uint32_t duration; ///< Duration in resolution units
+  bool level;        ///< Signal level (true = high, false = low)
+
+  PioSymbol() noexcept : duration(0), level(false) {}
+  PioSymbol(uint32_t dur, bool lvl) noexcept : duration(dur), level(lvl) {}
 };
 
 /**
  * @brief PIO channel status information
  */
 struct PioChannelStatus {
-    bool is_initialized;              ///< Channel is initialized
-    bool is_busy;                     ///< Channel is currently busy
-    bool is_transmitting;             ///< Channel is transmitting
-    bool is_receiving;                ///< Channel is receiving
-    size_t symbols_queued;            ///< Number of symbols in queue
-    size_t symbols_processed;         ///< Number of symbols processed
-    HfPioErr last_error;              ///< Last error that occurred
-    uint32_t timestamp_us;            ///< Timestamp of last operation
+  bool is_initialized;      ///< Channel is initialized
+  bool is_busy;             ///< Channel is currently busy
+  bool is_transmitting;     ///< Channel is transmitting
+  bool is_receiving;        ///< Channel is receiving
+  size_t symbols_queued;    ///< Number of symbols in queue
+  size_t symbols_processed; ///< Number of symbols processed
+  HfPioErr last_error;      ///< Last error that occurred
+  uint32_t timestamp_us;    ///< Timestamp of last operation
 };
 
 /**
  * @brief PIO capability information
  */
 struct PioCapabilities {
-    uint8_t max_channels;             ///< Maximum number of channels
-    uint32_t min_resolution_ns;       ///< Minimum time resolution
-    uint32_t max_resolution_ns;       ///< Maximum time resolution
-    uint32_t max_duration;            ///< Maximum single duration
-    size_t max_buffer_size;           ///< Maximum buffer size
-    bool supports_bidirectional;     ///< Supports bidirectional mode
-    bool supports_loopback;           ///< Supports loopback mode
-    bool supports_carrier;            ///< Supports carrier modulation
+  uint8_t max_channels;        ///< Maximum number of channels
+  uint32_t min_resolution_ns;  ///< Minimum time resolution
+  uint32_t max_resolution_ns;  ///< Maximum time resolution
+  uint32_t max_duration;       ///< Maximum single duration
+  size_t max_buffer_size;      ///< Maximum buffer size
+  bool supports_bidirectional; ///< Supports bidirectional mode
+  bool supports_loopback;      ///< Supports loopback mode
+  bool supports_carrier;       ///< Supports carrier modulation
 };
 
 //--------------------------------------
@@ -189,7 +190,8 @@ struct PioCapabilities {
  * @param symbols_sent Number of symbols transmitted
  * @param user_data User-provided data
  */
-using PioTransmitCallback = std::function<void(uint8_t channel_id, size_t symbols_sent, void* user_data)>;
+using PioTransmitCallback =
+    std::function<void(uint8_t channel_id, size_t symbols_sent, void *user_data)>;
 
 /**
  * @brief Callback for PIO reception complete events
@@ -198,7 +200,8 @@ using PioTransmitCallback = std::function<void(uint8_t channel_id, size_t symbol
  * @param symbol_count Number of symbols received
  * @param user_data User-provided data
  */
-using PioReceiveCallback = std::function<void(uint8_t channel_id, const PioSymbol* symbols, size_t symbol_count, void* user_data)>;
+using PioReceiveCallback = std::function<void(uint8_t channel_id, const PioSymbol *symbols,
+                                              size_t symbol_count, void *user_data)>;
 
 /**
  * @brief Callback for PIO error events
@@ -206,7 +209,7 @@ using PioReceiveCallback = std::function<void(uint8_t channel_id, const PioSymbo
  * @param error Error that occurred
  * @param user_data User-provided data
  */
-using PioErrorCallback = std::function<void(uint8_t channel_id, HfPioErr error, void* user_data)>;
+using PioErrorCallback = std::function<void(uint8_t channel_id, HfPioErr error, void *user_data)>;
 
 //--------------------------------------
 //  Abstract Base Class
@@ -215,17 +218,17 @@ using PioErrorCallback = std::function<void(uint8_t channel_id, HfPioErr error, 
 /**
  * @class BasePio
  * @brief Abstract base class for Programmable IO Channel implementations.
- * 
+ *
  * This class defines the interface for precise, buffered digital signal I/O
  * that can handle timing-critical operations like WS2812 LED driving,
  * IR communication, stepper motor control, and custom protocols.
- * 
+ *
  * The abstraction is designed to work with various hardware backends:
  * - ESP32: RMT (Remote Control Transceiver) peripheral
  * - RP2040: PIO (Programmable I/O) state machines
  * - STM32: Timer + DMA + GPIO combinations
  * - Generic: Software-based implementations
- * 
+ *
  * Key features:
  * - Precise timing control down to nanosecond resolution
  * - Buffered symbol transmission and reception
@@ -235,133 +238,139 @@ using PioErrorCallback = std::function<void(uint8_t channel_id, HfPioErr error, 
  */
 class BasePio {
 public:
-    /**
-     * @brief Virtual destructor
-     */
-    virtual ~BasePio() noexcept = default;
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~BasePio() noexcept = default;
 
-    // Disable copy constructor and assignment operator for safety
-    BasePio(const BasePio&) = delete;
-    BasePio& operator=(const BasePio&) = delete;
+  // Disable copy constructor and assignment operator for safety
+  BasePio(const BasePio &) = delete;
+  BasePio &operator=(const BasePio &) = delete;
 
-    // Allow move operations
-    BasePio(BasePio&&) noexcept = default;
-    BasePio& operator=(BasePio&&) noexcept = default;
+  // Allow move operations
+  BasePio(BasePio &&) noexcept = default;
+  BasePio &operator=(BasePio &&) noexcept = default;
 
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
-    //==============================================//
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
+  //==============================================//
 
-    /**
-     * @brief Initialize the PIO peripheral
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr Initialize() noexcept = 0;
+  /**
+   * @brief Initialize the PIO peripheral
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr Initialize() noexcept = 0;
 
-    /**
-     * @brief Deinitialize the PIO peripheral
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr Deinitialize() noexcept = 0;
+  /**
+   * @brief Deinitialize the PIO peripheral
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr Deinitialize() noexcept = 0;
 
-    /**
-     * @brief Check if the PIO is initialized
-     * @return true if initialized, false otherwise
-     */
-    virtual bool IsInitialized() const noexcept = 0;
+  /**
+   * @brief Check if the PIO is initialized
+   * @return true if initialized, false otherwise
+   */
+  virtual bool IsInitialized() const noexcept = 0;
 
-    /**
-     * @brief Configure a PIO channel
-     * @param channel_id Channel identifier
-     * @param config Channel configuration
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr ConfigureChannel(uint8_t channel_id, const PioChannelConfig& config) noexcept = 0;
+  /**
+   * @brief Configure a PIO channel
+   * @param channel_id Channel identifier
+   * @param config Channel configuration
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr ConfigureChannel(uint8_t channel_id,
+                                    const PioChannelConfig &config) noexcept = 0;
 
-    /**
-     * @brief Transmit a sequence of symbols
-     * @param channel_id Channel identifier
-     * @param symbols Array of symbols to transmit
-     * @param symbol_count Number of symbols in the array
-     * @param wait_completion If true, block until transmission is complete
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr Transmit(uint8_t channel_id, const PioSymbol* symbols, size_t symbol_count, bool wait_completion = false) noexcept = 0;
+  /**
+   * @brief Transmit a sequence of symbols
+   * @param channel_id Channel identifier
+   * @param symbols Array of symbols to transmit
+   * @param symbol_count Number of symbols in the array
+   * @param wait_completion If true, block until transmission is complete
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr Transmit(uint8_t channel_id, const PioSymbol *symbols, size_t symbol_count,
+                            bool wait_completion = false) noexcept = 0;
 
-    /**
-     * @brief Start receiving symbols
-     * @param channel_id Channel identifier
-     * @param buffer Buffer to store received symbols
-     * @param buffer_size Size of the buffer
-     * @param timeout_us Timeout in microseconds (0 = no timeout)
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr StartReceive(uint8_t channel_id, PioSymbol* buffer, size_t buffer_size, uint32_t timeout_us = 0) noexcept = 0;
+  /**
+   * @brief Start receiving symbols
+   * @param channel_id Channel identifier
+   * @param buffer Buffer to store received symbols
+   * @param buffer_size Size of the buffer
+   * @param timeout_us Timeout in microseconds (0 = no timeout)
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr StartReceive(uint8_t channel_id, PioSymbol *buffer, size_t buffer_size,
+                                uint32_t timeout_us = 0) noexcept = 0;
 
-    /**
-     * @brief Stop receiving and get the number of symbols received
-     * @param channel_id Channel identifier
-     * @param symbols_received [out] Number of symbols actually received
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr StopReceive(uint8_t channel_id, size_t& symbols_received) noexcept = 0;
+  /**
+   * @brief Stop receiving and get the number of symbols received
+   * @param channel_id Channel identifier
+   * @param symbols_received [out] Number of symbols actually received
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr StopReceive(uint8_t channel_id, size_t &symbols_received) noexcept = 0;
 
-    /**
-     * @brief Check if a channel is currently busy
-     * @param channel_id Channel identifier
-     * @return true if channel is busy, false otherwise
-     */
-    virtual bool IsChannelBusy(uint8_t channel_id) const noexcept = 0;
+  /**
+   * @brief Check if a channel is currently busy
+   * @param channel_id Channel identifier
+   * @return true if channel is busy, false otherwise
+   */
+  virtual bool IsChannelBusy(uint8_t channel_id) const noexcept = 0;
 
-    /**
-     * @brief Get channel status information
-     * @param channel_id Channel identifier
-     * @param status [out] Status information
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr GetChannelStatus(uint8_t channel_id, PioChannelStatus& status) const noexcept = 0;
+  /**
+   * @brief Get channel status information
+   * @param channel_id Channel identifier
+   * @param status [out] Status information
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr GetChannelStatus(uint8_t channel_id,
+                                    PioChannelStatus &status) const noexcept = 0;
 
-    /**
-     * @brief Get PIO capabilities
-     * @param capabilities [out] Capability information
-     * @return Error code indicating success or failure
-     */
-    virtual HfPioErr GetCapabilities(PioCapabilities& capabilities) const noexcept = 0;
+  /**
+   * @brief Get PIO capabilities
+   * @param capabilities [out] Capability information
+   * @return Error code indicating success or failure
+   */
+  virtual HfPioErr GetCapabilities(PioCapabilities &capabilities) const noexcept = 0;
 
-    /**
-     * @brief Set callback for transmission complete events
-     * @param callback Callback function
-     * @param user_data User data to pass to callback
-     */
-    virtual void SetTransmitCallback(PioTransmitCallback callback, void* user_data = nullptr) noexcept = 0;
+  /**
+   * @brief Set callback for transmission complete events
+   * @param callback Callback function
+   * @param user_data User data to pass to callback
+   */
+  virtual void SetTransmitCallback(PioTransmitCallback callback,
+                                   void *user_data = nullptr) noexcept = 0;
 
-    /**
-     * @brief Set callback for reception complete events
-     * @param callback Callback function
-     * @param user_data User data to pass to callback
-     */
-    virtual void SetReceiveCallback(PioReceiveCallback callback, void* user_data = nullptr) noexcept = 0;
+  /**
+   * @brief Set callback for reception complete events
+   * @param callback Callback function
+   * @param user_data User data to pass to callback
+   */
+  virtual void SetReceiveCallback(PioReceiveCallback callback,
+                                  void *user_data = nullptr) noexcept = 0;
 
-    /**
-     * @brief Set callback for error events
-     * @param callback Callback function
-     * @param user_data User data to pass to callback
-     */
-    virtual void SetErrorCallback(PioErrorCallback callback, void* user_data = nullptr) noexcept = 0;
+  /**
+   * @brief Set callback for error events
+   * @param callback Callback function
+   * @param user_data User data to pass to callback
+   */
+  virtual void SetErrorCallback(PioErrorCallback callback, void *user_data = nullptr) noexcept = 0;
 
-    /**
-     * @brief Clear all callbacks
-     */
-    virtual void ClearCallbacks() noexcept = 0;
+  /**
+   * @brief Clear all callbacks
+   */
+  virtual void ClearCallbacks() noexcept = 0;
 
 protected:
-    /**
-     * @brief Protected constructor
-     */
-    BasePio() noexcept = default;
+  /**
+   * @brief Protected constructor
+   */
+  BasePio() noexcept = default;
 
 private:
-    bool initialized_{false};
+  bool initialized_{false};
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASEPIO_H_

--- a/inc/base/BasePwm.h
+++ b/inc/base/BasePwm.h
@@ -1,11 +1,11 @@
 /**
  * @file BasePwm.h
  * @brief Abstract base class for PWM implementations in the HardFOC system.
- * 
+ *
  * This header-only file defines the abstract base class for PWM generation
  * that provides a consistent API across different PWM implementations.
  * Concrete implementations (like McuPwm for ESP32 LEDC, external PWM ICs) inherit from this class.
- * 
+ *
  * @note This is a header-only abstract base class following the same pattern as BaseCan/BaseAdc.
  * @note Users should program against this interface, not specific implementations.
  */
@@ -27,55 +27,58 @@
  *          This enumeration is used across all PWM-related classes to provide
  *          consistent error reporting and handling.
  */
-#define HF_PWM_ERR_LIST(X) \
-    /* Success codes */ \
-    X(PWM_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(PWM_ERR_FAILURE, 1, "General failure") \
-    X(PWM_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(PWM_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(PWM_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(PWM_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(PWM_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Channel errors */ \
-    X(PWM_ERR_INVALID_CHANNEL, 7, "Invalid PWM channel") \
-    X(PWM_ERR_CHANNEL_BUSY, 8, "Channel already in use") \
-    X(PWM_ERR_CHANNEL_NOT_AVAILABLE, 9, "Channel not available") \
-    X(PWM_ERR_INSUFFICIENT_CHANNELS, 10, "Insufficient channels available") \
-    /* Frequency/timing errors */ \
-    X(PWM_ERR_INVALID_FREQUENCY, 11, "Invalid frequency") \
-    X(PWM_ERR_FREQUENCY_TOO_HIGH, 12, "Frequency too high") \
-    X(PWM_ERR_FREQUENCY_TOO_LOW, 13, "Frequency too low") \
-    X(PWM_ERR_RESOLUTION_NOT_SUPPORTED, 14, "Resolution not supported") \
-    /* Duty cycle errors */ \
-    X(PWM_ERR_INVALID_DUTY_CYCLE, 15, "Invalid duty cycle") \
-    X(PWM_ERR_DUTY_OUT_OF_RANGE, 16, "Duty cycle out of range") \
-    /* Hardware errors */ \
-    X(PWM_ERR_HARDWARE_FAULT, 17, "Hardware fault") \
-    X(PWM_ERR_TIMER_CONFLICT, 18, "Timer resource conflict") \
-    X(PWM_ERR_PIN_CONFLICT, 19, "Pin already in use") \
-    /* Communication errors (for external PWM ICs) */ \
-    X(PWM_ERR_COMMUNICATION_TIMEOUT, 20, "Communication timeout") \
-    X(PWM_ERR_COMMUNICATION_FAILURE, 21, "Communication failure") \
-    X(PWM_ERR_DEVICE_NOT_RESPONDING, 22, "Device not responding") \
-    X(PWM_ERR_INVALID_DEVICE_ID, 23, "Invalid device ID")
+#define HF_PWM_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(PWM_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(PWM_ERR_FAILURE, 1, "General failure")                                                         \
+  X(PWM_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(PWM_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(PWM_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(PWM_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(PWM_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Channel errors */                                                                             \
+  X(PWM_ERR_INVALID_CHANNEL, 7, "Invalid PWM channel")                                             \
+  X(PWM_ERR_CHANNEL_BUSY, 8, "Channel already in use")                                             \
+  X(PWM_ERR_CHANNEL_NOT_AVAILABLE, 9, "Channel not available")                                     \
+  X(PWM_ERR_INSUFFICIENT_CHANNELS, 10, "Insufficient channels available")                          \
+  /* Frequency/timing errors */                                                                    \
+  X(PWM_ERR_INVALID_FREQUENCY, 11, "Invalid frequency")                                            \
+  X(PWM_ERR_FREQUENCY_TOO_HIGH, 12, "Frequency too high")                                          \
+  X(PWM_ERR_FREQUENCY_TOO_LOW, 13, "Frequency too low")                                            \
+  X(PWM_ERR_RESOLUTION_NOT_SUPPORTED, 14, "Resolution not supported")                              \
+  /* Duty cycle errors */                                                                          \
+  X(PWM_ERR_INVALID_DUTY_CYCLE, 15, "Invalid duty cycle")                                          \
+  X(PWM_ERR_DUTY_OUT_OF_RANGE, 16, "Duty cycle out of range")                                      \
+  /* Hardware errors */                                                                            \
+  X(PWM_ERR_HARDWARE_FAULT, 17, "Hardware fault")                                                  \
+  X(PWM_ERR_TIMER_CONFLICT, 18, "Timer resource conflict")                                         \
+  X(PWM_ERR_PIN_CONFLICT, 19, "Pin already in use")                                                \
+  /* Communication errors (for external PWM ICs) */                                                \
+  X(PWM_ERR_COMMUNICATION_TIMEOUT, 20, "Communication timeout")                                    \
+  X(PWM_ERR_COMMUNICATION_FAILURE, 21, "Communication failure")                                    \
+  X(PWM_ERR_DEVICE_NOT_RESPONDING, 22, "Device not responding")                                    \
+  X(PWM_ERR_INVALID_DEVICE_ID, 23, "Invalid device ID")
 
 // Generate enum class
 enum class HfPwmErr : uint32_t {
 #define X(name, value, description) name = value,
-    HF_PWM_ERR_LIST(X)
+  HF_PWM_ERR_LIST(X)
 #undef X
-    PWM_ERR_COUNT  // Total number of error codes
+      PWM_ERR_COUNT // Total number of error codes
 };
 
 // Generate error message function
-constexpr const char* PwmErrorToString(HfPwmErr error) noexcept {
-    switch (error) {
-#define X(name, value, description) case HfPwmErr::name: return description;
-        HF_PWM_ERR_LIST(X)
+constexpr const char *PwmErrorToString(HfPwmErr error) noexcept {
+  switch (error) {
+#define X(name, value, description)                                                                \
+  case HfPwmErr::name:                                                                             \
+    return description;
+    HF_PWM_ERR_LIST(X)
 #undef X
-        default: return "Unknown PWM error";
-    }
+  default:
+    return "Unknown PWM error";
+  }
 }
 
 //--------------------------------------
@@ -86,69 +89,61 @@ constexpr const char* PwmErrorToString(HfPwmErr error) noexcept {
  * @brief PWM output mode configuration
  */
 enum class PwmOutputMode : uint8_t {
-    Normal = 0,        ///< Normal PWM output
-    Inverted = 1,      ///< Inverted PWM output
-    Complementary = 2, ///< Complementary output (for motor control)
-    Differential = 3   ///< Differential output
+  Normal = 0,        ///< Normal PWM output
+  Inverted = 1,      ///< Inverted PWM output
+  Complementary = 2, ///< Complementary output (for motor control)
+  Differential = 3   ///< Differential output
 };
 
 /**
  * @brief PWM alignment mode
  */
 enum class PwmAlignment : uint8_t {
-    EdgeAligned = 0,   ///< Edge-aligned PWM (standard)
-    CenterAligned = 1  ///< Center-aligned PWM (better for motor control)
+  EdgeAligned = 0,  ///< Edge-aligned PWM (standard)
+  CenterAligned = 1 ///< Center-aligned PWM (better for motor control)
 };
 
 /**
  * @brief PWM idle state
  */
 enum class PwmIdleState : uint8_t {
-    Low = 0,   ///< Output low when idle
-    High = 1   ///< Output high when idle
+  Low = 0, ///< Output low when idle
+  High = 1 ///< Output high when idle
 };
 
 /**
  * @brief PWM channel configuration structure
  */
 struct PwmChannelConfig {
-    HfPinNumber output_pin;               ///< GPIO pin for PWM output
-    uint32_t frequency_hz;              ///< PWM frequency in Hz
-    uint8_t resolution_bits;            ///< PWM resolution (8-16 bits typical)
-    PwmOutputMode output_mode;          ///< Output mode configuration
-    PwmAlignment alignment;             ///< PWM alignment mode
-    PwmIdleState idle_state;            ///< Idle state configuration
-    float initial_duty_cycle;           ///< Initial duty cycle (0.0 - 1.0)
-    bool invert_output;                 ///< Invert the output signal
-    
-    // Default constructor with sensible defaults
-    PwmChannelConfig() noexcept
-        : output_pin(-1)
-        , frequency_hz(1000)
-        , resolution_bits(12)
-        , output_mode(PwmOutputMode::Normal)
-        , alignment(PwmAlignment::EdgeAligned)
-        , idle_state(PwmIdleState::Low)
-        , initial_duty_cycle(0.0f)
-        , invert_output(false)
-    {}
+  HfPinNumber output_pin;    ///< GPIO pin for PWM output
+  uint32_t frequency_hz;     ///< PWM frequency in Hz
+  uint8_t resolution_bits;   ///< PWM resolution (8-16 bits typical)
+  PwmOutputMode output_mode; ///< Output mode configuration
+  PwmAlignment alignment;    ///< PWM alignment mode
+  PwmIdleState idle_state;   ///< Idle state configuration
+  float initial_duty_cycle;  ///< Initial duty cycle (0.0 - 1.0)
+  bool invert_output;        ///< Invert the output signal
+
+  // Default constructor with sensible defaults
+  PwmChannelConfig() noexcept
+      : output_pin(-1), frequency_hz(1000), resolution_bits(12), output_mode(PwmOutputMode::Normal),
+        alignment(PwmAlignment::EdgeAligned), idle_state(PwmIdleState::Low),
+        initial_duty_cycle(0.0f), invert_output(false) {}
 };
 
 /**
  * @brief PWM timer configuration (for MCU implementations)
  */
 struct PwmTimerConfig {
-    uint8_t timer_number;               ///< Timer/group number
-    uint32_t base_frequency_hz;         ///< Base timer frequency
-    uint8_t resolution_bits;            ///< Timer resolution
-    PwmAlignment alignment;             ///< Timer alignment mode
-    
-    PwmTimerConfig() noexcept
-        : timer_number(0)
-        , base_frequency_hz(80000000)  // 80MHz typical for ESP32
-        , resolution_bits(12)
-        , alignment(PwmAlignment::EdgeAligned)
-    {}
+  uint8_t timer_number;       ///< Timer/group number
+  uint32_t base_frequency_hz; ///< Base timer frequency
+  uint8_t resolution_bits;    ///< Timer resolution
+  PwmAlignment alignment;     ///< Timer alignment mode
+
+  PwmTimerConfig() noexcept
+      : timer_number(0), base_frequency_hz(80000000) // 80MHz typical for ESP32
+        ,
+        resolution_bits(12), alignment(PwmAlignment::EdgeAligned) {}
 };
 
 //--------------------------------------
@@ -159,37 +154,32 @@ struct PwmTimerConfig {
  * @brief PWM channel status information
  */
 struct PwmChannelStatus {
-    bool is_enabled;                    ///< Channel is enabled
-    bool is_running;                    ///< Channel is actively generating PWM
-    uint32_t current_frequency_hz;      ///< Current frequency
-    float current_duty_cycle;           ///< Current duty cycle (0.0 - 1.0)
-    uint32_t raw_duty_value;            ///< Raw duty register value
-    HfPwmErr last_error;                ///< Last error encountered
-    
-    PwmChannelStatus() noexcept
-        : is_enabled(false)
-        , is_running(false)
-        , current_frequency_hz(0)
-        , current_duty_cycle(0.0f)
-        , raw_duty_value(0)
-        , last_error(HfPwmErr::PWM_SUCCESS)
-    {}
+  bool is_enabled;               ///< Channel is enabled
+  bool is_running;               ///< Channel is actively generating PWM
+  uint32_t current_frequency_hz; ///< Current frequency
+  float current_duty_cycle;      ///< Current duty cycle (0.0 - 1.0)
+  uint32_t raw_duty_value;       ///< Raw duty register value
+  HfPwmErr last_error;           ///< Last error encountered
+
+  PwmChannelStatus() noexcept
+      : is_enabled(false), is_running(false), current_frequency_hz(0), current_duty_cycle(0.0f),
+        raw_duty_value(0), last_error(HfPwmErr::PWM_SUCCESS) {}
 };
 
 /**
  * @brief PWM capability information (what the implementation supports)
  */
 struct PwmCapabilities {
-    uint8_t max_channels;               ///< Maximum number of channels
-    uint8_t max_timers;                 ///< Maximum number of timers
-    uint32_t min_frequency_hz;          ///< Minimum supported frequency
-    uint32_t max_frequency_hz;          ///< Maximum supported frequency
-    uint8_t min_resolution_bits;        ///< Minimum resolution
-    uint8_t max_resolution_bits;        ///< Maximum resolution
-    bool supports_complementary;        ///< Supports complementary outputs
-    bool supports_center_aligned;      ///< Supports center-aligned PWM
-    bool supports_deadtime;             ///< Supports deadtime insertion
-    bool supports_phase_shift;          ///< Supports phase shifting
+  uint8_t max_channels;         ///< Maximum number of channels
+  uint8_t max_timers;           ///< Maximum number of timers
+  uint32_t min_frequency_hz;    ///< Minimum supported frequency
+  uint32_t max_frequency_hz;    ///< Maximum supported frequency
+  uint8_t min_resolution_bits;  ///< Minimum resolution
+  uint8_t max_resolution_bits;  ///< Maximum resolution
+  bool supports_complementary;  ///< Supports complementary outputs
+  bool supports_center_aligned; ///< Supports center-aligned PWM
+  bool supports_deadtime;       ///< Supports deadtime insertion
+  bool supports_phase_shift;    ///< Supports phase shifting
 };
 
 //--------------------------------------
@@ -201,7 +191,7 @@ struct PwmCapabilities {
  * @param channel_id Channel that completed a period
  * @param user_data User-provided data
  */
-using PwmPeriodCallback = std::function<void(HfChannelId channel_id, void* user_data)>;
+using PwmPeriodCallback = std::function<void(HfChannelId channel_id, void *user_data)>;
 
 /**
  * @brief Callback for PWM fault/error events
@@ -209,7 +199,8 @@ using PwmPeriodCallback = std::function<void(HfChannelId channel_id, void* user_
  * @param error Error that occurred
  * @param user_data User-provided data
  */
-using PwmFaultCallback = std::function<void(HfChannelId channel_id, HfPwmErr error, void* user_data)>;
+using PwmFaultCallback =
+    std::function<void(HfChannelId channel_id, HfPwmErr error, void *user_data)>;
 
 //--------------------------------------
 //  Abstract Base Class
@@ -218,11 +209,11 @@ using PwmFaultCallback = std::function<void(HfChannelId channel_id, HfPwmErr err
 /**
  * @class BasePwm
  * @brief Abstract base class for PWM implementations.
- * 
+ *
  * This class defines the common interface that all PWM implementations must provide.
  * It supports both MCU-integrated PWM (like ESP32 LEDC) and external PWM ICs
  * (like PCA9685, TLC5940, etc.).
- * 
+ *
  * Key features:
  * - Multi-channel PWM support
  * - Configurable frequency and resolution
@@ -230,7 +221,7 @@ using PwmFaultCallback = std::function<void(HfChannelId channel_id, HfPwmErr err
  * - Event callbacks for period and fault events
  * - Comprehensive error handling
  * - Thread-safe design when used with SfPwm wrapper
- * 
+ *
  * Implementations:
  * - McuPwm: For MCU-integrated PWM controllers
  * - Pca9685Pwm: For PCA9685 I2C PWM IC
@@ -239,244 +230,251 @@ using PwmFaultCallback = std::function<void(HfChannelId channel_id, HfPwmErr err
  */
 class BasePwm {
 public:
-    //==============================================================================
-    // LIFECYCLE
-    //==============================================================================
-    
-    virtual ~BasePwm() noexcept = default;
-    
-    /**
-     * @brief Initialize the PWM system
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr Initialize() noexcept = 0;
-    
-    /**
-     * @brief Deinitialize the PWM system
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr Deinitialize() noexcept = 0;
-    
-    /**
-     * @brief Check if PWM system is initialized
-     * @return true if initialized, false otherwise
-     */
-    virtual bool IsInitialized() const noexcept = 0;
-    
-    //==============================================================================
-    // CHANNEL MANAGEMENT
-    //==============================================================================
-    
-    /**
-     * @brief Configure a PWM channel
-     * @param channel_id Channel identifier (0-based)
-     * @param config Channel configuration
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr ConfigureChannel(HfChannelId channel_id, const PwmChannelConfig& config) noexcept = 0;
-    
-    /**
-     * @brief Enable a PWM channel
-     * @param channel_id Channel to enable
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr EnableChannel(HfChannelId channel_id) noexcept = 0;
-    
-    /**
-     * @brief Disable a PWM channel
-     * @param channel_id Channel to disable
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr DisableChannel(HfChannelId channel_id) noexcept = 0;
-    
-    /**
-     * @brief Check if a channel is enabled
-     * @param channel_id Channel to check
-     * @return true if enabled, false otherwise
-     */
-    virtual bool IsChannelEnabled(HfChannelId channel_id) const noexcept = 0;
-    
-    //==============================================================================
-    // PWM CONTROL
-    //==============================================================================
-    
-    /**
-     * @brief Set duty cycle for a channel
-     * @param channel_id Channel identifier
-     * @param duty_cycle Duty cycle (0.0 - 1.0)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept = 0;
-    
-    /**
-     * @brief Set raw duty value for a channel
-     * @param channel_id Channel identifier
-     * @param raw_value Raw duty register value
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept = 0;
-    
-    /**
-     * @brief Set frequency for a channel
-     * @param channel_id Channel identifier
-     * @param frequency_hz Frequency in Hz
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept = 0;
-    
-    /**
-     * @brief Set phase shift for a channel (if supported)
-     * @param channel_id Channel identifier
-     * @param phase_shift_degrees Phase shift in degrees (0-360)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept = 0;
-    
-    //==============================================================================
-    // ADVANCED FEATURES
-    //==============================================================================
-    
-    /**
-     * @brief Start all enabled channels simultaneously
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr StartAll() noexcept = 0;
-    
-    /**
-     * @brief Stop all channels
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr StopAll() noexcept = 0;
-    
-    /**
-     * @brief Update all channel outputs simultaneously (for synchronized updates)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr UpdateAll() noexcept = 0;
-    
-    /**
-     * @brief Set complementary output configuration (for motor control)
-     * @param primary_channel Primary channel
-     * @param complementary_channel Complementary channel
-     * @param deadtime_ns Deadtime in nanoseconds
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr SetComplementaryOutput(HfChannelId primary_channel, 
-                                          HfChannelId complementary_channel, 
+  //==============================================================================
+  // LIFECYCLE
+  //==============================================================================
+
+  virtual ~BasePwm() noexcept = default;
+
+  /**
+   * @brief Initialize the PWM system
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr Initialize() noexcept = 0;
+
+  /**
+   * @brief Deinitialize the PWM system
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr Deinitialize() noexcept = 0;
+
+  /**
+   * @brief Check if PWM system is initialized
+   * @return true if initialized, false otherwise
+   */
+  virtual bool IsInitialized() const noexcept = 0;
+
+  //==============================================================================
+  // CHANNEL MANAGEMENT
+  //==============================================================================
+
+  /**
+   * @brief Configure a PWM channel
+   * @param channel_id Channel identifier (0-based)
+   * @param config Channel configuration
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr ConfigureChannel(HfChannelId channel_id,
+                                    const PwmChannelConfig &config) noexcept = 0;
+
+  /**
+   * @brief Enable a PWM channel
+   * @param channel_id Channel to enable
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr EnableChannel(HfChannelId channel_id) noexcept = 0;
+
+  /**
+   * @brief Disable a PWM channel
+   * @param channel_id Channel to disable
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr DisableChannel(HfChannelId channel_id) noexcept = 0;
+
+  /**
+   * @brief Check if a channel is enabled
+   * @param channel_id Channel to check
+   * @return true if enabled, false otherwise
+   */
+  virtual bool IsChannelEnabled(HfChannelId channel_id) const noexcept = 0;
+
+  //==============================================================================
+  // PWM CONTROL
+  //==============================================================================
+
+  /**
+   * @brief Set duty cycle for a channel
+   * @param channel_id Channel identifier
+   * @param duty_cycle Duty cycle (0.0 - 1.0)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept = 0;
+
+  /**
+   * @brief Set raw duty value for a channel
+   * @param channel_id Channel identifier
+   * @param raw_value Raw duty register value
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept = 0;
+
+  /**
+   * @brief Set frequency for a channel
+   * @param channel_id Channel identifier
+   * @param frequency_hz Frequency in Hz
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept = 0;
+
+  /**
+   * @brief Set phase shift for a channel (if supported)
+   * @param channel_id Channel identifier
+   * @param phase_shift_degrees Phase shift in degrees (0-360)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept = 0;
+
+  //==============================================================================
+  // ADVANCED FEATURES
+  //==============================================================================
+
+  /**
+   * @brief Start all enabled channels simultaneously
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr StartAll() noexcept = 0;
+
+  /**
+   * @brief Stop all channels
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr StopAll() noexcept = 0;
+
+  /**
+   * @brief Update all channel outputs simultaneously (for synchronized updates)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr UpdateAll() noexcept = 0;
+
+  /**
+   * @brief Set complementary output configuration (for motor control)
+   * @param primary_channel Primary channel
+   * @param complementary_channel Complementary channel
+   * @param deadtime_ns Deadtime in nanoseconds
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr SetComplementaryOutput(HfChannelId primary_channel,
+                                          HfChannelId complementary_channel,
                                           uint32_t deadtime_ns) noexcept = 0;
-    
-    //==============================================================================
-    // STATUS AND INFORMATION
-    //==============================================================================
-    
-    /**
-     * @brief Get current duty cycle for a channel
-     * @param channel_id Channel identifier
-     * @return Current duty cycle (0.0 - 1.0), or -1.0 on error
-     */
-    virtual float GetDutyCycle(HfChannelId channel_id) const noexcept = 0;
-    
-    /**
-     * @brief Get current frequency for a channel
-     * @param channel_id Channel identifier
-     * @return Current frequency in Hz, or 0 on error
-     */
-    virtual HfFrequencyHz GetFrequency(HfChannelId channel_id) const noexcept = 0;
-    
-    /**
-     * @brief Get channel status
-     * @param channel_id Channel identifier
-     * @param status Status structure to fill
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr GetChannelStatus(HfChannelId channel_id, PwmChannelStatus& status) const noexcept = 0;
-    
-    /**
-     * @brief Get PWM implementation capabilities
-     * @param capabilities Capabilities structure to fill
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    virtual HfPwmErr GetCapabilities(PwmCapabilities& capabilities) const noexcept = 0;
-    
-    /**
-     * @brief Get last error for a specific channel
-     * @param channel_id Channel identifier
-     * @return Last error code for the channel
-     */
-    virtual HfPwmErr GetLastError(HfChannelId channel_id) const noexcept = 0;
-    
-    //==============================================================================
-    // CALLBACKS
-    //==============================================================================
-    
-    /**
-     * @brief Set period complete callback
-     * @param callback Callback function
-     * @param user_data User data passed to callback
-     */
-    virtual void SetPeriodCallback(PwmPeriodCallback callback, void* user_data = nullptr) noexcept = 0;
-    
-    /**
-     * @brief Set fault/error callback
-     * @param callback Callback function
-     * @param user_data User data passed to callback
-     */
-    virtual void SetFaultCallback(PwmFaultCallback callback, void* user_data = nullptr) noexcept = 0;
-    
-    //==============================================================================
-    // UTILITY FUNCTIONS
-    //==============================================================================
-    
-    /**
-     * @brief Calculate raw duty value from percentage
-     * @param duty_cycle Duty cycle (0.0 - 1.0)
-     * @param resolution_bits PWM resolution in bits
-     * @return Raw duty value
-     */
-    static constexpr uint32_t DutyCycleToRaw(float duty_cycle, uint8_t resolution_bits) noexcept {
-        if (duty_cycle < 0.0f) duty_cycle = 0.0f;
-        if (duty_cycle > 1.0f) duty_cycle = 1.0f;
-        return static_cast<uint32_t>(duty_cycle * ((1U << resolution_bits) - 1));
-    }
-    
-    /**
-     * @brief Calculate duty cycle percentage from raw value
-     * @param raw_value Raw duty value
-     * @param resolution_bits PWM resolution in bits
-     * @return Duty cycle (0.0 - 1.0)
-     */
-    static constexpr float RawToDutyCycle(uint32_t raw_value, uint8_t resolution_bits) noexcept {
-        uint32_t max_value = (1U << resolution_bits) - 1;
-        if (raw_value > max_value) raw_value = max_value;
-        return static_cast<float>(raw_value) / static_cast<float>(max_value);
-    }
-    
-    /**
-     * @brief Validate duty cycle range
-     * @param duty_cycle Duty cycle to validate
-     * @return true if valid (0.0 - 1.0), false otherwise
-     */
-    static constexpr bool IsValidDutyCycle(float duty_cycle) noexcept {
-        return (duty_cycle >= 0.0f && duty_cycle <= 1.0f);
-    }
-    
-    /**
-     * @brief Validate frequency range
-     * @param frequency_hz Frequency to validate
-     * @param min_freq_hz Minimum allowed frequency
-     * @param max_freq_hz Maximum allowed frequency
-     * @return true if valid, false otherwise
-     */
-    static constexpr bool IsValidFrequency(uint32_t frequency_hz, uint32_t min_freq_hz, uint32_t max_freq_hz) noexcept {
-        return (frequency_hz >= min_freq_hz && frequency_hz <= max_freq_hz);
-    }
+
+  //==============================================================================
+  // STATUS AND INFORMATION
+  //==============================================================================
+
+  /**
+   * @brief Get current duty cycle for a channel
+   * @param channel_id Channel identifier
+   * @return Current duty cycle (0.0 - 1.0), or -1.0 on error
+   */
+  virtual float GetDutyCycle(HfChannelId channel_id) const noexcept = 0;
+
+  /**
+   * @brief Get current frequency for a channel
+   * @param channel_id Channel identifier
+   * @return Current frequency in Hz, or 0 on error
+   */
+  virtual HfFrequencyHz GetFrequency(HfChannelId channel_id) const noexcept = 0;
+
+  /**
+   * @brief Get channel status
+   * @param channel_id Channel identifier
+   * @param status Status structure to fill
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr GetChannelStatus(HfChannelId channel_id,
+                                    PwmChannelStatus &status) const noexcept = 0;
+
+  /**
+   * @brief Get PWM implementation capabilities
+   * @param capabilities Capabilities structure to fill
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  virtual HfPwmErr GetCapabilities(PwmCapabilities &capabilities) const noexcept = 0;
+
+  /**
+   * @brief Get last error for a specific channel
+   * @param channel_id Channel identifier
+   * @return Last error code for the channel
+   */
+  virtual HfPwmErr GetLastError(HfChannelId channel_id) const noexcept = 0;
+
+  //==============================================================================
+  // CALLBACKS
+  //==============================================================================
+
+  /**
+   * @brief Set period complete callback
+   * @param callback Callback function
+   * @param user_data User data passed to callback
+   */
+  virtual void SetPeriodCallback(PwmPeriodCallback callback,
+                                 void *user_data = nullptr) noexcept = 0;
+
+  /**
+   * @brief Set fault/error callback
+   * @param callback Callback function
+   * @param user_data User data passed to callback
+   */
+  virtual void SetFaultCallback(PwmFaultCallback callback, void *user_data = nullptr) noexcept = 0;
+
+  //==============================================================================
+  // UTILITY FUNCTIONS
+  //==============================================================================
+
+  /**
+   * @brief Calculate raw duty value from percentage
+   * @param duty_cycle Duty cycle (0.0 - 1.0)
+   * @param resolution_bits PWM resolution in bits
+   * @return Raw duty value
+   */
+  static constexpr uint32_t DutyCycleToRaw(float duty_cycle, uint8_t resolution_bits) noexcept {
+    if (duty_cycle < 0.0f)
+      duty_cycle = 0.0f;
+    if (duty_cycle > 1.0f)
+      duty_cycle = 1.0f;
+    return static_cast<uint32_t>(duty_cycle * ((1U << resolution_bits) - 1));
+  }
+
+  /**
+   * @brief Calculate duty cycle percentage from raw value
+   * @param raw_value Raw duty value
+   * @param resolution_bits PWM resolution in bits
+   * @return Duty cycle (0.0 - 1.0)
+   */
+  static constexpr float RawToDutyCycle(uint32_t raw_value, uint8_t resolution_bits) noexcept {
+    uint32_t max_value = (1U << resolution_bits) - 1;
+    if (raw_value > max_value)
+      raw_value = max_value;
+    return static_cast<float>(raw_value) / static_cast<float>(max_value);
+  }
+
+  /**
+   * @brief Validate duty cycle range
+   * @param duty_cycle Duty cycle to validate
+   * @return true if valid (0.0 - 1.0), false otherwise
+   */
+  static constexpr bool IsValidDutyCycle(float duty_cycle) noexcept {
+    return (duty_cycle >= 0.0f && duty_cycle <= 1.0f);
+  }
+
+  /**
+   * @brief Validate frequency range
+   * @param frequency_hz Frequency to validate
+   * @param min_freq_hz Minimum allowed frequency
+   * @param max_freq_hz Maximum allowed frequency
+   * @return true if valid, false otherwise
+   */
+  static constexpr bool IsValidFrequency(uint32_t frequency_hz, uint32_t min_freq_hz,
+                                         uint32_t max_freq_hz) noexcept {
+    return (frequency_hz >= min_freq_hz && frequency_hz <= max_freq_hz);
+  }
 
 protected:
-    BasePwm() noexcept = default;
-    BasePwm(const BasePwm&) = delete;
-    BasePwm& operator=(const BasePwm&) = delete;
-    BasePwm(BasePwm&&) = delete;
-    BasePwm& operator=(BasePwm&&) = delete;
+  BasePwm() noexcept = default;
+  BasePwm(const BasePwm &) = delete;
+  BasePwm &operator=(const BasePwm &) = delete;
+  BasePwm(BasePwm &&) = delete;
+  BasePwm &operator=(BasePwm &&) = delete;
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASEPWM_H_

--- a/inc/base/BaseSpi.h
+++ b/inc/base/BaseSpi.h
@@ -28,49 +28,49 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_SPI_ERR_LIST(X) \
-    /* Success codes */ \
-    X(SPI_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(SPI_ERR_FAILURE, 1, "General failure") \
-    X(SPI_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(SPI_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(SPI_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(SPI_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(SPI_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Bus errors */ \
-    X(SPI_ERR_BUS_BUSY, 7, "Bus busy") \
-    X(SPI_ERR_BUS_ERROR, 8, "Bus error") \
-    X(SPI_ERR_BUS_NOT_AVAILABLE, 9, "Bus not available") \
-    X(SPI_ERR_BUS_TIMEOUT, 10, "Bus timeout") \
-    /* Transfer errors */ \
-    X(SPI_ERR_TRANSFER_FAILED, 11, "Transfer failed") \
-    X(SPI_ERR_TRANSFER_TIMEOUT, 12, "Transfer timeout") \
-    X(SPI_ERR_TRANSFER_TOO_LONG, 13, "Transfer too long") \
-    X(SPI_ERR_TRANSFER_SIZE_MISMATCH, 14, "Transfer size mismatch") \
-    /* Device errors */ \
-    X(SPI_ERR_DEVICE_NOT_FOUND, 15, "Device not found") \
-    X(SPI_ERR_DEVICE_NOT_RESPONDING, 16, "Device not responding") \
-    X(SPI_ERR_CS_CONTROL_FAILED, 17, "Chip select control failed") \
-    /* Hardware errors */ \
-    X(SPI_ERR_HARDWARE_FAULT, 18, "Hardware fault") \
-    X(SPI_ERR_COMMUNICATION_FAILURE, 19, "Communication failure") \
-    X(SPI_ERR_VOLTAGE_OUT_OF_RANGE, 20, "Voltage out of range") \
-    X(SPI_ERR_CLOCK_ERROR, 21, "Clock error") \
-    /* Configuration errors */ \
-    X(SPI_ERR_INVALID_CONFIGURATION, 22, "Invalid configuration") \
-    X(SPI_ERR_UNSUPPORTED_OPERATION, 23, "Unsupported operation") \
-    X(SPI_ERR_INVALID_CLOCK_SPEED, 24, "Invalid clock speed") \
-    X(SPI_ERR_INVALID_MODE, 25, "Invalid SPI mode") \
-    X(SPI_ERR_PIN_CONFIGURATION_ERROR, 26, "Pin configuration error") \
-    /* System errors */ \
-    X(SPI_ERR_SYSTEM_ERROR, 27, "System error") \
-    X(SPI_ERR_PERMISSION_DENIED, 28, "Permission denied") \
-    X(SPI_ERR_OPERATION_ABORTED, 29, "Operation aborted")
+#define HF_SPI_ERR_LIST(X)                                                                         \
+  /* Success codes */                                                                              \
+  X(SPI_SUCCESS, 0, "Success")                                                                     \
+  /* General errors */                                                                             \
+  X(SPI_ERR_FAILURE, 1, "General failure")                                                         \
+  X(SPI_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                 \
+  X(SPI_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                         \
+  X(SPI_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                             \
+  X(SPI_ERR_NULL_POINTER, 5, "Null pointer")                                                       \
+  X(SPI_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                     \
+  /* Bus errors */                                                                                 \
+  X(SPI_ERR_BUS_BUSY, 7, "Bus busy")                                                               \
+  X(SPI_ERR_BUS_ERROR, 8, "Bus error")                                                             \
+  X(SPI_ERR_BUS_NOT_AVAILABLE, 9, "Bus not available")                                             \
+  X(SPI_ERR_BUS_TIMEOUT, 10, "Bus timeout")                                                        \
+  /* Transfer errors */                                                                            \
+  X(SPI_ERR_TRANSFER_FAILED, 11, "Transfer failed")                                                \
+  X(SPI_ERR_TRANSFER_TIMEOUT, 12, "Transfer timeout")                                              \
+  X(SPI_ERR_TRANSFER_TOO_LONG, 13, "Transfer too long")                                            \
+  X(SPI_ERR_TRANSFER_SIZE_MISMATCH, 14, "Transfer size mismatch")                                  \
+  /* Device errors */                                                                              \
+  X(SPI_ERR_DEVICE_NOT_FOUND, 15, "Device not found")                                              \
+  X(SPI_ERR_DEVICE_NOT_RESPONDING, 16, "Device not responding")                                    \
+  X(SPI_ERR_CS_CONTROL_FAILED, 17, "Chip select control failed")                                   \
+  /* Hardware errors */                                                                            \
+  X(SPI_ERR_HARDWARE_FAULT, 18, "Hardware fault")                                                  \
+  X(SPI_ERR_COMMUNICATION_FAILURE, 19, "Communication failure")                                    \
+  X(SPI_ERR_VOLTAGE_OUT_OF_RANGE, 20, "Voltage out of range")                                      \
+  X(SPI_ERR_CLOCK_ERROR, 21, "Clock error")                                                        \
+  /* Configuration errors */                                                                       \
+  X(SPI_ERR_INVALID_CONFIGURATION, 22, "Invalid configuration")                                    \
+  X(SPI_ERR_UNSUPPORTED_OPERATION, 23, "Unsupported operation")                                    \
+  X(SPI_ERR_INVALID_CLOCK_SPEED, 24, "Invalid clock speed")                                        \
+  X(SPI_ERR_INVALID_MODE, 25, "Invalid SPI mode")                                                  \
+  X(SPI_ERR_PIN_CONFIGURATION_ERROR, 26, "Pin configuration error")                                \
+  /* System errors */                                                                              \
+  X(SPI_ERR_SYSTEM_ERROR, 27, "System error")                                                      \
+  X(SPI_ERR_PERMISSION_DENIED, 28, "Permission denied")                                            \
+  X(SPI_ERR_OPERATION_ABORTED, 29, "Operation aborted")
 
 enum class HfSpiErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
-    HF_SPI_ERR_LIST(X)
+  HF_SPI_ERR_LIST(X)
 #undef X
 };
 
@@ -80,12 +80,15 @@ enum class HfSpiErr : uint8_t {
  * @return String view of the error description
  */
 constexpr std::string_view HfSpiErrToString(HfSpiErr err) noexcept {
-    switch (err) {
-#define X(NAME, VALUE, DESC) case HfSpiErr::NAME: return DESC;
-        HF_SPI_ERR_LIST(X)
+  switch (err) {
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfSpiErr::NAME:                                                                             \
+    return DESC;
+    HF_SPI_ERR_LIST(X)
 #undef X
-        default: return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 //--------------------------------------
@@ -98,32 +101,27 @@ constexpr std::string_view HfSpiErrToString(HfSpiErr err) noexcept {
  *          supporting various platforms and SPI modes without MCU-specific types.
  */
 struct SpiBusConfig {
-    HfHostId host;                        ///< SPI host/controller
-    HfPinNumber mosi_pin;                 ///< MOSI (Master Out Slave In) pin
-    HfPinNumber miso_pin;                 ///< MISO (Master In Slave Out) pin
-    HfPinNumber sclk_pin;                 ///< SCLK (Serial Clock) pin
-    HfPinNumber cs_pin;                   ///< CS (Chip Select) pin
-    HfFrequencyHz clock_speed_hz;         ///< Clock speed in Hz
-    uint8_t mode;                       ///< SPI mode (0-3: CPOL/CPHA combinations)
-    uint8_t bits_per_word;              ///< Bits per transfer (typically 8 or 16)
-    bool cs_active_low;                 ///< True if CS is active low, false if active high
-    HfTimeoutMs timeout_ms;               ///< Default timeout for operations in milliseconds
-    
-    /**
-     * @brief Default constructor with sensible defaults.
-     */
-    SpiBusConfig() noexcept :
-        host(HF_INVALID_HOST),
-        mosi_pin(HF_INVALID_PIN),
-        miso_pin(HF_INVALID_PIN),
-        sclk_pin(HF_INVALID_PIN),
-        cs_pin(HF_INVALID_PIN),
-        clock_speed_hz(1000000),    // 1MHz default
-        mode(0),                    // Mode 0 (CPOL=0, CPHA=0)
-        bits_per_word(8),           // 8-bit transfers
-        cs_active_low(true),        // Most devices use active-low CS
-        timeout_ms(1000)
-    {}
+  HfHostId host;                ///< SPI host/controller
+  HfPinNumber mosi_pin;         ///< MOSI (Master Out Slave In) pin
+  HfPinNumber miso_pin;         ///< MISO (Master In Slave Out) pin
+  HfPinNumber sclk_pin;         ///< SCLK (Serial Clock) pin
+  HfPinNumber cs_pin;           ///< CS (Chip Select) pin
+  HfFrequencyHz clock_speed_hz; ///< Clock speed in Hz
+  uint8_t mode;                 ///< SPI mode (0-3: CPOL/CPHA combinations)
+  uint8_t bits_per_word;        ///< Bits per transfer (typically 8 or 16)
+  bool cs_active_low;           ///< True if CS is active low, false if active high
+  HfTimeoutMs timeout_ms;       ///< Default timeout for operations in milliseconds
+
+  /**
+   * @brief Default constructor with sensible defaults.
+   */
+  SpiBusConfig() noexcept
+      : host(HF_INVALID_HOST), mosi_pin(HF_INVALID_PIN), miso_pin(HF_INVALID_PIN),
+        sclk_pin(HF_INVALID_PIN), cs_pin(HF_INVALID_PIN), clock_speed_hz(1000000), // 1MHz default
+        mode(0),             // Mode 0 (CPOL=0, CPHA=0)
+        bits_per_word(8),    // 8-bit transfers
+        cs_active_low(true), // Most devices use active-low CS
+        timeout_ms(1000) {}
 };
 
 //--------------------------------------
@@ -143,253 +141,249 @@ struct SpiBusConfig {
  *          - Configurable word sizes
  *          - Comprehensive error handling
  *          - Lazy initialization pattern
- *          
+ *
  *          Derived classes implement platform-specific details for:
  *          - MCU SPI controllers (ESP32, STM32, etc.)
  *          - Bit-banged SPI implementations
  *          - SPI bridge/adapter hardware
- * 
+ *
  * @note This is a header-only abstract base class - instantiate concrete implementations instead.
  * @note This class is not inherently thread-safe. Use appropriate synchronization if
  *       accessed from multiple contexts.
  */
 class BaseSpi {
 public:
-    /**
-     * @brief Constructor with configuration.
-     * @param config SPI bus configuration parameters
-     */
-    explicit BaseSpi(const SpiBusConfig& config) noexcept :
-        config_(config), initialized_(false) {}
+  /**
+   * @brief Constructor with configuration.
+   * @param config SPI bus configuration parameters
+   */
+  explicit BaseSpi(const SpiBusConfig &config) noexcept : config_(config), initialized_(false) {}
 
-    /**
-     * @brief Virtual destructor ensures proper cleanup in derived classes.
-     */
-    virtual ~BaseSpi() noexcept = default;
-    
-    // Non-copyable, non-movable (can be changed in derived classes if needed)
-    BaseSpi(const BaseSpi&) = delete;
-    BaseSpi& operator=(const BaseSpi&) = delete;
-    BaseSpi(BaseSpi&&) = delete;
-    BaseSpi& operator=(BaseSpi&&) = delete;
+  /**
+   * @brief Virtual destructor ensures proper cleanup in derived classes.
+   */
+  virtual ~BaseSpi() noexcept = default;
 
-    /**
-     * @brief Ensures that the SPI bus is initialized (lazy initialization).
-     * @return true if the SPI bus is initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized_) {
-            initialized_ = Initialize();
-        }
-        return initialized_;
-    }
+  // Non-copyable, non-movable (can be changed in derived classes if needed)
+  BaseSpi(const BaseSpi &) = delete;
+  BaseSpi &operator=(const BaseSpi &) = delete;
+  BaseSpi(BaseSpi &&) = delete;
+  BaseSpi &operator=(BaseSpi &&) = delete;
 
-    /**
-     * @brief Checks if the bus is initialized.
-     * @return true if initialized, false otherwise
-     */
-    [[nodiscard]] bool IsInitialized() const noexcept {
-        return initialized_;
+  /**
+   * @brief Ensures that the SPI bus is initialized (lazy initialization).
+   * @return true if the SPI bus is initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized_) {
+      initialized_ = Initialize();
     }
-    
-    /**
-     * @brief Get the bus configuration.
-     * @return Reference to the current configuration
-     */
-    [[nodiscard]] const SpiBusConfig& GetConfig() const noexcept {
-        return config_;
-    }
-    
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
-    //==============================================//
-    
-    /**
-     * @brief Initialize the SPI bus.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Initialize() noexcept = 0;
-    
-    /**
-     * @brief Deinitialize the SPI bus.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Deinitialize() noexcept = 0;
-    
-    /**
-     * @brief Perform a full-duplex SPI transfer.
-     * @param tx_data Transmit data buffer (can be nullptr for read-only)
-     * @param rx_data Receive data buffer (can be nullptr for write-only)
-     * @param length Number of bytes to transfer
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfSpiErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfSpiErr Transfer(const uint8_t* tx_data, uint8_t* rx_data, 
-                             uint16_t length, uint32_t timeout_ms = 0) noexcept = 0;
+    return initialized_;
+  }
 
-    /**
-     * @brief Assert/deassert the chip select signal.
-     * @param active True to assert CS, false to deassert
-     * @return HfSpiErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfSpiErr SetChipSelect(bool active) noexcept = 0;
-    
-    //==============================================//
-    // CONVENIENCE METHODS WITH DEFAULT IMPLEMENTATIONS //
-    //==============================================//
-    
-    /**
-     * @brief Legacy compatibility: Open and initialize the SPI bus.
-     * @return true if open, false otherwise.
-     */
-    virtual bool Open() noexcept {
-        return EnsureInitialized();
-    }
+  /**
+   * @brief Checks if the bus is initialized.
+   * @return true if initialized, false otherwise
+   */
+  [[nodiscard]] bool IsInitialized() const noexcept {
+    return initialized_;
+  }
 
-    /**
-     * @brief Legacy compatibility: Close and de-initialize the SPI bus.
-     * @return true if closed, false otherwise.
-     */
-    virtual bool Close() noexcept {
-        if (initialized_) {
-            initialized_ = !Deinitialize();
-            return !initialized_;
-        }
-        return true;
-    }
+  /**
+   * @brief Get the bus configuration.
+   * @return Reference to the current configuration
+   */
+  [[nodiscard]] const SpiBusConfig &GetConfig() const noexcept {
+    return config_;
+  }
 
-    /**
-     * @brief Legacy compatibility: Transfer with boolean return.
-     * @param tx_data Transmit data buffer
-     * @param rx_data Receive data buffer
-     * @param length Number of bytes to transfer
-     * @return true if transfer succeeded
-     */
-    virtual bool Transfer(const uint8_t* tx_data, uint8_t* rx_data, 
-                         uint16_t length) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return Transfer(tx_data, rx_data, length, 0) == HfSpiErr::SPI_SUCCESS;
-    }
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
+  //==============================================//
 
-    /**
-     * @brief Write data to SPI bus.
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfSpiErr result code
-     */
-    virtual HfSpiErr Write(const uint8_t* data, uint16_t length, 
-                          uint32_t timeout_ms = 0) noexcept {
-        return Transfer(data, nullptr, length, timeout_ms);
-    }
+  /**
+   * @brief Initialize the SPI bus.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Initialize() noexcept = 0;
 
-    /**
-     * @brief Read data from SPI bus.
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfSpiErr result code
-     */
-    virtual HfSpiErr Read(uint8_t* data, uint16_t length, 
-                         uint32_t timeout_ms = 0) noexcept {
-        return Transfer(nullptr, data, length, timeout_ms);
-    }
+  /**
+   * @brief Deinitialize the SPI bus.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Deinitialize() noexcept = 0;
 
-    /**
-     * @brief Legacy compatibility: Write with boolean return.
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @return true if write succeeded
-     */
-    virtual bool Write(const uint8_t* data, uint16_t length) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return Write(data, length, 0) == HfSpiErr::SPI_SUCCESS;
-    }
+  /**
+   * @brief Perform a full-duplex SPI transfer.
+   * @param tx_data Transmit data buffer (can be nullptr for read-only)
+   * @param rx_data Receive data buffer (can be nullptr for write-only)
+   * @param length Number of bytes to transfer
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfSpiErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfSpiErr Transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                            uint32_t timeout_ms = 0) noexcept = 0;
 
-    /**
-     * @brief Legacy compatibility: Read with boolean return.
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @return true if read succeeded
-     */
-    virtual bool Read(uint8_t* data, uint16_t length) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return Read(data, length, 0) == HfSpiErr::SPI_SUCCESS;
-    }
+  /**
+   * @brief Assert/deassert the chip select signal.
+   * @param active True to assert CS, false to deassert
+   * @return HfSpiErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfSpiErr SetChipSelect(bool active) noexcept = 0;
 
-    /**
-     * @brief Get the configured clock speed.
-     * @return Clock speed in Hz
-     */
-    [[nodiscard]] virtual uint32_t GetClockHz() const noexcept {
-        return config_.clock_speed_hz;
-    }
+  //==============================================//
+  // CONVENIENCE METHODS WITH DEFAULT IMPLEMENTATIONS //
+  //==============================================//
 
-    /**
-     * @brief Get the configured SPI mode.
-     * @return SPI mode (0-3)
-     */
-    [[nodiscard]] virtual uint8_t GetMode() const noexcept {
-        return config_.mode;
-    }
+  /**
+   * @brief Legacy compatibility: Open and initialize the SPI bus.
+   * @return true if open, false otherwise.
+   */
+  virtual bool Open() noexcept {
+    return EnsureInitialized();
+  }
 
-    /**
-     * @brief Get the configured bits per word.
-     * @return Bits per word
-     */
-    [[nodiscard]] virtual uint8_t GetBitsPerWord() const noexcept {
-        return config_.bits_per_word;
+  /**
+   * @brief Legacy compatibility: Close and de-initialize the SPI bus.
+   * @return true if closed, false otherwise.
+   */
+  virtual bool Close() noexcept {
+    if (initialized_) {
+      initialized_ = !Deinitialize();
+      return !initialized_;
     }
+    return true;
+  }
 
-    /**
-     * @brief Get the SPI host/controller.
-     * @return SPI host number
-     */
-    [[nodiscard]] virtual HfHostId GetHost() const noexcept { 
-        return config_.host; 
+  /**
+   * @brief Legacy compatibility: Transfer with boolean return.
+   * @param tx_data Transmit data buffer
+   * @param rx_data Receive data buffer
+   * @param length Number of bytes to transfer
+   * @return true if transfer succeeded
+   */
+  virtual bool Transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
     }
+    return Transfer(tx_data, rx_data, length, 0) == HfSpiErr::SPI_SUCCESS;
+  }
 
-    /**
-     * @brief Write single byte to SPI bus.
-     * @param data Byte to write
-     * @return true if successful, false otherwise
-     */
-    virtual bool WriteByte(uint8_t data) noexcept {
-        return Write(&data, 1) == HfSpiErr::SPI_SUCCESS;
-    }
+  /**
+   * @brief Write data to SPI bus.
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfSpiErr result code
+   */
+  virtual HfSpiErr Write(const uint8_t *data, uint16_t length, uint32_t timeout_ms = 0) noexcept {
+    return Transfer(data, nullptr, length, timeout_ms);
+  }
 
-    /**
-     * @brief Read single byte from SPI bus.
-     * @param data Output: byte read
-     * @return true if successful, false otherwise
-     */
-    virtual bool ReadByte(uint8_t& data) noexcept {
-        return Read(&data, 1) == HfSpiErr::SPI_SUCCESS;
-    }
+  /**
+   * @brief Read data from SPI bus.
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfSpiErr result code
+   */
+  virtual HfSpiErr Read(uint8_t *data, uint16_t length, uint32_t timeout_ms = 0) noexcept {
+    return Transfer(nullptr, data, length, timeout_ms);
+  }
 
-    /**
-     * @brief Write single byte and read response.
-     * @param tx_data Byte to write
-     * @param rx_data Output: byte read
-     * @return true if successful, false otherwise
-     */
-    virtual bool TransferByte(uint8_t tx_data, uint8_t& rx_data) noexcept {
-        return Transfer(&tx_data, &rx_data, 1) == HfSpiErr::SPI_SUCCESS;
+  /**
+   * @brief Legacy compatibility: Write with boolean return.
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @return true if write succeeded
+   */
+  virtual bool Write(const uint8_t *data, uint16_t length) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
     }
+    return Write(data, length, 0) == HfSpiErr::SPI_SUCCESS;
+  }
+
+  /**
+   * @brief Legacy compatibility: Read with boolean return.
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @return true if read succeeded
+   */
+  virtual bool Read(uint8_t *data, uint16_t length) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
+    }
+    return Read(data, length, 0) == HfSpiErr::SPI_SUCCESS;
+  }
+
+  /**
+   * @brief Get the configured clock speed.
+   * @return Clock speed in Hz
+   */
+  [[nodiscard]] virtual uint32_t GetClockHz() const noexcept {
+    return config_.clock_speed_hz;
+  }
+
+  /**
+   * @brief Get the configured SPI mode.
+   * @return SPI mode (0-3)
+   */
+  [[nodiscard]] virtual uint8_t GetMode() const noexcept {
+    return config_.mode;
+  }
+
+  /**
+   * @brief Get the configured bits per word.
+   * @return Bits per word
+   */
+  [[nodiscard]] virtual uint8_t GetBitsPerWord() const noexcept {
+    return config_.bits_per_word;
+  }
+
+  /**
+   * @brief Get the SPI host/controller.
+   * @return SPI host number
+   */
+  [[nodiscard]] virtual HfHostId GetHost() const noexcept {
+    return config_.host;
+  }
+
+  /**
+   * @brief Write single byte to SPI bus.
+   * @param data Byte to write
+   * @return true if successful, false otherwise
+   */
+  virtual bool WriteByte(uint8_t data) noexcept {
+    return Write(&data, 1) == HfSpiErr::SPI_SUCCESS;
+  }
+
+  /**
+   * @brief Read single byte from SPI bus.
+   * @param data Output: byte read
+   * @return true if successful, false otherwise
+   */
+  virtual bool ReadByte(uint8_t &data) noexcept {
+    return Read(&data, 1) == HfSpiErr::SPI_SUCCESS;
+  }
+
+  /**
+   * @brief Write single byte and read response.
+   * @param tx_data Byte to write
+   * @param rx_data Output: byte read
+   * @return true if successful, false otherwise
+   */
+  virtual bool TransferByte(uint8_t tx_data, uint8_t &rx_data) noexcept {
+    return Transfer(&tx_data, &rx_data, 1) == HfSpiErr::SPI_SUCCESS;
+  }
 
 protected:
-    SpiBusConfig config_;                ///< Bus configuration
-    bool initialized_;                   ///< Initialization state
+  SpiBusConfig config_; ///< Bus configuration
+  bool initialized_;    ///< Initialization state
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASESPI_H_

--- a/inc/base/BaseUart.h
+++ b/inc/base/BaseUart.h
@@ -28,50 +28,50 @@
  *          consistent error reporting and handling.
  */
 
-#define HF_UART_ERR_LIST(X) \
-    /* Success codes */ \
-    X(UART_SUCCESS, 0, "Success") \
-    /* General errors */ \
-    X(UART_ERR_FAILURE, 1, "General failure") \
-    X(UART_ERR_NOT_INITIALIZED, 2, "Not initialized") \
-    X(UART_ERR_ALREADY_INITIALIZED, 3, "Already initialized") \
-    X(UART_ERR_INVALID_PARAMETER, 4, "Invalid parameter") \
-    X(UART_ERR_NULL_POINTER, 5, "Null pointer") \
-    X(UART_ERR_OUT_OF_MEMORY, 6, "Out of memory") \
-    /* Communication errors */ \
-    X(UART_ERR_TIMEOUT, 7, "Operation timeout") \
-    X(UART_ERR_BUFFER_FULL, 8, "Buffer full") \
-    X(UART_ERR_BUFFER_EMPTY, 9, "Buffer empty") \
-    X(UART_ERR_TRANSMISSION_FAILED, 10, "Transmission failed") \
-    X(UART_ERR_RECEPTION_FAILED, 11, "Reception failed") \
-    /* Frame errors */ \
-    X(UART_ERR_FRAME_ERROR, 12, "Frame error") \
-    X(UART_ERR_PARITY_ERROR, 13, "Parity error") \
-    X(UART_ERR_OVERRUN_ERROR, 14, "Overrun error") \
-    X(UART_ERR_NOISE_ERROR, 15, "Noise error") \
-    X(UART_ERR_BREAK_DETECTED, 16, "Break condition detected") \
-    /* Hardware errors */ \
-    X(UART_ERR_HARDWARE_FAULT, 17, "Hardware fault") \
-    X(UART_ERR_COMMUNICATION_FAILURE, 18, "Communication failure") \
-    X(UART_ERR_DEVICE_NOT_RESPONDING, 19, "Device not responding") \
-    X(UART_ERR_VOLTAGE_OUT_OF_RANGE, 20, "Voltage out of range") \
-    /* Configuration errors */ \
-    X(UART_ERR_INVALID_CONFIGURATION, 21, "Invalid configuration") \
-    X(UART_ERR_UNSUPPORTED_OPERATION, 22, "Unsupported operation") \
-    X(UART_ERR_INVALID_BAUD_RATE, 23, "Invalid baud rate") \
-    X(UART_ERR_INVALID_DATA_BITS, 24, "Invalid data bits") \
-    X(UART_ERR_INVALID_PARITY, 25, "Invalid parity") \
-    X(UART_ERR_INVALID_STOP_BITS, 26, "Invalid stop bits") \
-    X(UART_ERR_PIN_CONFIGURATION_ERROR, 27, "Pin configuration error") \
-    X(UART_ERR_FLOW_CONTROL_ERROR, 28, "Flow control error") \
-    /* System errors */ \
-    X(UART_ERR_SYSTEM_ERROR, 29, "System error") \
-    X(UART_ERR_PERMISSION_DENIED, 30, "Permission denied") \
-    X(UART_ERR_OPERATION_ABORTED, 31, "Operation aborted")
+#define HF_UART_ERR_LIST(X)                                                                        \
+  /* Success codes */                                                                              \
+  X(UART_SUCCESS, 0, "Success")                                                                    \
+  /* General errors */                                                                             \
+  X(UART_ERR_FAILURE, 1, "General failure")                                                        \
+  X(UART_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                \
+  X(UART_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                        \
+  X(UART_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                            \
+  X(UART_ERR_NULL_POINTER, 5, "Null pointer")                                                      \
+  X(UART_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                    \
+  /* Communication errors */                                                                       \
+  X(UART_ERR_TIMEOUT, 7, "Operation timeout")                                                      \
+  X(UART_ERR_BUFFER_FULL, 8, "Buffer full")                                                        \
+  X(UART_ERR_BUFFER_EMPTY, 9, "Buffer empty")                                                      \
+  X(UART_ERR_TRANSMISSION_FAILED, 10, "Transmission failed")                                       \
+  X(UART_ERR_RECEPTION_FAILED, 11, "Reception failed")                                             \
+  /* Frame errors */                                                                               \
+  X(UART_ERR_FRAME_ERROR, 12, "Frame error")                                                       \
+  X(UART_ERR_PARITY_ERROR, 13, "Parity error")                                                     \
+  X(UART_ERR_OVERRUN_ERROR, 14, "Overrun error")                                                   \
+  X(UART_ERR_NOISE_ERROR, 15, "Noise error")                                                       \
+  X(UART_ERR_BREAK_DETECTED, 16, "Break condition detected")                                       \
+  /* Hardware errors */                                                                            \
+  X(UART_ERR_HARDWARE_FAULT, 17, "Hardware fault")                                                 \
+  X(UART_ERR_COMMUNICATION_FAILURE, 18, "Communication failure")                                   \
+  X(UART_ERR_DEVICE_NOT_RESPONDING, 19, "Device not responding")                                   \
+  X(UART_ERR_VOLTAGE_OUT_OF_RANGE, 20, "Voltage out of range")                                     \
+  /* Configuration errors */                                                                       \
+  X(UART_ERR_INVALID_CONFIGURATION, 21, "Invalid configuration")                                   \
+  X(UART_ERR_UNSUPPORTED_OPERATION, 22, "Unsupported operation")                                   \
+  X(UART_ERR_INVALID_BAUD_RATE, 23, "Invalid baud rate")                                           \
+  X(UART_ERR_INVALID_DATA_BITS, 24, "Invalid data bits")                                           \
+  X(UART_ERR_INVALID_PARITY, 25, "Invalid parity")                                                 \
+  X(UART_ERR_INVALID_STOP_BITS, 26, "Invalid stop bits")                                           \
+  X(UART_ERR_PIN_CONFIGURATION_ERROR, 27, "Pin configuration error")                               \
+  X(UART_ERR_FLOW_CONTROL_ERROR, 28, "Flow control error")                                         \
+  /* System errors */                                                                              \
+  X(UART_ERR_SYSTEM_ERROR, 29, "System error")                                                     \
+  X(UART_ERR_PERMISSION_DENIED, 30, "Permission denied")                                           \
+  X(UART_ERR_OPERATION_ABORTED, 31, "Operation aborted")
 
 enum class HfUartErr : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
-    HF_UART_ERR_LIST(X)
+  HF_UART_ERR_LIST(X)
 #undef X
 };
 
@@ -81,12 +81,15 @@ enum class HfUartErr : uint8_t {
  * @return String view of the error description
  */
 constexpr std::string_view HfUartErrToString(HfUartErr err) noexcept {
-    switch (err) {
-#define X(NAME, VALUE, DESC) case HfUartErr::NAME: return DESC;
-        HF_UART_ERR_LIST(X)
+  switch (err) {
+#define X(NAME, VALUE, DESC)                                                                       \
+  case HfUartErr::NAME:                                                                            \
+    return DESC;
+    HF_UART_ERR_LIST(X)
 #undef X
-        default: return "Unknown error";
-    }
+  default:
+    return "Unknown error";
+  }
 }
 
 //--------------------------------------
@@ -99,36 +102,33 @@ constexpr std::string_view HfUartErrToString(HfUartErr err) noexcept {
  *          supporting various platforms and UART modes without MCU-specific types.
  */
 struct UartConfig {
-    HfBaudRate baud_rate;                      ///< Baud rate (bits per second)
-    uint8_t data_bits;                       ///< Data bits (5-8, typically 8)
-    uint8_t parity;                          ///< Parity: 0=None, 1=Even, 2=Odd
-    uint8_t stop_bits;                       ///< Stop bits (1-2, typically 1)
-    bool use_hardware_flow_control;          ///< Enable hardware flow control (RTS/CTS)
-    HfPinNumber tx_pin;                        ///< TX (transmit) pin
-    HfPinNumber rx_pin;                        ///< RX (receive) pin
-    HfPinNumber rts_pin;                       ///< RTS (Request To Send) pin (optional)
-    HfPinNumber cts_pin;                       ///< CTS (Clear To Send) pin (optional)
-    uint16_t tx_buffer_size;                 ///< TX buffer size in bytes
-    uint16_t rx_buffer_size;                 ///< RX buffer size in bytes
-    HfTimeoutMs timeout_ms;                    ///< Default timeout for operations in milliseconds
-    
-    /**
-     * @brief Default constructor with sensible defaults.
-     */
-    UartConfig() noexcept :
-        baud_rate(115200),                  // Common baud rate
-        data_bits(8),                       // 8 data bits
-        parity(0),                          // No parity
-        stop_bits(1),                       // 1 stop bit
-        use_hardware_flow_control(false),   // No flow control by default
-        tx_pin(HF_INVALID_PIN),
-        rx_pin(HF_INVALID_PIN),
-        rts_pin(HF_INVALID_PIN),
-        cts_pin(HF_INVALID_PIN),
-        tx_buffer_size(256),                // 256 bytes TX buffer
-        rx_buffer_size(256),                // 256 bytes RX buffer
-        timeout_ms(1000)                    // 1 second timeout
-    {}
+  HfBaudRate baud_rate;           ///< Baud rate (bits per second)
+  uint8_t data_bits;              ///< Data bits (5-8, typically 8)
+  uint8_t parity;                 ///< Parity: 0=None, 1=Even, 2=Odd
+  uint8_t stop_bits;              ///< Stop bits (1-2, typically 1)
+  bool use_hardware_flow_control; ///< Enable hardware flow control (RTS/CTS)
+  HfPinNumber tx_pin;             ///< TX (transmit) pin
+  HfPinNumber rx_pin;             ///< RX (receive) pin
+  HfPinNumber rts_pin;            ///< RTS (Request To Send) pin (optional)
+  HfPinNumber cts_pin;            ///< CTS (Clear To Send) pin (optional)
+  uint16_t tx_buffer_size;        ///< TX buffer size in bytes
+  uint16_t rx_buffer_size;        ///< RX buffer size in bytes
+  HfTimeoutMs timeout_ms;         ///< Default timeout for operations in milliseconds
+
+  /**
+   * @brief Default constructor with sensible defaults.
+   */
+  UartConfig() noexcept
+      : baud_rate(115200),                // Common baud rate
+        data_bits(8),                     // 8 data bits
+        parity(0),                        // No parity
+        stop_bits(1),                     // 1 stop bit
+        use_hardware_flow_control(false), // No flow control by default
+        tx_pin(HF_INVALID_PIN), rx_pin(HF_INVALID_PIN), rts_pin(HF_INVALID_PIN),
+        cts_pin(HF_INVALID_PIN), tx_buffer_size(256), // 256 bytes TX buffer
+        rx_buffer_size(256),                          // 256 bytes RX buffer
+        timeout_ms(1000)                              // 1 second timeout
+  {}
 };
 
 //--------------------------------------
@@ -148,305 +148,304 @@ struct UartConfig {
  *          - Comprehensive error handling and status reporting
  *          - Printf-style formatted output
  *          - Lazy initialization pattern
- *          
+ *
  *          Derived classes implement platform-specific details for:
  *          - MCU UART controllers (ESP32, STM32, etc.)
  *          - USB-to-serial adapters
  *          - Bluetooth/WiFi serial bridges
  *          - Bit-banged software UART implementations
- * 
+ *
  * @note This is a header-only abstract base class - instantiate concrete implementations instead.
  * @note This class is not inherently thread-safe. Use appropriate synchronization if
  *       accessed from multiple contexts.
  */
 class BaseUart {
 public:
-    /**
-     * @brief Constructor with port and configuration.
-     * @param port UART port number
-     * @param config UART configuration parameters
-     */
-    BaseUart(HfPortNumber port, const UartConfig& config) noexcept :
-        port_(port), config_(config), initialized_(false) {}
+  /**
+   * @brief Constructor with port and configuration.
+   * @param port UART port number
+   * @param config UART configuration parameters
+   */
+  BaseUart(HfPortNumber port, const UartConfig &config) noexcept
+      : port_(port), config_(config), initialized_(false) {}
 
-    /**
-     * @brief Virtual destructor ensures proper cleanup in derived classes.
-     */
-    virtual ~BaseUart() noexcept = default;
-    
-    // Non-copyable, non-movable (can be changed in derived classes if needed)
-    BaseUart(const BaseUart&) = delete;
-    BaseUart& operator=(const BaseUart&) = delete;
-    BaseUart(BaseUart&&) = delete;
-    BaseUart& operator=(BaseUart&&) = delete;
+  /**
+   * @brief Virtual destructor ensures proper cleanup in derived classes.
+   */
+  virtual ~BaseUart() noexcept = default;
 
-    /**
-     * @brief Ensures that the UART is initialized (lazy initialization).
-     * @return true if the UART is initialized, false otherwise.
-     */
-    bool EnsureInitialized() noexcept {
-        if (!initialized_) {
-            initialized_ = Initialize();
-        }
-        return initialized_;
-    }
+  // Non-copyable, non-movable (can be changed in derived classes if needed)
+  BaseUart(const BaseUart &) = delete;
+  BaseUart &operator=(const BaseUart &) = delete;
+  BaseUart(BaseUart &&) = delete;
+  BaseUart &operator=(BaseUart &&) = delete;
 
-    /**
-     * @brief Checks if the driver is initialized.
-     * @return true if initialized, false otherwise
-     */
-    [[nodiscard]] bool IsInitialized() const noexcept {
-        return initialized_;
+  /**
+   * @brief Ensures that the UART is initialized (lazy initialization).
+   * @return true if the UART is initialized, false otherwise.
+   */
+  bool EnsureInitialized() noexcept {
+    if (!initialized_) {
+      initialized_ = Initialize();
     }
-    
-    /**
-     * @brief Get the UART configuration.
-     * @return Reference to the current configuration
-     */
-    [[nodiscard]] const UartConfig& GetConfig() const noexcept {
-        return config_;
-    }
-    
-    /**
-     * @brief Get the UART port number.
-     * @return UART port number
-     */
-    [[nodiscard]] HfPortNumber GetPort() const noexcept { 
-        return port_; 
-    }
-    
-    //==============================================//
-    // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
-    //==============================================//
-    
-    /**
-     * @brief Initialize the UART driver.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Initialize() noexcept = 0;
-    
-    /**
-     * @brief Deinitialize the UART driver.
-     * @return true if successful, false otherwise
-     * @note Must be implemented by concrete classes.
-     */
-    virtual bool Deinitialize() noexcept = 0;
-    
-    /**
-     * @brief Write data to the UART.
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfUartErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfUartErr Write(const uint8_t* data, uint16_t length, 
-                           uint32_t timeout_ms = 0) noexcept = 0;
+    return initialized_;
+  }
 
-    /**
-     * @brief Read data from the UART.
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfUartErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfUartErr Read(uint8_t* data, uint16_t length, 
+  /**
+   * @brief Checks if the driver is initialized.
+   * @return true if initialized, false otherwise
+   */
+  [[nodiscard]] bool IsInitialized() const noexcept {
+    return initialized_;
+  }
+
+  /**
+   * @brief Get the UART configuration.
+   * @return Reference to the current configuration
+   */
+  [[nodiscard]] const UartConfig &GetConfig() const noexcept {
+    return config_;
+  }
+
+  /**
+   * @brief Get the UART port number.
+   * @return UART port number
+   */
+  [[nodiscard]] HfPortNumber GetPort() const noexcept {
+    return port_;
+  }
+
+  //==============================================//
+  // PURE VIRTUAL FUNCTIONS - MUST BE OVERRIDDEN  //
+  //==============================================//
+
+  /**
+   * @brief Initialize the UART driver.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Initialize() noexcept = 0;
+
+  /**
+   * @brief Deinitialize the UART driver.
+   * @return true if successful, false otherwise
+   * @note Must be implemented by concrete classes.
+   */
+  virtual bool Deinitialize() noexcept = 0;
+
+  /**
+   * @brief Write data to the UART.
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfUartErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfUartErr Write(const uint8_t *data, uint16_t length,
                           uint32_t timeout_ms = 0) noexcept = 0;
 
-    /**
-     * @brief Get the number of bytes available to read.
-     * @return Number of bytes available in the receive buffer
-     * @note Must be implemented by concrete classes.
-     */
-    virtual uint16_t BytesAvailable() noexcept = 0;
+  /**
+   * @brief Read data from the UART.
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfUartErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfUartErr Read(uint8_t *data, uint16_t length, uint32_t timeout_ms = 0) noexcept = 0;
 
-    /**
-     * @brief Flush the transmit buffer.
-     * @return HfUartErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfUartErr FlushTx() noexcept = 0;
+  /**
+   * @brief Get the number of bytes available to read.
+   * @return Number of bytes available in the receive buffer
+   * @note Must be implemented by concrete classes.
+   */
+  virtual uint16_t BytesAvailable() noexcept = 0;
 
-    /**
-     * @brief Flush the receive buffer.
-     * @return HfUartErr result code
-     * @note Must be implemented by concrete classes.
-     */
-    virtual HfUartErr FlushRx() noexcept = 0;
-    
-    //==============================================//
-    // CONVENIENCE METHODS WITH DEFAULT IMPLEMENTATIONS //
-    //==============================================//
-    
-    /**
-     * @brief Legacy compatibility: Open and initialize the UART.
-     * @return true if open, false otherwise.
-     */
-    virtual bool Open() noexcept {
-        return EnsureInitialized();
+  /**
+   * @brief Flush the transmit buffer.
+   * @return HfUartErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfUartErr FlushTx() noexcept = 0;
+
+  /**
+   * @brief Flush the receive buffer.
+   * @return HfUartErr result code
+   * @note Must be implemented by concrete classes.
+   */
+  virtual HfUartErr FlushRx() noexcept = 0;
+
+  //==============================================//
+  // CONVENIENCE METHODS WITH DEFAULT IMPLEMENTATIONS //
+  //==============================================//
+
+  /**
+   * @brief Legacy compatibility: Open and initialize the UART.
+   * @return true if open, false otherwise.
+   */
+  virtual bool Open() noexcept {
+    return EnsureInitialized();
+  }
+
+  /**
+   * @brief Legacy compatibility: Close and de-initialize the UART.
+   * @return true if closed, false otherwise.
+   */
+  virtual bool Close() noexcept {
+    if (initialized_) {
+      initialized_ = !Deinitialize();
+      return !initialized_;
     }
+    return true;
+  }
 
-    /**
-     * @brief Legacy compatibility: Close and de-initialize the UART.
-     * @return true if closed, false otherwise.
-     */
-    virtual bool Close() noexcept {
-        if (initialized_) {
-            initialized_ = !Deinitialize();
-            return !initialized_;
-        }
-        return true;
+  /**
+   * @brief Legacy compatibility: Write with boolean return.
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @return true if write succeeded
+   */
+  virtual bool Write(const uint8_t *data, uint16_t length) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
     }
+    return Write(data, length, 0) == HfUartErr::UART_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: Write with boolean return.
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @return true if write succeeded
-     */
-    virtual bool Write(const uint8_t *data, uint16_t length) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return Write(data, length, 0) == HfUartErr::UART_SUCCESS;
+  /**
+   * @brief Legacy compatibility: Read with boolean return.
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds
+   * @return true if read succeeded
+   */
+  virtual bool Read(uint8_t *data, uint16_t length, uint32_t timeout_ms = UINT32_MAX) noexcept {
+    if (!EnsureInitialized()) {
+      return false;
     }
+    uint32_t timeout = (timeout_ms == UINT32_MAX) ? config_.timeout_ms : timeout_ms;
+    return Read(data, length, timeout) == HfUartErr::UART_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: Read with boolean return.
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds
-     * @return true if read succeeded
-     */
-    virtual bool Read(uint8_t *data, uint16_t length, uint32_t timeout_ms = UINT32_MAX) noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        uint32_t timeout = (timeout_ms == UINT32_MAX) ? config_.timeout_ms : timeout_ms;
-        return Read(data, length, timeout) == HfUartErr::UART_SUCCESS;
+  /**
+   * @brief Write string data.
+   * @param str Null-terminated string to write
+   * @return true if successful, false otherwise
+   */
+  virtual bool WriteString(const char *str) noexcept {
+    if (!str) {
+      return false;
     }
-
-    /**
-     * @brief Write string data.
-     * @param str Null-terminated string to write
-     * @return true if successful, false otherwise
-     */
-    virtual bool WriteString(const char* str) noexcept {
-        if (!str) {
-            return false;
-        }
-        // Calculate string length (simple strlen implementation)
-        uint16_t len = 0;
-        while (str[len] != '\0') {
-            len++;
-        }
-        return Write(reinterpret_cast<const uint8_t*>(str), len) == HfUartErr::UART_SUCCESS;
+    // Calculate string length (simple strlen implementation)
+    uint16_t len = 0;
+    while (str[len] != '\0') {
+      len++;
     }
+    return Write(reinterpret_cast<const uint8_t *>(str), len) == HfUartErr::UART_SUCCESS;
+  }
 
-    /**
-     * @brief Write single byte.
-     * @param byte Byte to write
-     * @return true if successful, false otherwise
-     */
-    virtual bool WriteByte(uint8_t byte) noexcept {
-        return Write(&byte, 1) == HfUartErr::UART_SUCCESS;
+  /**
+   * @brief Write single byte.
+   * @param byte Byte to write
+   * @return true if successful, false otherwise
+   */
+  virtual bool WriteByte(uint8_t byte) noexcept {
+    return Write(&byte, 1) == HfUartErr::UART_SUCCESS;
+  }
+
+  /**
+   * @brief Read single byte.
+   * @param byte Output: byte read
+   * @param timeout_ms Timeout in milliseconds
+   * @return true if successful, false otherwise
+   */
+  virtual bool ReadByte(uint8_t &byte, uint32_t timeout_ms = 1000) noexcept {
+    return Read(&byte, 1, timeout_ms) == HfUartErr::UART_SUCCESS;
+  }
+
+  /**
+   * @brief Legacy compatibility: Flush transmit buffer with boolean return.
+   * @return true if successful, false otherwise
+   */
+  virtual bool FlushTx() noexcept {
+    if (!EnsureInitialized()) {
+      return false;
     }
+    return FlushTx() == HfUartErr::UART_SUCCESS;
+  }
 
-    /**
-     * @brief Read single byte.
-     * @param byte Output: byte read
-     * @param timeout_ms Timeout in milliseconds
-     * @return true if successful, false otherwise
-     */
-    virtual bool ReadByte(uint8_t& byte, uint32_t timeout_ms = 1000) noexcept {
-        return Read(&byte, 1, timeout_ms) == HfUartErr::UART_SUCCESS;
+  /**
+   * @brief Legacy compatibility: Flush receive buffer with boolean return.
+   * @return true if successful, false otherwise
+   */
+  virtual bool FlushRx() noexcept {
+    if (!EnsureInitialized()) {
+      return false;
     }
+    return FlushRx() == HfUartErr::UART_SUCCESS;
+  }
 
-    /**
-     * @brief Legacy compatibility: Flush transmit buffer with boolean return.
-     * @return true if successful, false otherwise
-     */
-    virtual bool FlushTx() noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return FlushTx() == HfUartErr::UART_SUCCESS;
-    }
+  /**
+   * @brief Set timeout for read operations.
+   * @param timeout_ms Timeout in milliseconds
+   */
+  virtual void SetReadTimeout(uint32_t timeout_ms) noexcept {
+    config_.timeout_ms = timeout_ms;
+  }
 
-    /**
-     * @brief Legacy compatibility: Flush receive buffer with boolean return.
-     * @return true if successful, false otherwise
-     */
-    virtual bool FlushRx() noexcept {
-        if (!EnsureInitialized()) {
-            return false;
-        }
-        return FlushRx() == HfUartErr::UART_SUCCESS;
-    }
+  /**
+   * @brief Get the configured baud rate.
+   * @return Baud rate in bits per second
+   */
+  [[nodiscard]] virtual HfBaudRate GetBaudRate() const noexcept {
+    return config_.baud_rate;
+  }
 
-    /**
-     * @brief Set timeout for read operations.
-     * @param timeout_ms Timeout in milliseconds
-     */
-    virtual void SetReadTimeout(uint32_t timeout_ms) noexcept {
-        config_.timeout_ms = timeout_ms;
-    }
+  /**
+   * @brief Get the configured data bits.
+   * @return Number of data bits
+   */
+  [[nodiscard]] virtual uint8_t GetDataBits() const noexcept {
+    return config_.data_bits;
+  }
 
-    /**
-     * @brief Get the configured baud rate.
-     * @return Baud rate in bits per second
-     */
-    [[nodiscard]] virtual HfBaudRate GetBaudRate() const noexcept {
-        return config_.baud_rate;
-    }
+  /**
+   * @brief Get the configured parity setting.
+   * @return Parity setting (0=None, 1=Even, 2=Odd)
+   */
+  [[nodiscard]] virtual uint8_t GetParity() const noexcept {
+    return config_.parity;
+  }
 
-    /**
-     * @brief Get the configured data bits.
-     * @return Number of data bits
-     */
-    [[nodiscard]] virtual uint8_t GetDataBits() const noexcept {
-        return config_.data_bits;
-    }
+  /**
+   * @brief Get the configured stop bits.
+   * @return Number of stop bits
+   */
+  [[nodiscard]] virtual uint8_t GetStopBits() const noexcept {
+    return config_.stop_bits;
+  }
 
-    /**
-     * @brief Get the configured parity setting.
-     * @return Parity setting (0=None, 1=Even, 2=Odd)
-     */
-    [[nodiscard]] virtual uint8_t GetParity() const noexcept {
-        return config_.parity;
-    }
+  /**
+   * @brief Check if hardware flow control is enabled.
+   * @return true if hardware flow control is enabled
+   */
+  [[nodiscard]] virtual bool IsFlowControlEnabled() const noexcept {
+    return config_.use_hardware_flow_control;
+  }
 
-    /**
-     * @brief Get the configured stop bits.
-     * @return Number of stop bits
-     */
-    [[nodiscard]] virtual uint8_t GetStopBits() const noexcept {
-        return config_.stop_bits;
-    }
-
-    /**
-     * @brief Check if hardware flow control is enabled.
-     * @return true if hardware flow control is enabled
-     */
-    [[nodiscard]] virtual bool IsFlowControlEnabled() const noexcept {
-        return config_.use_hardware_flow_control;
-    }
-
-    /**
-     * @brief Printf-style formatted output.
-     * @param format Format string
-     * @param ... Format arguments
-     * @return Number of characters written, or -1 on error
-     * @note This is a virtual method that can be overridden for platform-specific implementations
-     */
-    virtual int Printf(const char* format, ...) noexcept = 0;
+  /**
+   * @brief Printf-style formatted output.
+   * @param format Format string
+   * @param ... Format arguments
+   * @return Number of characters written, or -1 on error
+   * @note This is a virtual method that can be overridden for platform-specific implementations
+   */
+  virtual int Printf(const char *format, ...) noexcept = 0;
 
 protected:
-    HfPortNumber port_;                    ///< UART port number
-    UartConfig config_;                  ///< UART configuration
-    bool initialized_;                   ///< Initialization state
+  HfPortNumber port_; ///< UART port number
+  UartConfig config_; ///< UART configuration
+  bool initialized_;  ///< Initialization state
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_BASEUART_H_

--- a/inc/base/HardwareTypes.h
+++ b/inc/base/HardwareTypes.h
@@ -113,7 +113,7 @@ using HfTimestampUs = uint32_t;
  * @return true if valid, false otherwise
  */
 constexpr bool IsValidPin(HfPinNumber pin) noexcept {
-    return pin >= 0 && pin <= HF_MAX_PIN_NUMBER;
+  return pin >= 0 && pin <= HF_MAX_PIN_NUMBER;
 }
 
 /**
@@ -122,7 +122,7 @@ constexpr bool IsValidPin(HfPinNumber pin) noexcept {
  * @return true if valid, false otherwise
  */
 constexpr bool IsValidPort(HfPortNumber port) noexcept {
-    return port != HF_INVALID_PORT;
+  return port != HF_INVALID_PORT;
 }
 
 /**
@@ -131,7 +131,7 @@ constexpr bool IsValidPort(HfPortNumber port) noexcept {
  * @return true if valid, false otherwise
  */
 constexpr bool IsValidHost(HfHostId host) noexcept {
-    return host != HF_INVALID_HOST;
+  return host != HF_INVALID_HOST;
 }
 
 /**
@@ -140,7 +140,7 @@ constexpr bool IsValidHost(HfHostId host) noexcept {
  * @return true if valid, false otherwise
  */
 constexpr bool IsValidChannel(HfChannelId channel) noexcept {
-    return channel != HF_INVALID_CHANNEL;
+  return channel != HF_INVALID_CHANNEL;
 }
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_HARDWARETYPES_H_

--- a/inc/mcu/McuAdc.h
+++ b/inc/mcu/McuAdc.h
@@ -16,23 +16,23 @@
 #include "BaseAdc.h"
 #include "McuTypes.h"
 #include <cstdint>
-#include <memory>
 #include <functional>
-#include <vector>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 
 #ifdef ESP_PLATFORM
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_continuous.h"
 #include "esp_adc/adc_filter.h"
 #include "esp_adc/adc_monitor.h"
-#include "esp_adc/adc_cali.h"
-#include "esp_adc/adc_cali_scheme.h"
-#include "soc/adc_channel.h"
-#include "hal/adc_types.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "hal/adc_types.h"
+#include "soc/adc_channel.h"
 #endif
 
 //--------------------------------------
@@ -43,192 +43,196 @@
  * @brief ADC continuous mode sampling strategies.
  */
 enum class AdcSamplingStrategy : uint8_t {
-    Single = 0,             ///< Single-shot conversion
-    Continuous = 1,         ///< Continuous conversion with DMA
-    Burst = 2,              ///< Burst mode (fixed number of samples)
-    Triggered = 3,          ///< External trigger-based sampling
-    ZeroCrossing = 4        ///< Zero-crossing detection mode
+  Single = 0,      ///< Single-shot conversion
+  Continuous = 1,  ///< Continuous conversion with DMA
+  Burst = 2,       ///< Burst mode (fixed number of samples)
+  Triggered = 3,   ///< External trigger-based sampling
+  ZeroCrossing = 4 ///< Zero-crossing detection mode
 };
 
 /**
  * @brief ADC trigger sources for advanced sampling.
  */
 enum class AdcTriggerSource : uint8_t {
-    Software = 0,           ///< Software trigger (manual)
-    Timer = 1,              ///< Timer-based trigger
-    GPIO = 2,               ///< GPIO edge trigger
-    PWM = 3,                ///< PWM sync trigger
-    External = 4,           ///< External trigger signal
-    ULP = 5                 ///< ULP processor trigger
+  Software = 0, ///< Software trigger (manual)
+  Timer = 1,    ///< Timer-based trigger
+  GPIO = 2,     ///< GPIO edge trigger
+  PWM = 3,      ///< PWM sync trigger
+  External = 4, ///< External trigger signal
+  ULP = 5       ///< ULP processor trigger
 };
 
 /**
  * @brief ADC digital filter types supported by ESP32C6.
  */
 enum class AdcFilterType : uint8_t {
-    None = 0,               ///< No filtering
-    IIR = 1,                ///< IIR digital filter
-    FIR = 2,                ///< FIR digital filter (if available)
-    MovingAverage = 3       ///< Moving average filter
+  None = 0,         ///< No filtering
+  IIR = 1,          ///< IIR digital filter
+  FIR = 2,          ///< FIR digital filter (if available)
+  MovingAverage = 3 ///< Moving average filter
 };
 
 /**
  * @brief ADC power mode settings.
  */
 enum class AdcPowerMode : uint8_t {
-    FullPower = 0,          ///< Maximum performance, highest power
-    LowPower = 1,           ///< Reduced power consumption
-    UltraLowPower = 2,      ///< Minimal power, reduced functionality
-    Sleep = 3               ///< Power-down mode
+  FullPower = 0,     ///< Maximum performance, highest power
+  LowPower = 1,      ///< Reduced power consumption
+  UltraLowPower = 2, ///< Minimal power, reduced functionality
+  Sleep = 3          ///< Power-down mode
 };
 
 /**
  * @brief ADC calibration schemes.
  */
 enum class AdcCalibrationScheme : uint8_t {
-    None = 0,               ///< No calibration
-    LineFitting = 1,        ///< Line fitting calibration
-    Curve = 2,              ///< Curve fitting calibration
-    TwoPoint = 3            ///< Two-point calibration
+  None = 0,        ///< No calibration
+  LineFitting = 1, ///< Line fitting calibration
+  Curve = 2,       ///< Curve fitting calibration
+  TwoPoint = 3     ///< Two-point calibration
 };
 
 /**
  * @brief Continuous mode configuration structure.
  */
 struct AdcContinuousConfig {
-    uint32_t sampleFreqHz;              ///< Sampling frequency in Hz
-    uint32_t convMode;                  ///< Conversion mode (platform-specific)
-    uint32_t format;                    ///< Output data format
-    size_t bufferSize;                  ///< DMA buffer size
-    size_t bufferCount;                 ///< Number of DMA buffers
-    bool enableDMA;                     ///< Enable DMA transfers
-    
-    AdcContinuousConfig() : sampleFreqHz(20000), convMode(0), format(0)
-        , bufferSize(4096), bufferCount(2), enableDMA(true) {}
+  uint32_t sampleFreqHz; ///< Sampling frequency in Hz
+  uint32_t convMode;     ///< Conversion mode (platform-specific)
+  uint32_t format;       ///< Output data format
+  size_t bufferSize;     ///< DMA buffer size
+  size_t bufferCount;    ///< Number of DMA buffers
+  bool enableDMA;        ///< Enable DMA transfers
+
+  AdcContinuousConfig()
+      : sampleFreqHz(20000), convMode(0), format(0), bufferSize(4096), bufferCount(2),
+        enableDMA(true) {}
 };
 
 /**
  * @brief ADC digital filter configuration.
  */
 struct AdcFilterConfig {
-    uint8_t channelId;                  ///< Channel to apply filter
-    AdcFilterType filterType;           ///< Type of filter
-    uint8_t filterCoeff;                ///< Filter coefficient (0-15 for IIR)
-    bool enabled;                       ///< Enable/disable filter
-    
-    AdcFilterConfig() : channelId(0), filterType(AdcFilterType::None)
-        , filterCoeff(2), enabled(false) {}
+  uint8_t channelId;        ///< Channel to apply filter
+  AdcFilterType filterType; ///< Type of filter
+  uint8_t filterCoeff;      ///< Filter coefficient (0-15 for IIR)
+  bool enabled;             ///< Enable/disable filter
+
+  AdcFilterConfig()
+      : channelId(0), filterType(AdcFilterType::None), filterCoeff(2), enabled(false) {}
 };
 
 /**
  * @brief ADC threshold monitor configuration.
  */
 struct AdcMonitorConfig {
-    uint8_t monitorId;                  ///< Monitor ID (0-1 for ESP32C6)
-    uint8_t channelId;                  ///< Channel to monitor
-    uint32_t highThreshold;             ///< High threshold value
-    uint32_t lowThreshold;              ///< Low threshold value
-    bool highThresholdIntEn;            ///< Enable high threshold interrupt
-    bool lowThresholdIntEn;             ///< Enable low threshold interrupt
-    
-    AdcMonitorConfig() : monitorId(0), channelId(0)
-        , highThreshold(4000), lowThreshold(100)
-        , highThresholdIntEn(false), lowThresholdIntEn(false) {}
+  uint8_t monitorId;       ///< Monitor ID (0-1 for ESP32C6)
+  uint8_t channelId;       ///< Channel to monitor
+  uint32_t highThreshold;  ///< High threshold value
+  uint32_t lowThreshold;   ///< Low threshold value
+  bool highThresholdIntEn; ///< Enable high threshold interrupt
+  bool lowThresholdIntEn;  ///< Enable low threshold interrupt
+
+  AdcMonitorConfig()
+      : monitorId(0), channelId(0), highThreshold(4000), lowThreshold(100),
+        highThresholdIntEn(false), lowThresholdIntEn(false) {}
 };
 
 /**
  * @brief ADC calibration configuration.
  */
 struct AdcCalibrationConfig {
-    AdcCalibrationScheme scheme;        ///< Calibration scheme
-    uint32_t attenuation;               ///< Attenuation setting
-    uint32_t bitWidth;                  ///< Bit width for calibration
-    bool autoCalibrate;                 ///< Enable automatic calibration
-    
-    AdcCalibrationConfig() : scheme(AdcCalibrationScheme::LineFitting)
-        , attenuation(0), bitWidth(12), autoCalibrate(true) {}
+  AdcCalibrationScheme scheme; ///< Calibration scheme
+  uint32_t attenuation;        ///< Attenuation setting
+  uint32_t bitWidth;           ///< Bit width for calibration
+  bool autoCalibrate;          ///< Enable automatic calibration
+
+  AdcCalibrationConfig()
+      : scheme(AdcCalibrationScheme::LineFitting), attenuation(0), bitWidth(12),
+        autoCalibrate(true) {}
 };
 
 /**
  * @brief Advanced ADC configuration structure.
  */
 struct AdcAdvancedConfig {
-    // Basic configuration
-    uint8_t adcUnit;                    ///< ADC unit (1 or 2)
-    uint32_t resolution;                ///< Resolution in bits (12, 11, 10, 9)
-    uint32_t attenuation;               ///< Input attenuation
-    uint32_t sampleTime;                ///< Sample time setting
-    
-    // Advanced configuration
-    AdcSamplingStrategy samplingStrategy; ///< Sampling strategy
-    AdcTriggerSource triggerSource;     ///< Trigger source
-    AdcPowerMode powerMode;             ///< Power mode setting
-    bool oversamplingEnabled;           ///< Enable hardware oversampling
-    uint8_t oversamplingRatio;          ///< Oversampling ratio (2^n)
-    
-    // Continuous mode
-    bool continuousMode;                ///< Enable continuous mode
-    AdcContinuousConfig continuousConfig; ///< Continuous mode configuration
-    
-    // Calibration
-    AdcCalibrationConfig calibrationConfig; ///< Calibration configuration
-    
-    // Statistics and diagnostics
-    bool statisticsEnabled;             ///< Enable operation statistics
-    bool diagnosticsEnabled;            ///< Enable diagnostic features
-    
-    AdcAdvancedConfig() : adcUnit(1), resolution(12), attenuation(0), sampleTime(0)
-        , samplingStrategy(AdcSamplingStrategy::Single)
-        , triggerSource(AdcTriggerSource::Software)
-        , powerMode(AdcPowerMode::FullPower)
-        , oversamplingEnabled(false), oversamplingRatio(1)
-        , continuousMode(false), statisticsEnabled(false), diagnosticsEnabled(false) {}
+  // Basic configuration
+  uint8_t adcUnit;      ///< ADC unit (1 or 2)
+  uint32_t resolution;  ///< Resolution in bits (12, 11, 10, 9)
+  uint32_t attenuation; ///< Input attenuation
+  uint32_t sampleTime;  ///< Sample time setting
+
+  // Advanced configuration
+  AdcSamplingStrategy samplingStrategy; ///< Sampling strategy
+  AdcTriggerSource triggerSource;       ///< Trigger source
+  AdcPowerMode powerMode;               ///< Power mode setting
+  bool oversamplingEnabled;             ///< Enable hardware oversampling
+  uint8_t oversamplingRatio;            ///< Oversampling ratio (2^n)
+
+  // Continuous mode
+  bool continuousMode;                  ///< Enable continuous mode
+  AdcContinuousConfig continuousConfig; ///< Continuous mode configuration
+
+  // Calibration
+  AdcCalibrationConfig calibrationConfig; ///< Calibration configuration
+
+  // Statistics and diagnostics
+  bool statisticsEnabled;  ///< Enable operation statistics
+  bool diagnosticsEnabled; ///< Enable diagnostic features
+
+  AdcAdvancedConfig()
+      : adcUnit(1), resolution(12), attenuation(0), sampleTime(0),
+        samplingStrategy(AdcSamplingStrategy::Single), triggerSource(AdcTriggerSource::Software),
+        powerMode(AdcPowerMode::FullPower), oversamplingEnabled(false), oversamplingRatio(1),
+        continuousMode(false), statisticsEnabled(false), diagnosticsEnabled(false) {}
 };
 
 /**
  * @brief ADC operation statistics.
  */
 struct AdcStatistics {
-    uint64_t totalConversions;          ///< Total conversions performed
-    uint64_t successfulConversions;     ///< Successful conversions
-    uint64_t failedConversions;         ///< Failed conversions
-    uint64_t averageConversionTimeUs;   ///< Average conversion time (microseconds)
-    uint64_t maxConversionTimeUs;       ///< Maximum conversion time
-    uint64_t minConversionTimeUs;       ///< Minimum conversion time
-    uint32_t calibrationCount;          ///< Number of calibrations performed
-    uint32_t thresholdViolations;       ///< Threshold monitor violations
-    
-    AdcStatistics() : totalConversions(0), successfulConversions(0), failedConversions(0)
-        , averageConversionTimeUs(0), maxConversionTimeUs(0), minConversionTimeUs(UINT64_MAX)
-        , calibrationCount(0), thresholdViolations(0) {}
+  uint64_t totalConversions;        ///< Total conversions performed
+  uint64_t successfulConversions;   ///< Successful conversions
+  uint64_t failedConversions;       ///< Failed conversions
+  uint64_t averageConversionTimeUs; ///< Average conversion time (microseconds)
+  uint64_t maxConversionTimeUs;     ///< Maximum conversion time
+  uint64_t minConversionTimeUs;     ///< Minimum conversion time
+  uint32_t calibrationCount;        ///< Number of calibrations performed
+  uint32_t thresholdViolations;     ///< Threshold monitor violations
+
+  AdcStatistics()
+      : totalConversions(0), successfulConversions(0), failedConversions(0),
+        averageConversionTimeUs(0), maxConversionTimeUs(0), minConversionTimeUs(UINT64_MAX),
+        calibrationCount(0), thresholdViolations(0) {}
 };
 
 /**
  * @brief ADC diagnostic information.
  */
 struct AdcDiagnostics {
-    bool adcHealthy;                    ///< Overall ADC health status
-    uint32_t lastErrorCode;             ///< Last error code
-    uint64_t lastErrorTimestamp;        ///< Last error timestamp
-    uint32_t consecutiveErrors;         ///< Consecutive error count
-    double temperatureC;                ///< ADC temperature (if available)
-    double referenceVoltage;            ///< Reference voltage
-    bool calibrationValid;              ///< Calibration validity
-    
-    AdcDiagnostics() : adcHealthy(true), lastErrorCode(0), lastErrorTimestamp(0)
-        , consecutiveErrors(0), temperatureC(25.0), referenceVoltage(3.3)
-        , calibrationValid(false) {}
+  bool adcHealthy;             ///< Overall ADC health status
+  uint32_t lastErrorCode;      ///< Last error code
+  uint64_t lastErrorTimestamp; ///< Last error timestamp
+  uint32_t consecutiveErrors;  ///< Consecutive error count
+  double temperatureC;         ///< ADC temperature (if available)
+  double referenceVoltage;     ///< Reference voltage
+  bool calibrationValid;       ///< Calibration validity
+
+  AdcDiagnostics()
+      : adcHealthy(true), lastErrorCode(0), lastErrorTimestamp(0), consecutiveErrors(0),
+        temperatureC(25.0), referenceVoltage(3.3), calibrationValid(false) {}
 };
 
 // Callback function types
-using AdcConversionCallback = std::function<void(uint8_t channel, uint32_t rawValue, float voltage, void* userData)>;
-using AdcThresholdCallback = std::function<void(uint8_t monitorId, uint8_t channel, uint32_t value, bool isHigh, void* userData)>;
-using AdcErrorCallback = std::function<void(HfAdcErr error, void* userData)>;
+using AdcConversionCallback =
+    std::function<void(uint8_t channel, uint32_t rawValue, float voltage, void *userData)>;
+using AdcThresholdCallback = std::function<void(uint8_t monitorId, uint8_t channel, uint32_t value,
+                                                bool isHigh, void *userData)>;
+using AdcErrorCallback = std::function<void(HfAdcErr error, void *userData)>;
 
 /**
  * @class McuAdc
  * @brief Advanced platform-agnostic MCU ADC driver with ESP32C6/ESP-IDF v5.5+ features.
- * 
+ *
  * This class provides a comprehensive implementation of ADC operations that automatically
  * adapts to the current MCU platform with support for both basic and advanced features.
  * On ESP32C6, it utilizes the latest ESP-IDF v5.5+ ADC features including continuous
@@ -257,419 +261,422 @@ using AdcErrorCallback = std::function<void(HfAdcErr error, void* userData)>;
  */
 class McuAdc : public BaseAdc {
 public:
-    /**
-     * @brief Constructor for basic ADC functionality.
-     */
-    McuAdc() noexcept;
-    
-    /**
-     * @brief Constructor with advanced configuration.
-     * @param config Advanced ADC configuration
-     */
-    explicit McuAdc(const AdcAdvancedConfig& config) noexcept;
+  /**
+   * @brief Constructor for basic ADC functionality.
+   */
+  McuAdc() noexcept;
 
-    /**
-     * @brief Destructor - ensures proper cleanup.
-     */
-    ~McuAdc() noexcept override;
+  /**
+   * @brief Constructor with advanced configuration.
+   * @param config Advanced ADC configuration
+   */
+  explicit McuAdc(const AdcAdvancedConfig &config) noexcept;
 
-    //==============================================================================
-    // BASIC ADC OPERATIONS (BaseAdc Interface)
-    //==============================================================================
+  /**
+   * @brief Destructor - ensures proper cleanup.
+   */
+  ~McuAdc() noexcept override;
 
-    /**
-     * @brief Initialize the ADC system.
-     * @return true if successful, false otherwise
-     */
-    bool Initialize() noexcept override;
+  //==============================================================================
+  // BASIC ADC OPERATIONS (BaseAdc Interface)
+  //==============================================================================
 
-    /**
-     * @brief Deinitialize the ADC system.
-     * @return true if successful, false otherwise
-     */
-    bool Deinitialize() noexcept override;
+  /**
+   * @brief Initialize the ADC system.
+   * @return true if successful, false otherwise
+   */
+  bool Initialize() noexcept override;
 
-    /**
-     * @brief Get the maximum number of channels supported.
-     * @return Maximum channel count
-     */
-    uint8_t GetMaxChannels() const noexcept override;
+  /**
+   * @brief Deinitialize the ADC system.
+   * @return true if successful, false otherwise
+   */
+  bool Deinitialize() noexcept override;
 
-    /**
-     * @brief Check if a specific channel is available.
-     * @param channel_num Channel number to check
-     * @return true if available, false otherwise
-     */
-    bool IsChannelAvailable(uint8_t channel_num) const noexcept override;
+  /**
+   * @brief Get the maximum number of channels supported.
+   * @return Maximum channel count
+   */
+  uint8_t GetMaxChannels() const noexcept override;
 
-    /**
-     * @brief Configure a channel with specified settings.
-     * @param channel_num Channel number to configure
-     * @param config Channel configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr ConfigureChannel(uint8_t channel_num, const AdcChannelConfig& config) noexcept override;
+  /**
+   * @brief Check if a specific channel is available.
+   * @param channel_num Channel number to check
+   * @return true if available, false otherwise
+   */
+  bool IsChannelAvailable(uint8_t channel_num) const noexcept override;
 
-    /**
-     * @brief Perform a single ADC conversion.
-     * @param channel_num Channel number to read
-     * @param raw_value Reference to store raw ADC value
-     * @return HfAdcErr result code
-     */
-    HfAdcErr ReadRaw(uint8_t channel_num, uint32_t& raw_value) noexcept override;
+  /**
+   * @brief Configure a channel with specified settings.
+   * @param channel_num Channel number to configure
+   * @param config Channel configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr ConfigureChannel(uint8_t channel_num, const AdcChannelConfig &config) noexcept override;
 
-    /**
-     * @brief Perform ADC conversion and return calibrated voltage.
-     * @param channel_num Channel number to read
-     * @param voltage Reference to store voltage value
-     * @return HfAdcErr result code
-     */
-    HfAdcErr ReadVoltage(uint8_t channel_num, float& voltage) noexcept override;
+  /**
+   * @brief Perform a single ADC conversion.
+   * @param channel_num Channel number to read
+   * @param raw_value Reference to store raw ADC value
+   * @return HfAdcErr result code
+   */
+  HfAdcErr ReadRaw(uint8_t channel_num, uint32_t &raw_value) noexcept override;
 
-    /**
-     * @brief Perform multiple conversions and average the result.
-     * @param channel_num Channel number to read
-     * @param samples Number of samples to average
-     * @param raw_value Reference to store averaged raw value
-     * @return HfAdcErr result code
-     */
-    HfAdcErr ReadRawAveraged(uint8_t channel_num, uint8_t samples, uint32_t& raw_value) noexcept override;
+  /**
+   * @brief Perform ADC conversion and return calibrated voltage.
+   * @param channel_num Channel number to read
+   * @param voltage Reference to store voltage value
+   * @return HfAdcErr result code
+   */
+  HfAdcErr ReadVoltage(uint8_t channel_num, float &voltage) noexcept override;
 
-    /**
-     * @brief Get channel configuration.
-     * @param channel_num Channel number
-     * @param config Reference to store configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr GetChannelConfig(uint8_t channel_num, AdcChannelConfig& config) const noexcept override;
+  /**
+   * @brief Perform multiple conversions and average the result.
+   * @param channel_num Channel number to read
+   * @param samples Number of samples to average
+   * @param raw_value Reference to store averaged raw value
+   * @return HfAdcErr result code
+   */
+  HfAdcErr ReadRawAveraged(uint8_t channel_num, uint8_t samples,
+                           uint32_t &raw_value) noexcept override;
 
-    /**
-     * @brief Read the internal temperature sensor.
-     * @param temperature Reference to store temperature in Celsius
-     * @return HfAdcErr result code
-     */
-    HfAdcErr ReadTemperature(float& temperature) noexcept override;
+  /**
+   * @brief Get channel configuration.
+   * @param channel_num Channel number
+   * @param config Reference to store configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr GetChannelConfig(uint8_t channel_num, AdcChannelConfig &config) const noexcept override;
 
-    //==============================================================================
-    // ADVANCED ADC OPERATIONS
-    //==============================================================================
+  /**
+   * @brief Read the internal temperature sensor.
+   * @param temperature Reference to store temperature in Celsius
+   * @return HfAdcErr result code
+   */
+  HfAdcErr ReadTemperature(float &temperature) noexcept override;
 
-    /**
-     * @brief Initialize with advanced configuration.
-     * @param config Advanced configuration parameters
-     * @return HfAdcErr result code
-     */
-    HfAdcErr initializeAdvanced(const AdcAdvancedConfig& config) noexcept;
+  //==============================================================================
+  // ADVANCED ADC OPERATIONS
+  //==============================================================================
 
-    /**
-     * @brief Reconfigure ADC with new settings.
-     * @param config New configuration parameters
-     * @return HfAdcErr result code
-     */
-    HfAdcErr reconfigure(const AdcAdvancedConfig& config) noexcept;
+  /**
+   * @brief Initialize with advanced configuration.
+   * @param config Advanced configuration parameters
+   * @return HfAdcErr result code
+   */
+  HfAdcErr initializeAdvanced(const AdcAdvancedConfig &config) noexcept;
 
-    /**
-     * @brief Get current ADC configuration.
-     * @return Current configuration
-     */
-    AdcAdvancedConfig getCurrentConfiguration() const noexcept;
+  /**
+   * @brief Reconfigure ADC with new settings.
+   * @param config New configuration parameters
+   * @return HfAdcErr result code
+   */
+  HfAdcErr reconfigure(const AdcAdvancedConfig &config) noexcept;
 
-    //==============================================================================
-    // CONTINUOUS MODE OPERATIONS
-    //==============================================================================
+  /**
+   * @brief Get current ADC configuration.
+   * @return Current configuration
+   */
+  AdcAdvancedConfig getCurrentConfiguration() const noexcept;
 
-    /**
-     * @brief Start continuous mode sampling.
-     * @param channels Vector of channels to sample
-     * @param config Continuous mode configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr startContinuous(const std::vector<uint8_t>& channels, const AdcContinuousConfig& config) noexcept;
+  //==============================================================================
+  // CONTINUOUS MODE OPERATIONS
+  //==============================================================================
 
-    /**
-     * @brief Stop continuous mode sampling.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr stopContinuous() noexcept;
+  /**
+   * @brief Start continuous mode sampling.
+   * @param channels Vector of channels to sample
+   * @param config Continuous mode configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr startContinuous(const std::vector<uint8_t> &channels,
+                           const AdcContinuousConfig &config) noexcept;
 
-    /**
-     * @brief Read samples from continuous mode.
-     * @param buffer Buffer to store samples
-     * @param maxSamples Maximum number of samples to read
-     * @param samplesRead Reference to store actual samples read
-     * @param timeoutMs Timeout in milliseconds
-     * @return HfAdcErr result code
-     */
-    HfAdcErr readContinuous(uint8_t* buffer, size_t maxSamples, size_t& samplesRead, uint32_t timeoutMs = 1000) noexcept;
+  /**
+   * @brief Stop continuous mode sampling.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr stopContinuous() noexcept;
 
-    /**
-     * @brief Set continuous mode callback.
-     * @param callback Callback function
-     * @param userData User data for callback
-     */
-    void setContinuousCallback(AdcConversionCallback callback, void* userData = nullptr) noexcept;
+  /**
+   * @brief Read samples from continuous mode.
+   * @param buffer Buffer to store samples
+   * @param maxSamples Maximum number of samples to read
+   * @param samplesRead Reference to store actual samples read
+   * @param timeoutMs Timeout in milliseconds
+   * @return HfAdcErr result code
+   */
+  HfAdcErr readContinuous(uint8_t *buffer, size_t maxSamples, size_t &samplesRead,
+                          uint32_t timeoutMs = 1000) noexcept;
 
-    //==============================================================================
-    // DIGITAL FILTER OPERATIONS
-    //==============================================================================
+  /**
+   * @brief Set continuous mode callback.
+   * @param callback Callback function
+   * @param userData User data for callback
+   */
+  void setContinuousCallback(AdcConversionCallback callback, void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Configure digital filter for a channel.
-     * @param config Filter configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr configureFilter(const AdcFilterConfig& config) noexcept;
+  //==============================================================================
+  // DIGITAL FILTER OPERATIONS
+  //==============================================================================
 
-    /**
-     * @brief Enable digital filter for a channel.
-     * @param channelId Channel ID
-     * @param enable Enable/disable filter
-     * @return HfAdcErr result code
-     */
-    HfAdcErr enableFilter(uint8_t channelId, bool enable) noexcept;
+  /**
+   * @brief Configure digital filter for a channel.
+   * @param config Filter configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr configureFilter(const AdcFilterConfig &config) noexcept;
 
-    /**
-     * @brief Get filter configuration for a channel.
-     * @param channelId Channel ID
-     * @param config Reference to store configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr getFilterConfig(uint8_t channelId, AdcFilterConfig& config) const noexcept;
+  /**
+   * @brief Enable digital filter for a channel.
+   * @param channelId Channel ID
+   * @param enable Enable/disable filter
+   * @return HfAdcErr result code
+   */
+  HfAdcErr enableFilter(uint8_t channelId, bool enable) noexcept;
 
-    //==============================================================================
-    // THRESHOLD MONITOR OPERATIONS
-    //==============================================================================
+  /**
+   * @brief Get filter configuration for a channel.
+   * @param channelId Channel ID
+   * @param config Reference to store configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr getFilterConfig(uint8_t channelId, AdcFilterConfig &config) const noexcept;
 
-    /**
-     * @brief Configure threshold monitor.
-     * @param config Monitor configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr configureMonitor(const AdcMonitorConfig& config) noexcept;
+  //==============================================================================
+  // THRESHOLD MONITOR OPERATIONS
+  //==============================================================================
 
-    /**
-     * @brief Enable threshold monitor.
-     * @param monitorId Monitor ID
-     * @param enable Enable/disable monitor
-     * @return HfAdcErr result code
-     */
-    HfAdcErr enableMonitor(uint8_t monitorId, bool enable) noexcept;
+  /**
+   * @brief Configure threshold monitor.
+   * @param config Monitor configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr configureMonitor(const AdcMonitorConfig &config) noexcept;
 
-    /**
-     * @brief Set threshold callback.
-     * @param callback Callback function
-     * @param userData User data for callback
-     */
-    void setThresholdCallback(AdcThresholdCallback callback, void* userData = nullptr) noexcept;
+  /**
+   * @brief Enable threshold monitor.
+   * @param monitorId Monitor ID
+   * @param enable Enable/disable monitor
+   * @return HfAdcErr result code
+   */
+  HfAdcErr enableMonitor(uint8_t monitorId, bool enable) noexcept;
 
-    //==============================================================================
-    // CALIBRATION OPERATIONS
-    //==============================================================================
+  /**
+   * @brief Set threshold callback.
+   * @param callback Callback function
+   * @param userData User data for callback
+   */
+  void setThresholdCallback(AdcThresholdCallback callback, void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Perform ADC calibration.
-     * @param config Calibration configuration
-     * @return HfAdcErr result code
-     */
-    HfAdcErr performCalibration(const AdcCalibrationConfig& config) noexcept;
+  //==============================================================================
+  // CALIBRATION OPERATIONS
+  //==============================================================================
 
-    /**
-     * @brief Check if calibration is valid.
-     * @return true if calibration is valid, false otherwise
-     */
-    bool isCalibrationValid() const noexcept;
+  /**
+   * @brief Perform ADC calibration.
+   * @param config Calibration configuration
+   * @return HfAdcErr result code
+   */
+  HfAdcErr performCalibration(const AdcCalibrationConfig &config) noexcept;
 
-    /**
-     * @brief Convert raw value to voltage using calibration.
-     * @param channelId Channel ID
-     * @param rawValue Raw ADC value
-     * @param voltage Reference to store voltage
-     * @return HfAdcErr result code
-     */
-    HfAdcErr rawToVoltage(uint8_t channelId, uint32_t rawValue, float& voltage) const noexcept;
+  /**
+   * @brief Check if calibration is valid.
+   * @return true if calibration is valid, false otherwise
+   */
+  bool isCalibrationValid() const noexcept;
 
-    //==============================================================================
-    // POWER MANAGEMENT
-    //==============================================================================
+  /**
+   * @brief Convert raw value to voltage using calibration.
+   * @param channelId Channel ID
+   * @param rawValue Raw ADC value
+   * @param voltage Reference to store voltage
+   * @return HfAdcErr result code
+   */
+  HfAdcErr rawToVoltage(uint8_t channelId, uint32_t rawValue, float &voltage) const noexcept;
 
-    /**
-     * @brief Set power mode.
-     * @param mode Power mode to set
-     * @return HfAdcErr result code
-     */
-    HfAdcErr setPowerMode(AdcPowerMode mode) noexcept;
+  //==============================================================================
+  // POWER MANAGEMENT
+  //==============================================================================
 
-    /**
-     * @brief Get current power mode.
-     * @return Current power mode
-     */
-    AdcPowerMode getPowerMode() const noexcept;
+  /**
+   * @brief Set power mode.
+   * @param mode Power mode to set
+   * @return HfAdcErr result code
+   */
+  HfAdcErr setPowerMode(AdcPowerMode mode) noexcept;
 
-    /**
-     * @brief Enter low-power mode.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr enterLowPowerMode() noexcept;
+  /**
+   * @brief Get current power mode.
+   * @return Current power mode
+   */
+  AdcPowerMode getPowerMode() const noexcept;
 
-    /**
-     * @brief Exit low-power mode.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr exitLowPowerMode() noexcept;
+  /**
+   * @brief Enter low-power mode.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr enterLowPowerMode() noexcept;
 
-    //==============================================================================
-    // STATISTICS AND DIAGNOSTICS
-    //==============================================================================
+  /**
+   * @brief Exit low-power mode.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr exitLowPowerMode() noexcept;
 
-    /**
-     * @brief Get operation statistics.
-     * @return Current statistics
-     */
-    AdcStatistics getStatistics() const noexcept;
+  //==============================================================================
+  // STATISTICS AND DIAGNOSTICS
+  //==============================================================================
 
-    /**
-     * @brief Reset operation statistics.
-     */
-    void resetStatistics() noexcept;
+  /**
+   * @brief Get operation statistics.
+   * @return Current statistics
+   */
+  AdcStatistics getStatistics() const noexcept;
 
-    /**
-     * @brief Get diagnostic information.
-     * @return Current diagnostics
-     */
-    AdcDiagnostics getDiagnostics() noexcept;
+  /**
+   * @brief Reset operation statistics.
+   */
+  void resetStatistics() noexcept;
 
-    /**
-     * @brief Check ADC health status.
-     * @return true if ADC is healthy, false otherwise
-     */
-    bool isAdcHealthy() noexcept;
+  /**
+   * @brief Get diagnostic information.
+   * @return Current diagnostics
+   */
+  AdcDiagnostics getDiagnostics() noexcept;
 
-    //==============================================================================
-    // ADVANCED FEATURES
-    //==============================================================================
+  /**
+   * @brief Check ADC health status.
+   * @return true if ADC is healthy, false otherwise
+   */
+  bool isAdcHealthy() noexcept;
 
-    /**
-     * @brief Enable hardware oversampling.
-     * @param channelId Channel ID
-     * @param ratio Oversampling ratio (2^n)
-     * @return HfAdcErr result code
-     */
-    HfAdcErr enableOversampling(uint8_t channelId, uint8_t ratio) noexcept;
+  //==============================================================================
+  // ADVANCED FEATURES
+  //==============================================================================
 
-    /**
-     * @brief Configure trigger source.
-     * @param source Trigger source
-     * @param parameter Source-specific parameter
-     * @return HfAdcErr result code
-     */
-    HfAdcErr configureTriggerSource(AdcTriggerSource source, uint32_t parameter = 0) noexcept;
+  /**
+   * @brief Enable hardware oversampling.
+   * @param channelId Channel ID
+   * @param ratio Oversampling ratio (2^n)
+   * @return HfAdcErr result code
+   */
+  HfAdcErr enableOversampling(uint8_t channelId, uint8_t ratio) noexcept;
 
-    /**
-     * @brief Start triggered sampling.
-     * @param channels Vector of channels to sample
-     * @return HfAdcErr result code
-     */
-    HfAdcErr startTriggeredSampling(const std::vector<uint8_t>& channels) noexcept;
+  /**
+   * @brief Configure trigger source.
+   * @param source Trigger source
+   * @param parameter Source-specific parameter
+   * @return HfAdcErr result code
+   */
+  HfAdcErr configureTriggerSource(AdcTriggerSource source, uint32_t parameter = 0) noexcept;
 
-    /**
-     * @brief Stop triggered sampling.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr stopTriggeredSampling() noexcept;
+  /**
+   * @brief Start triggered sampling.
+   * @param channels Vector of channels to sample
+   * @return HfAdcErr result code
+   */
+  HfAdcErr startTriggeredSampling(const std::vector<uint8_t> &channels) noexcept;
+
+  /**
+   * @brief Stop triggered sampling.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr stopTriggeredSampling() noexcept;
 
 private:
-    //==============================================================================
-    // PRIVATE METHODS
-    //==============================================================================
+  //==============================================================================
+  // PRIVATE METHODS
+  //==============================================================================
 
-    /**
-     * @brief Convert platform-specific error to HfAdcErr.
-     * @param platformError Platform-specific error code
-     * @return Corresponding HfAdcErr
-     */
-    HfAdcErr ConvertPlatformError(int32_t platformError) noexcept;
+  /**
+   * @brief Convert platform-specific error to HfAdcErr.
+   * @param platformError Platform-specific error code
+   * @return Corresponding HfAdcErr
+   */
+  HfAdcErr ConvertPlatformError(int32_t platformError) noexcept;
 
-    /**
-     * @brief Validate channel number.
-     * @param channelNum Channel number to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidChannel(uint8_t channelNum) const noexcept;
+  /**
+   * @brief Validate channel number.
+   * @param channelNum Channel number to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidChannel(uint8_t channelNum) const noexcept;
 
-    /**
-     * @brief Update operation statistics.
-     * @param success Operation success status
-     * @param operationTimeUs Operation time in microseconds
-     */
-    void UpdateStatistics(bool success, uint64_t operationTimeUs) noexcept;
+  /**
+   * @brief Update operation statistics.
+   * @param success Operation success status
+   * @param operationTimeUs Operation time in microseconds
+   */
+  void UpdateStatistics(bool success, uint64_t operationTimeUs) noexcept;
 
-    /**
-     * @brief Handle platform-specific error.
-     * @param error Platform error code
-     */
-    void HandlePlatformError(int32_t error) noexcept;
+  /**
+   * @brief Handle platform-specific error.
+   * @param error Platform error code
+   */
+  void HandlePlatformError(int32_t error) noexcept;
 
-    /**
-     * @brief Initialize ESP32 ADC continuous mode.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr InitializeEsp32Continuous() noexcept;
+  /**
+   * @brief Initialize ESP32 ADC continuous mode.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr InitializeEsp32Continuous() noexcept;
 
-    /**
-     * @brief Initialize ESP32 ADC filters.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr InitializeEsp32Filters() noexcept;
+  /**
+   * @brief Initialize ESP32 ADC filters.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr InitializeEsp32Filters() noexcept;
 
-    /**
-     * @brief Initialize ESP32 ADC monitors.
-     * @return HfAdcErr result code
-     */
-    HfAdcErr InitializeEsp32Monitors() noexcept;
+  /**
+   * @brief Initialize ESP32 ADC monitors.
+   * @return HfAdcErr result code
+   */
+  HfAdcErr InitializeEsp32Monitors() noexcept;
 
-    //==============================================================================
-    // PRIVATE MEMBER VARIABLES
-    //==============================================================================
+  //==============================================================================
+  // PRIVATE MEMBER VARIABLES
+  //==============================================================================
 
-    // Configuration
-    AdcAdvancedConfig advanced_config_;     ///< Advanced configuration
-    bool use_advanced_config_;              ///< Flag indicating advanced config usage
-    bool advanced_initialized_;             ///< Advanced features initialized flag
+  // Configuration
+  AdcAdvancedConfig advanced_config_; ///< Advanced configuration
+  bool use_advanced_config_;          ///< Flag indicating advanced config usage
+  bool advanced_initialized_;         ///< Advanced features initialized flag
 
-    // Platform-specific handles
-    void* continuous_handle_;               ///< Continuous mode handle
-    void* calibration_handle_;              ///< Calibration handle
-    std::unordered_map<uint8_t, void*> filter_handles_; ///< Filter handles
-    std::unordered_map<uint8_t, void*> monitor_handles_; ///< Monitor handles
+  // Platform-specific handles
+  void *continuous_handle_;                             ///< Continuous mode handle
+  void *calibration_handle_;                            ///< Calibration handle
+  std::unordered_map<uint8_t, void *> filter_handles_;  ///< Filter handles
+  std::unordered_map<uint8_t, void *> monitor_handles_; ///< Monitor handles
 
-    // Channel configurations
-    std::vector<AdcFilterConfig> filter_configs_;     ///< Filter configurations
-    std::vector<AdcMonitorConfig> monitor_configs_;   ///< Monitor configurations
-    AdcCalibrationConfig calibration_config_;         ///< Calibration configuration
+  // Channel configurations
+  std::vector<AdcFilterConfig> filter_configs_;   ///< Filter configurations
+  std::vector<AdcMonitorConfig> monitor_configs_; ///< Monitor configurations
+  AdcCalibrationConfig calibration_config_;       ///< Calibration configuration
 
-    // State management
-    mutable std::mutex mutex_;              ///< Thread synchronization mutex
-    bool continuous_running_;               ///< Continuous mode status
-    bool triggered_sampling_;               ///< Triggered sampling status
-    AdcPowerMode current_power_mode_;       ///< Current power mode
+  // State management
+  mutable std::mutex mutex_;        ///< Thread synchronization mutex
+  bool continuous_running_;         ///< Continuous mode status
+  bool triggered_sampling_;         ///< Triggered sampling status
+  AdcPowerMode current_power_mode_; ///< Current power mode
 
-    // Callback functions
-    AdcConversionCallback conversion_callback_; ///< Conversion callback
-    AdcThresholdCallback threshold_callback_;   ///< Threshold callback
-    AdcErrorCallback error_callback_;           ///< Error callback
-    void* callback_userdata_;               ///< Callback user data
+  // Callback functions
+  AdcConversionCallback conversion_callback_; ///< Conversion callback
+  AdcThresholdCallback threshold_callback_;   ///< Threshold callback
+  AdcErrorCallback error_callback_;           ///< Error callback
+  void *callback_userdata_;                   ///< Callback user data
 
-    // Statistics and diagnostics
-    mutable AdcStatistics statistics_;      ///< Operation statistics
-    AdcDiagnostics diagnostics_;           ///< Diagnostic information
-    uint64_t last_operation_time_;         ///< Last operation timestamp
+  // Statistics and diagnostics
+  mutable AdcStatistics statistics_; ///< Operation statistics
+  AdcDiagnostics diagnostics_;       ///< Diagnostic information
+  uint64_t last_operation_time_;     ///< Last operation timestamp
 
-    // Platform-specific constants
-    static constexpr uint8_t MAX_CHANNELS_ESP32C6 = 7;
-    static constexpr uint8_t MAX_FILTERS = 2;
-    static constexpr uint8_t MAX_MONITORS = 2;
-    static constexpr uint32_t DEFAULT_SAMPLE_FREQ = 20000;
-    static constexpr size_t DEFAULT_BUFFER_SIZE = 4096;
+  // Platform-specific constants
+  static constexpr uint8_t MAX_CHANNELS_ESP32C6 = 7;
+  static constexpr uint8_t MAX_FILTERS = 2;
+  static constexpr uint8_t MAX_MONITORS = 2;
+  static constexpr uint32_t DEFAULT_SAMPLE_FREQ = 20000;
+  static constexpr size_t DEFAULT_BUFFER_SIZE = 4096;
 };
 
 #endif // MCU_ADC_H_

--- a/inc/mcu/McuCan.h
+++ b/inc/mcu/McuCan.h
@@ -1,11 +1,11 @@
 /**
  * @file McuCan.h
  * @brief MCU-integrated CAN controller implementation.
- * 
+ *
  * This header provides a CAN bus implementation for microcontrollers with
  * built-in CAN peripherals. On ESP32, this wraps TWAI (Two-Wire Automotive Interface),
  * on STM32 it would wrap CAN peripheral, etc.
- * 
+ *
  * This is the primary CAN implementation for the ESP32C6 and similar MCUs
  * that have integrated CAN controllers with external transceivers.
  */
@@ -20,12 +20,12 @@
 /**
  * @class McuCan
  * @brief CAN bus implementation for microcontrollers with integrated CAN peripherals.
- * 
+ *
  * This class provides CAN communication using the microcontroller's built-in
  * CAN peripheral. On ESP32, it uses the TWAI (Two-Wire Automotive Interface)
  * controller. The implementation handles platform-specific details while
  * providing the unified BaseCan API.
- * 
+ *
  * Features:
  * - High-performance CAN communication using MCU's integrated controller
  * - Interrupt-driven reception with callback support
@@ -34,115 +34,119 @@
  * - Support for both standard and extended CAN frames
  * - Acceptance filtering for selective message reception
  * - Lazy initialization support
- * 
+ *
  * @note This implementation requires an external CAN transceiver chip for ESP32.
  */
 class McuCan : public BaseCan {
 public:
-    /**
-     * @brief Constructor with configuration.
-     * @param config CAN bus configuration parameters
-     */
-    explicit McuCan(const CanBusConfig& config) noexcept;
-    
-    /**
-     * @brief Destructor - ensures proper cleanup.
-     */
-    ~McuCan() noexcept override;
-      // Implement BaseCan interface
-    bool Initialize() noexcept override;
-    bool Deinitialize() noexcept override;
-      bool SendMessage(const CanMessage& message, uint32_t timeout_ms = 1000) noexcept override;
-    bool ReceiveMessage(CanMessage& message, uint32_t timeout_ms = 0) noexcept override;
-    
-    bool SetReceiveCallback(CanReceiveCallback callback) noexcept override;
-    void ClearReceiveCallback() noexcept override;
-    
-    bool GetStatus(CanBusStatus& status) noexcept override;
-    bool Reset() noexcept override;
-    
-    bool SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended = false) noexcept override;
-    bool ClearAcceptanceFilter() noexcept override;
-    
-    /**
-     * @brief Start the CAN controller (after initialization).
-     * @return true if started successfully, false otherwise
-     */
-    bool Start() noexcept;
-    
-    /**
-     * @brief Stop the CAN controller (but keep initialized).
-     * @return true if stopped successfully, false otherwise
-     */
-    bool Stop() noexcept;
-    
-    /**
-     * @brief Get the current configuration.
-     * @return Reference to the configuration structure
-     */
-    const CanBusConfig& GetConfig() const noexcept { return config_; }
-    
-    /**
-     * @brief Check if the transmit queue is full.
-     * @return true if queue is full, false otherwise
-     */
-    bool IsTransmitQueueFull() const noexcept;
-    
-    /**
-     * @brief Check if the receive queue is empty.
-     * @return true if queue is empty, false otherwise
-     */
-    bool IsReceiveQueueEmpty() const noexcept;
-    
-    /**
-     * @brief Get the current transmit error count.
-     * @return Number of transmit errors
-     */
-    uint32_t GetTransmitErrorCount() const noexcept;
-    
-    /**
-     * @brief Get the current receive error count.
-     * @return Number of receive errors
-     */
-    uint32_t GetReceiveErrorCount() const noexcept;
+  /**
+   * @brief Constructor with configuration.
+   * @param config CAN bus configuration parameters
+   */
+  explicit McuCan(const CanBusConfig &config) noexcept;
 
-    // CAN-FD Support methods (override base class defaults)
-    bool SupportsCanFD() const noexcept override;
-    bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000, bool enable_brs = true) noexcept override;
-    bool ConfigureCanFDTiming(uint16_t nominal_prescaler, uint8_t nominal_tseg1, uint8_t nominal_tseg2,
-                              uint16_t data_prescaler, uint8_t data_tseg1, uint8_t data_tseg2,
-                              uint8_t sjw = 1) noexcept override;
-    bool SetTransmitterDelayCompensation(uint8_t tdc_offset, uint8_t tdc_filter) noexcept override;
-    bool GetCanFDCapabilities(uint8_t& max_data_bytes, uint32_t& max_nominal_baudrate,
-                              uint32_t& max_data_baudrate, bool& supports_brs, bool& supports_esi) noexcept override;
+  /**
+   * @brief Destructor - ensures proper cleanup.
+   */
+  ~McuCan() noexcept override;
+  // Implement BaseCan interface
+  bool Initialize() noexcept override;
+  bool Deinitialize() noexcept override;
+  bool SendMessage(const CanMessage &message, uint32_t timeout_ms = 1000) noexcept override;
+  bool ReceiveMessage(CanMessage &message, uint32_t timeout_ms = 0) noexcept override;
+
+  bool SetReceiveCallback(CanReceiveCallback callback) noexcept override;
+  void ClearReceiveCallback() noexcept override;
+
+  bool GetStatus(CanBusStatus &status) noexcept override;
+  bool Reset() noexcept override;
+
+  bool SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended = false) noexcept override;
+  bool ClearAcceptanceFilter() noexcept override;
+
+  /**
+   * @brief Start the CAN controller (after initialization).
+   * @return true if started successfully, false otherwise
+   */
+  bool Start() noexcept;
+
+  /**
+   * @brief Stop the CAN controller (but keep initialized).
+   * @return true if stopped successfully, false otherwise
+   */
+  bool Stop() noexcept;
+
+  /**
+   * @brief Get the current configuration.
+   * @return Reference to the configuration structure
+   */
+  const CanBusConfig &GetConfig() const noexcept {
+    return config_;
+  }
+
+  /**
+   * @brief Check if the transmit queue is full.
+   * @return true if queue is full, false otherwise
+   */
+  bool IsTransmitQueueFull() const noexcept;
+
+  /**
+   * @brief Check if the receive queue is empty.
+   * @return true if queue is empty, false otherwise
+   */
+  bool IsReceiveQueueEmpty() const noexcept;
+
+  /**
+   * @brief Get the current transmit error count.
+   * @return Number of transmit errors
+   */
+  uint32_t GetTransmitErrorCount() const noexcept;
+
+  /**
+   * @brief Get the current receive error count.
+   * @return Number of receive errors
+   */
+  uint32_t GetReceiveErrorCount() const noexcept;
+
+  // CAN-FD Support methods (override base class defaults)
+  bool SupportsCanFD() const noexcept override;
+  bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000,
+                    bool enable_brs = true) noexcept override;
+  bool ConfigureCanFDTiming(uint16_t nominal_prescaler, uint8_t nominal_tseg1,
+                            uint8_t nominal_tseg2, uint16_t data_prescaler, uint8_t data_tseg1,
+                            uint8_t data_tseg2, uint8_t sjw = 1) noexcept override;
+  bool SetTransmitterDelayCompensation(uint8_t tdc_offset, uint8_t tdc_filter) noexcept override;
+  bool GetCanFDCapabilities(uint8_t &max_data_bytes, uint32_t &max_nominal_baudrate,
+                            uint32_t &max_data_baudrate, bool &supports_brs,
+                            bool &supports_esi) noexcept override;
 
 private:
-    CanBusConfig config_;                   ///< CAN bus configuration
-    CanReceiveCallback receive_callback_;   ///< User receive callback
-    mutable std::mutex mutex_;              ///< Thread safety mutex
-    
-    // Platform-specific implementation methods
-    bool PlatformInitialize() noexcept;
-    bool PlatformDeinitialize() noexcept;
-    bool PlatformStart() noexcept;
-    bool PlatformStop() noexcept;
-    bool PlatformSendMessage(const CanMessage& message, uint32_t timeout_ms) noexcept;
-    bool PlatformReceiveMessage(CanMessage& message, uint32_t timeout_ms) noexcept;
-    bool PlatformGetStatus(CanBusStatus& status) noexcept;
-    bool PlatformReset() noexcept;
-    bool PlatformSetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended) noexcept;
-    bool PlatformClearAcceptanceFilter() noexcept;
-    
-    // Platform-specific helper methods
-    bool GetTimingConfig(uint32_t baud_rate, void* timing_config) noexcept;
-    bool PlatformIsTransmitQueueFull() const noexcept;
-    bool PlatformIsReceiveQueueEmpty() const noexcept;
-    uint32_t PlatformGetTransmitErrorCount() const noexcept;
-    uint32_t PlatformGetReceiveErrorCount() const noexcept;
-    
-    // Static callback handler for platform interrupts
-    static void StaticReceiveHandler(void* arg);
-    void HandleReceiveInterrupt();
+  CanBusConfig config_;                 ///< CAN bus configuration
+  CanReceiveCallback receive_callback_; ///< User receive callback
+  mutable std::mutex mutex_;            ///< Thread safety mutex
+
+  // Platform-specific implementation methods
+  bool PlatformInitialize() noexcept;
+  bool PlatformDeinitialize() noexcept;
+  bool PlatformStart() noexcept;
+  bool PlatformStop() noexcept;
+  bool PlatformSendMessage(const CanMessage &message, uint32_t timeout_ms) noexcept;
+  bool PlatformReceiveMessage(CanMessage &message, uint32_t timeout_ms) noexcept;
+  bool PlatformGetStatus(CanBusStatus &status) noexcept;
+  bool PlatformReset() noexcept;
+  bool PlatformSetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended) noexcept;
+  bool PlatformClearAcceptanceFilter() noexcept;
+
+  // Platform-specific helper methods
+  bool GetTimingConfig(uint32_t baud_rate, void *timing_config) noexcept;
+  bool PlatformIsTransmitQueueFull() const noexcept;
+  bool PlatformIsReceiveQueueEmpty() const noexcept;
+  uint32_t PlatformGetTransmitErrorCount() const noexcept;
+  uint32_t PlatformGetReceiveErrorCount() const noexcept;
+
+  // Static callback handler for platform interrupts
+  static void StaticReceiveHandler(void *arg);
+  void HandleReceiveInterrupt();
 };
 
 #endif // MCU_CAN_H

--- a/inc/mcu/McuGpio.h
+++ b/inc/mcu/McuGpio.h
@@ -1,6 +1,7 @@
 /**
  * @file McuGpio.h
- * @brief Advanced MCU-specific implementation of the unified BaseGpio class with ESP32C6/ESP-IDF v5.5+ features.
+ * @brief Advanced MCU-specific implementation of the unified BaseGpio class with ESP32C6/ESP-IDF
+ * v5.5+ features.
  *
  * This file provides concrete implementations of the unified BaseGpio class
  * for microcontroller-based GPIO pins with support for both basic and advanced features.
@@ -21,84 +22,85 @@
  * @brief GPIO glitch filter types supported by ESP32C6.
  */
 enum class GpioGlitchFilterType : uint8_t {
-    None = 0,           ///< No glitch filter
-    Pin = 1,            ///< Pin glitch filter (fixed 2 clock cycles)
-    Flex = 2,           ///< Flexible glitch filter (configurable)
-    Both = 3            ///< Both pin and flex filters (maximum protection)
+  None = 0, ///< No glitch filter
+  Pin = 1,  ///< Pin glitch filter (fixed 2 clock cycles)
+  Flex = 2, ///< Flexible glitch filter (configurable)
+  Both = 3  ///< Both pin and flex filters (maximum protection)
 };
 
 /**
  * @brief GPIO drive capability levels for ESP32C6.
  */
 enum class GpioDriveCapability : uint8_t {
-    Weak = 0,           ///< ~5mA drive capability
-    Stronger = 1,       ///< ~10mA drive capability  
-    Medium = 2,         ///< ~20mA drive capability (default)
-    Strongest = 3       ///< ~40mA drive capability
+  Weak = 0,     ///< ~5mA drive capability
+  Stronger = 1, ///< ~10mA drive capability
+  Medium = 2,   ///< ~20mA drive capability (default)
+  Strongest = 3 ///< ~40mA drive capability
 };
 
 /**
  * @brief GPIO sleep configuration for power management.
  */
 struct GpioSleepConfig {
-    BaseGpio::Direction sleep_direction;    ///< Direction during sleep
-    BaseGpio::PullMode sleep_pull_mode;     ///< Pull resistors during sleep
-    bool sleep_output_enable;               ///< Output enabled during sleep
-    bool sleep_input_enable;                ///< Input enabled during sleep
-    bool hold_during_sleep;                 ///< Hold configuration during sleep
+  BaseGpio::Direction sleep_direction; ///< Direction during sleep
+  BaseGpio::PullMode sleep_pull_mode;  ///< Pull resistors during sleep
+  bool sleep_output_enable;            ///< Output enabled during sleep
+  bool sleep_input_enable;             ///< Input enabled during sleep
+  bool hold_during_sleep;              ///< Hold configuration during sleep
 };
 
 /**
  * @brief Flexible glitch filter configuration.
  */
 struct FlexGlitchFilterConfig {
-    uint32_t window_width_ns;               ///< Sample window width in nanoseconds
-    uint32_t window_threshold_ns;           ///< Threshold for filtering in nanoseconds
-    bool enable_on_init;                    ///< Enable filter immediately after creation
+  uint32_t window_width_ns;     ///< Sample window width in nanoseconds
+  uint32_t window_threshold_ns; ///< Threshold for filtering in nanoseconds
+  bool enable_on_init;          ///< Enable filter immediately after creation
 };
 
 /**
  * @brief GPIO wake-up configuration for deep sleep.
  */
 struct GpioWakeUpConfig {
-    BaseGpio::InterruptTrigger wake_trigger; ///< Wake-up trigger type
-    bool enable_rtc_wake;                   ///< Enable RTC domain wake-up
-    bool enable_ext1_wake;                  ///< Enable EXT1 wake-up source
-    uint8_t wake_level;                     ///< Wake-up level (0=low, 1=high)
+  BaseGpio::InterruptTrigger wake_trigger; ///< Wake-up trigger type
+  bool enable_rtc_wake;                    ///< Enable RTC domain wake-up
+  bool enable_ext1_wake;                   ///< Enable EXT1 wake-up source
+  uint8_t wake_level;                      ///< Wake-up level (0=low, 1=high)
 };
 
 /**
  * @brief GPIO configuration dump information.
  */
 struct GpioConfigDump {
-    uint8_t pin_number;                     ///< GPIO pin number
-    BaseGpio::Direction direction;          ///< Current direction
-    BaseGpio::PullMode pull_mode;           ///< Current pull mode
-    BaseGpio::OutputMode output_mode;       ///< Current output mode
-    GpioDriveCapability drive_capability;   ///< Current drive capability
-    bool input_enabled;                     ///< Input buffer enabled
-    bool output_enabled;                    ///< Output buffer enabled
-    bool open_drain;                        ///< Open drain mode
-    bool sleep_sel_enabled;                 ///< Sleep selection enabled
-    uint32_t function_select;               ///< IOMUX function selection
-    bool is_rtc_gpio;                       ///< Pin supports RTC GPIO
-    bool glitch_filter_enabled;             ///< Glitch filter enabled
-    GpioGlitchFilterType filter_type;       ///< Type of glitch filter
+  uint8_t pin_number;                   ///< GPIO pin number
+  BaseGpio::Direction direction;        ///< Current direction
+  BaseGpio::PullMode pull_mode;         ///< Current pull mode
+  BaseGpio::OutputMode output_mode;     ///< Current output mode
+  GpioDriveCapability drive_capability; ///< Current drive capability
+  bool input_enabled;                   ///< Input buffer enabled
+  bool output_enabled;                  ///< Output buffer enabled
+  bool open_drain;                      ///< Open drain mode
+  bool sleep_sel_enabled;               ///< Sleep selection enabled
+  uint32_t function_select;             ///< IOMUX function selection
+  bool is_rtc_gpio;                     ///< Pin supports RTC GPIO
+  bool glitch_filter_enabled;           ///< Glitch filter enabled
+  GpioGlitchFilterType filter_type;     ///< Type of glitch filter
 };
 
 /**
  * @class McuGpio
- * @brief Advanced MCU-specific implementation of unified BaseGpio with ESP32C6/ESP-IDF v5.5+ features.
+ * @brief Advanced MCU-specific implementation of unified BaseGpio with ESP32C6/ESP-IDF v5.5+
+ * features.
  * @details This class provides a comprehensive implementation of BaseGpio for MCU-based
  *          GPIO pins with support for both basic and advanced features including:
- *          
+ *
  *          **Basic Features:**
  *          - Dynamic switching between input and output modes
  *          - Active-high/active-low polarity configuration
  *          - Pull resistor configuration (floating, pull-up, pull-down)
  *          - Output drive modes (push-pull, open-drain)
  *          - Thread-safe state management
- *          
+ *
  *          **Advanced Features (ESP32C6/ESP-IDF v5.5+):**
  *          - Glitch filtering (pin and flexible filters)
  *          - RTC GPIO support for ultra-low power operations
@@ -107,7 +109,7 @@ struct GpioConfigDump {
  *          - Deep sleep wake-up configuration
  *          - Precise drive capability control (5mA to 40mA)
  *          - Advanced debugging and configuration dump
- *          
+ *
  * @note This class is designed to be platform-agnostic within the MCU domain.
  *       Platform-specific details are handled through conditional compilation.
  * @note Advanced features require ESP32C6 with ESP-IDF v5.5+ for full functionality.
@@ -117,7 +119,7 @@ public:
   //==============================================================//
   // CONSTRUCTORS
   //==============================================================//
-    /**
+  /**
    * @brief Constructor for McuGpio with full configuration including advanced features.
    * @param pin_num Platform-agnostic GPIO pin number
    * @param direction Initial pin direction (Input or Output)
@@ -126,16 +128,15 @@ public:
    * @param pull_mode Pull resistor configuration (Floating, PullUp, or PullDown)
    * @param drive_capability Drive strength capability (Weak to Strongest)
    * @details Creates an MCU GPIO instance with the specified configuration including
-   *          advanced features support. The pin is not physically configured until 
-   *          Initialize() is called. The platform-agnostic pin number is converted 
+   *          advanced features support. The pin is not physically configured until
+   *          Initialize() is called. The platform-agnostic pin number is converted
    *          internally to MCU-specific type.
    */
-  explicit McuGpio(HfPinNumber pin_num, 
-                          Direction direction = Direction::Input,
-                          ActiveState active_state = ActiveState::High,
-                          OutputMode output_mode = OutputMode::PushPull,
-                          PullMode pull_mode = PullMode::Floating,
-                          GpioDriveCapability drive_capability = GpioDriveCapability::Medium) noexcept;
+  explicit McuGpio(HfPinNumber pin_num, Direction direction = Direction::Input,
+                   ActiveState active_state = ActiveState::High,
+                   OutputMode output_mode = OutputMode::PushPull,
+                   PullMode pull_mode = PullMode::Floating,
+                   GpioDriveCapability drive_capability = GpioDriveCapability::Medium) noexcept;
 
   /**
    * @brief Destructor - ensures proper cleanup including interrupt resources.
@@ -179,7 +180,7 @@ public:
    * @brief Get human-readable description of this GPIO instance.
    * @return String view describing the MCU GPIO
    */
-  const char* GetDescription() const noexcept override;
+  const char *GetDescription() const noexcept override;
 
   //==============================================================//
   // INTERRUPT FUNCTIONALITY
@@ -198,9 +199,8 @@ public:
    * @param user_data User data passed to callback (optional)
    * @return HfGpioErr::GPIO_SUCCESS if successful, error code otherwise
    */
-  HfGpioErr ConfigureInterrupt(InterruptTrigger trigger, 
-                               InterruptCallback callback = nullptr, 
-                               void* user_data = nullptr) noexcept override;
+  HfGpioErr ConfigureInterrupt(InterruptTrigger trigger, InterruptCallback callback = nullptr,
+                               void *user_data = nullptr) noexcept override;
 
   /**
    * @brief Enable GPIO interrupt.
@@ -226,7 +226,7 @@ public:
    * @param status Reference to store interrupt status
    * @return HfGpioErr::GPIO_SUCCESS if successful, error code otherwise
    */
-  HfGpioErr GetInterruptStatus(InterruptStatus& status) noexcept override;
+  HfGpioErr GetInterruptStatus(InterruptStatus &status) noexcept override;
 
   /**
    * @brief Clear interrupt statistics/counters.
@@ -283,7 +283,7 @@ protected:
    * @return HfGpioErr::GPIO_SUCCESS if successful, error code otherwise
    * @details Reads the current MCU pin electrical level and converts to logical state.
    */
-  HfGpioErr IsActiveImpl(bool& is_active) noexcept override;
+  HfGpioErr IsActiveImpl(bool &is_active) noexcept override;
 
   /**
    * @brief Platform-specific implementation for setting pull resistor mode.
@@ -309,7 +309,7 @@ protected:
    * @return Current drive capability level
    */
   [[nodiscard]] GpioDriveCapability GetDriveCapability() const noexcept {
-      return drive_capability_;
+    return drive_capability_;
   }
 
   /**
@@ -344,7 +344,7 @@ protected:
    * @details Flexible glitch filter allows precise control over filtering parameters.
    *          Pulses shorter than window_threshold_ns within window_width_ns are filtered.
    */
-  HfGpioErr ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig& config) noexcept;
+  HfGpioErr ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig &config) noexcept;
 
   /**
    * @brief Enable all configured glitch filters.
@@ -371,7 +371,7 @@ protected:
    * @details Configures how the GPIO behaves during sleep modes.
    *          Essential for power-optimized applications.
    */
-  HfGpioErr ConfigureSleep(const GpioSleepConfig& config) noexcept;
+  HfGpioErr ConfigureSleep(const GpioSleepConfig &config) noexcept;
 
   /**
    * @brief Enable GPIO hold function.
@@ -389,7 +389,7 @@ protected:
    * @details Enables GPIO to wake the system from deep sleep.
    *          Essential for battery-powered applications.
    */
-  HfGpioErr ConfigureWakeUp(const GpioWakeUpConfig& config) noexcept;
+  HfGpioErr ConfigureWakeUp(const GpioWakeUpConfig &config) noexcept;
 
   /**
    * @brief Get comprehensive GPIO configuration information.
@@ -421,7 +421,7 @@ private:
    * @brief Static interrupt service routine handler.
    * @param arg Pointer to McuGpio instance
    */
-  static void IRAM_ATTR InterruptHandler(void* arg) noexcept;
+  static void IRAM_ATTR InterruptHandler(void *arg) noexcept;
 
   /**
    * @brief Initialize interrupt semaphore (called from constructor).
@@ -443,27 +443,27 @@ private:
   //==============================================================//
 
   // Interrupt state
-  InterruptTrigger interrupt_trigger_;      ///< Current interrupt trigger type
-  InterruptCallback interrupt_callback_;   ///< User interrupt callback
-  void* interrupt_user_data_;              ///< User data for callback
-  bool interrupt_enabled_;                 ///< Interrupt currently enabled
-  uint32_t interrupt_count_;               ///< Number of interrupts occurred
-  void* platform_semaphore_;              ///< Platform-specific semaphore for WaitForInterrupt
+  InterruptTrigger interrupt_trigger_;   ///< Current interrupt trigger type
+  InterruptCallback interrupt_callback_; ///< User interrupt callback
+  void *interrupt_user_data_;            ///< User data for callback
+  bool interrupt_enabled_;               ///< Interrupt currently enabled
+  uint32_t interrupt_count_;             ///< Number of interrupts occurred
+  void *platform_semaphore_;             ///< Platform-specific semaphore for WaitForInterrupt
 
   // Advanced GPIO state
-  GpioDriveCapability drive_capability_;   ///< Current drive capability setting
-  GpioGlitchFilterType glitch_filter_type_; ///< Type of glitch filter configured
-  bool pin_glitch_filter_enabled_;        ///< Pin glitch filter enabled
-  bool flex_glitch_filter_enabled_;       ///< Flexible glitch filter enabled
+  GpioDriveCapability drive_capability_;      ///< Current drive capability setting
+  GpioGlitchFilterType glitch_filter_type_;   ///< Type of glitch filter configured
+  bool pin_glitch_filter_enabled_;            ///< Pin glitch filter enabled
+  bool flex_glitch_filter_enabled_;           ///< Flexible glitch filter enabled
   FlexGlitchFilterConfig flex_filter_config_; ///< Flexible filter configuration
-  GpioSleepConfig sleep_config_;           ///< Sleep configuration
-  bool hold_enabled_;                      ///< Hold function enabled
-  bool rtc_gpio_enabled_;                  ///< RTC GPIO functionality enabled
-  GpioWakeUpConfig wakeup_config_;         ///< Wake-up configuration
-  
+  GpioSleepConfig sleep_config_;              ///< Sleep configuration
+  bool hold_enabled_;                         ///< Hold function enabled
+  bool rtc_gpio_enabled_;                     ///< RTC GPIO functionality enabled
+  GpioWakeUpConfig wakeup_config_;            ///< Wake-up configuration
+
   // Platform-specific handles for advanced features
-  void* glitch_filter_handle_;             ///< Platform-specific glitch filter handle
-  void* rtc_gpio_handle_;                  ///< Platform-specific RTC GPIO handle
+  void *glitch_filter_handle_; ///< Platform-specific glitch filter handle
+  void *rtc_gpio_handle_;      ///< Platform-specific RTC GPIO handle
 };
 
 #endif // MCU_GPIO_H

--- a/inc/mcu/McuI2c.h
+++ b/inc/mcu/McuI2c.h
@@ -16,22 +16,22 @@
 
 #include "BaseI2c.h"
 #include "McuTypes.h"
-#include <mutex>
 #include <functional>
-#include <vector>
-#include <unordered_map>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #ifdef ESP_PLATFORM
 #include "driver/i2c_master.h"
 #include "driver/i2c_slave.h"
 #include "driver/i2c_types.h"
-#include "hal/i2c_types.h"
 #include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/semphr.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "hal/i2c_types.h"
 #endif
 
 //--------------------------------------
@@ -42,187 +42,187 @@
  * @brief Clock source selection for I2C bus
  */
 enum class HfI2cClockSource : uint8_t {
-    DEFAULT = 0,        ///< Default I2C source clock
-    XTAL = 1,          ///< External crystal (lower power)
-    RC_FAST = 2        ///< Internal 20MHz RC oscillator
+  DEFAULT = 0, ///< Default I2C source clock
+  XTAL = 1,    ///< External crystal (lower power)
+  RC_FAST = 2  ///< Internal 20MHz RC oscillator
 };
 
 /**
  * @brief I2C bus mode selection
  */
 enum class HfI2cBusMode : uint8_t {
-    MASTER = 0,        ///< Master mode
-    SLAVE = 1          ///< Slave mode
+  MASTER = 0, ///< Master mode
+  SLAVE = 1   ///< Slave mode
 };
 
 /**
  * @brief I2C address bit width
  */
 enum class HfI2cAddressBits : uint8_t {
-    SEVEN_BIT = 7,     ///< 7-bit addressing (standard)
-    TEN_BIT = 10       ///< 10-bit addressing (extended)
+  SEVEN_BIT = 7, ///< 7-bit addressing (standard)
+  TEN_BIT = 10   ///< 10-bit addressing (extended)
 };
 
 /**
  * @brief I2C power modes for energy efficiency
  */
 enum class HfI2cPowerMode : uint8_t {
-    FULL_POWER = 0,    ///< Maximum performance, highest power
-    LOW_POWER = 1,     ///< Reduced power consumption
-    SLEEP = 2          ///< Minimal power, bus suspended
+  FULL_POWER = 0, ///< Maximum performance, highest power
+  LOW_POWER = 1,  ///< Reduced power consumption
+  SLEEP = 2       ///< Minimal power, bus suspended
 };
 
 /**
  * @brief Advanced I2C configuration structure
  */
 struct I2cAdvancedConfig {
-    // Basic configuration
-    uint8_t busNumber;                          ///< I2C bus number (0, 1, etc.)
-    uint32_t clockSpeed;                        ///< Clock speed in Hz (100000, 400000, 1000000)
-    int sclPin;                                 ///< SCL pin number
-    int sdaPin;                                 ///< SDA pin number
-    bool pullupResistors;                       ///< Enable internal pullup resistors
-    uint32_t timeoutMs;                         ///< Default timeout in milliseconds
-    
-    // Advanced configuration
-    HfI2cClockSource clockSource;               ///< Clock source selection
-    HfI2cBusMode busMode;                       ///< Bus mode (master/slave)
-    bool clockStretchingEnabled;                ///< Enable clock stretching
-    uint32_t clockStretchingTimeout;            ///< Clock stretching timeout (us)
-    bool digitalFilterEnabled;                  ///< Enable digital glitch filter
-    bool analogFilterEnabled;                   ///< Enable analog glitch filter
-    uint8_t digitalFilterLength;                ///< Digital filter length (cycles)
-    
-    // Asynchronous operations
-    bool asyncOperationsEnabled;                ///< Enable asynchronous operations
-    uint8_t maxConcurrentOperations;            ///< Max concurrent async operations
-    bool eventCallbacksEnabled;                ///< Enable event callbacks
-    
-    // Power management
-    HfI2cPowerMode powerMode;                   ///< Power mode setting
-    bool autoSuspendEnabled;                    ///< Auto-suspend when idle
-    uint32_t autoSuspendDelayMs;                ///< Delay before auto-suspend
-    
-    // Statistics and diagnostics
-    bool statisticsEnabled;                     ///< Enable operation statistics
-    bool diagnosticsEnabled;                    ///< Enable diagnostic features
-    
-    // Default constructor
-    I2cAdvancedConfig() 
-        : busNumber(0), clockSpeed(100000), sclPin(-1), sdaPin(-1)
-        , pullupResistors(true), timeoutMs(1000)
-        , clockSource(HfI2cClockSource::DEFAULT), busMode(HfI2cBusMode::MASTER)
-        , clockStretchingEnabled(true), clockStretchingTimeout(1000)
-        , digitalFilterEnabled(true), analogFilterEnabled(true), digitalFilterLength(7)
-        , asyncOperationsEnabled(false), maxConcurrentOperations(4), eventCallbacksEnabled(false)
-        , powerMode(HfI2cPowerMode::FULL_POWER), autoSuspendEnabled(false), autoSuspendDelayMs(5000)
-        , statisticsEnabled(false), diagnosticsEnabled(false) {}
+  // Basic configuration
+  uint8_t busNumber;    ///< I2C bus number (0, 1, etc.)
+  uint32_t clockSpeed;  ///< Clock speed in Hz (100000, 400000, 1000000)
+  int sclPin;           ///< SCL pin number
+  int sdaPin;           ///< SDA pin number
+  bool pullupResistors; ///< Enable internal pullup resistors
+  uint32_t timeoutMs;   ///< Default timeout in milliseconds
+
+  // Advanced configuration
+  HfI2cClockSource clockSource;    ///< Clock source selection
+  HfI2cBusMode busMode;            ///< Bus mode (master/slave)
+  bool clockStretchingEnabled;     ///< Enable clock stretching
+  uint32_t clockStretchingTimeout; ///< Clock stretching timeout (us)
+  bool digitalFilterEnabled;       ///< Enable digital glitch filter
+  bool analogFilterEnabled;        ///< Enable analog glitch filter
+  uint8_t digitalFilterLength;     ///< Digital filter length (cycles)
+
+  // Asynchronous operations
+  bool asyncOperationsEnabled;     ///< Enable asynchronous operations
+  uint8_t maxConcurrentOperations; ///< Max concurrent async operations
+  bool eventCallbacksEnabled;      ///< Enable event callbacks
+
+  // Power management
+  HfI2cPowerMode powerMode;    ///< Power mode setting
+  bool autoSuspendEnabled;     ///< Auto-suspend when idle
+  uint32_t autoSuspendDelayMs; ///< Delay before auto-suspend
+
+  // Statistics and diagnostics
+  bool statisticsEnabled;  ///< Enable operation statistics
+  bool diagnosticsEnabled; ///< Enable diagnostic features
+
+  // Default constructor
+  I2cAdvancedConfig()
+      : busNumber(0), clockSpeed(100000), sclPin(-1), sdaPin(-1), pullupResistors(true),
+        timeoutMs(1000), clockSource(HfI2cClockSource::DEFAULT), busMode(HfI2cBusMode::MASTER),
+        clockStretchingEnabled(true), clockStretchingTimeout(1000), digitalFilterEnabled(true),
+        analogFilterEnabled(true), digitalFilterLength(7), asyncOperationsEnabled(false),
+        maxConcurrentOperations(4), eventCallbacksEnabled(false),
+        powerMode(HfI2cPowerMode::FULL_POWER), autoSuspendEnabled(false), autoSuspendDelayMs(5000),
+        statisticsEnabled(false), diagnosticsEnabled(false) {}
 };
 
 /**
  * @brief I2C device-specific configuration
  */
 struct I2cDeviceConfig {
-    uint16_t deviceAddress;                     ///< Device address
-    HfI2cAddressBits addressBits;               ///< Address bit width
-    uint32_t timeoutMs;                         ///< Device-specific timeout
-    uint8_t retryCount;                         ///< Number of retry attempts
-    uint32_t clockStretchingTimeout;            ///< Device clock stretching timeout
-    bool requiresSpecialHandling;               ///< Device needs special handling
-    
-    I2cDeviceConfig() 
-        : deviceAddress(0), addressBits(HfI2cAddressBits::SEVEN_BIT)
-        , timeoutMs(1000), retryCount(3), clockStretchingTimeout(1000)
-        , requiresSpecialHandling(false) {}
+  uint16_t deviceAddress;          ///< Device address
+  HfI2cAddressBits addressBits;    ///< Address bit width
+  uint32_t timeoutMs;              ///< Device-specific timeout
+  uint8_t retryCount;              ///< Number of retry attempts
+  uint32_t clockStretchingTimeout; ///< Device clock stretching timeout
+  bool requiresSpecialHandling;    ///< Device needs special handling
+
+  I2cDeviceConfig()
+      : deviceAddress(0), addressBits(HfI2cAddressBits::SEVEN_BIT), timeoutMs(1000), retryCount(3),
+        clockStretchingTimeout(1000), requiresSpecialHandling(false) {}
 };
 
 /**
  * @brief Multi-buffer transaction descriptor
  */
 struct I2cMultiBufferTransaction {
-    struct Buffer {
-        const uint8_t* data;                    ///< Buffer data pointer
-        size_t length;                          ///< Buffer length
-        bool isWrite;                           ///< true for write, false for read
-        
-        Buffer(const uint8_t* d, size_t l, bool w) : data(d), length(l), isWrite(w) {}
-    };
-    
-    std::vector<Buffer> buffers;                ///< Transaction buffers
-    uint16_t deviceAddress;                     ///< Target device address
-    uint32_t timeoutMs;                         ///< Transaction timeout
-    bool stopCondition;                         ///< Generate stop condition at end
-    
-    I2cMultiBufferTransaction() 
-        : deviceAddress(0), timeoutMs(1000), stopCondition(true) {}
+  struct Buffer {
+    const uint8_t *data; ///< Buffer data pointer
+    size_t length;       ///< Buffer length
+    bool isWrite;        ///< true for write, false for read
+
+    Buffer(const uint8_t *d, size_t l, bool w) : data(d), length(l), isWrite(w) {}
+  };
+
+  std::vector<Buffer> buffers; ///< Transaction buffers
+  uint16_t deviceAddress;      ///< Target device address
+  uint32_t timeoutMs;          ///< Transaction timeout
+  bool stopCondition;          ///< Generate stop condition at end
+
+  I2cMultiBufferTransaction() : deviceAddress(0), timeoutMs(1000), stopCondition(true) {}
 };
 
 /**
  * @brief Custom command sequence operation
  */
 struct I2cCustomCommand {
-    enum class Type {
-        WRITE,                                  ///< Write operation
-        READ,                                   ///< Read operation
-        DELAY,                                  ///< Delay operation
-        START,                                  ///< Generate start condition
-        STOP,                                   ///< Generate stop condition
-        RESTART,                                ///< Generate restart condition
-        CONDITIONAL                             ///< Conditional operation
-    };
-    
-    Type type;                                  ///< Command type
-    std::vector<uint8_t> data;                  ///< Command data
-    uint32_t parameter;                         ///< Generic parameter (delay, condition, etc.)
-    std::function<bool()> condition;            ///< Condition function for CONDITIONAL type
-    
-    I2cCustomCommand(Type t) : type(t), parameter(0) {}
+  enum class Type {
+    WRITE,      ///< Write operation
+    READ,       ///< Read operation
+    DELAY,      ///< Delay operation
+    START,      ///< Generate start condition
+    STOP,       ///< Generate stop condition
+    RESTART,    ///< Generate restart condition
+    CONDITIONAL ///< Conditional operation
+  };
+
+  Type type;                       ///< Command type
+  std::vector<uint8_t> data;       ///< Command data
+  uint32_t parameter;              ///< Generic parameter (delay, condition, etc.)
+  std::function<bool()> condition; ///< Condition function for CONDITIONAL type
+
+  I2cCustomCommand(Type t) : type(t), parameter(0) {}
 };
 
 /**
  * @brief I2C operation statistics
  */
 struct I2cStatistics {
-    uint64_t totalOperations;                   ///< Total operations performed
-    uint64_t successfulOperations;              ///< Successful operations
-    uint64_t failedOperations;                  ///< Failed operations
-    uint64_t timeoutOperations;                 ///< Operations that timed out
-    uint64_t bytesTransmitted;                  ///< Total bytes transmitted
-    uint64_t bytesReceived;                     ///< Total bytes received
-    uint64_t averageOperationTimeUs;            ///< Average operation time (microseconds)
-    uint64_t maxOperationTimeUs;                ///< Maximum operation time
-    uint64_t minOperationTimeUs;                ///< Minimum operation time
-    uint32_t busErrorCount;                     ///< Bus error occurrences
-    uint32_t arbitrationLossCount;              ///< Arbitration loss count
-    uint32_t clockStretchingEvents;             ///< Clock stretching events
-    
-    I2cStatistics() : totalOperations(0), successfulOperations(0), failedOperations(0)
-        , timeoutOperations(0), bytesTransmitted(0), bytesReceived(0)
-        , averageOperationTimeUs(0), maxOperationTimeUs(0), minOperationTimeUs(UINT64_MAX)
-        , busErrorCount(0), arbitrationLossCount(0), clockStretchingEvents(0) {}
+  uint64_t totalOperations;        ///< Total operations performed
+  uint64_t successfulOperations;   ///< Successful operations
+  uint64_t failedOperations;       ///< Failed operations
+  uint64_t timeoutOperations;      ///< Operations that timed out
+  uint64_t bytesTransmitted;       ///< Total bytes transmitted
+  uint64_t bytesReceived;          ///< Total bytes received
+  uint64_t averageOperationTimeUs; ///< Average operation time (microseconds)
+  uint64_t maxOperationTimeUs;     ///< Maximum operation time
+  uint64_t minOperationTimeUs;     ///< Minimum operation time
+  uint32_t busErrorCount;          ///< Bus error occurrences
+  uint32_t arbitrationLossCount;   ///< Arbitration loss count
+  uint32_t clockStretchingEvents;  ///< Clock stretching events
+
+  I2cStatistics()
+      : totalOperations(0), successfulOperations(0), failedOperations(0), timeoutOperations(0),
+        bytesTransmitted(0), bytesReceived(0), averageOperationTimeUs(0), maxOperationTimeUs(0),
+        minOperationTimeUs(UINT64_MAX), busErrorCount(0), arbitrationLossCount(0),
+        clockStretchingEvents(0) {}
 };
 
 /**
  * @brief I2C diagnostic information
  */
 struct I2cDiagnostics {
-    bool busHealthy;                            ///< Overall bus health status
-    bool sclLineState;                          ///< SCL line state (high/low)
-    bool sdaLineState;                          ///< SDA line state (high/low)
-    uint32_t lastErrorCode;                     ///< Last error code
-    uint64_t lastErrorTimestamp;                ///< Last error timestamp
-    uint32_t consecutiveErrors;                 ///< Consecutive error count
-    uint32_t busRecoveryCount;                  ///< Bus recovery attempts
-    double busUtilizationPercent;               ///< Bus utilization percentage
-    
-    I2cDiagnostics() : busHealthy(true), sclLineState(true), sdaLineState(true)
-        , lastErrorCode(0), lastErrorTimestamp(0), consecutiveErrors(0)
-        , busRecoveryCount(0), busUtilizationPercent(0.0) {}
+  bool busHealthy;              ///< Overall bus health status
+  bool sclLineState;            ///< SCL line state (high/low)
+  bool sdaLineState;            ///< SDA line state (high/low)
+  uint32_t lastErrorCode;       ///< Last error code
+  uint64_t lastErrorTimestamp;  ///< Last error timestamp
+  uint32_t consecutiveErrors;   ///< Consecutive error count
+  uint32_t busRecoveryCount;    ///< Bus recovery attempts
+  double busUtilizationPercent; ///< Bus utilization percentage
+
+  I2cDiagnostics()
+      : busHealthy(true), sclLineState(true), sdaLineState(true), lastErrorCode(0),
+        lastErrorTimestamp(0), consecutiveErrors(0), busRecoveryCount(0),
+        busUtilizationPercent(0.0) {}
 };
 
 // Callback function types
-using I2cAsyncCallback = std::function<void(HfI2cErr result, size_t bytesTransferred, void* userData)>;
-using I2cEventCallback = std::function<void(int eventType, void* eventData, void* userData)>;
+using I2cAsyncCallback =
+    std::function<void(HfI2cErr result, size_t bytesTransferred, void *userData)>;
+using I2cEventCallback = std::function<void(int eventType, void *eventData, void *userData)>;
 
 /**
  * @class McuI2c
@@ -257,483 +257,492 @@ using I2cEventCallback = std::function<void(int eventType, void* eventData, void
  */
 class McuI2c : public BaseI2c {
 public:
-    /**
-     * @brief Constructor with basic configuration.
-     * @param config I2C bus configuration parameters
-     */
-    explicit McuI2c(const I2cBusConfig& config) noexcept;
-    
-    /**
-     * @brief Constructor with advanced configuration.
-     * @param config Advanced I2C bus configuration parameters
-     */
-    explicit McuI2c(const I2cAdvancedConfig& config) noexcept;
+  /**
+   * @brief Constructor with basic configuration.
+   * @param config I2C bus configuration parameters
+   */
+  explicit McuI2c(const I2cBusConfig &config) noexcept;
 
-    /**
-     * @brief Destructor - ensures proper cleanup.
-     */
-    ~McuI2c() noexcept override;
+  /**
+   * @brief Constructor with advanced configuration.
+   * @param config Advanced I2C bus configuration parameters
+   */
+  explicit McuI2c(const I2cAdvancedConfig &config) noexcept;
 
-    //==============================================//
-    // BASIC I2C OPERATIONS (BaseI2c Interface)    //
-    //==============================================//
+  /**
+   * @brief Destructor - ensures proper cleanup.
+   */
+  ~McuI2c() noexcept override;
 
-    /**
-     * @brief Initialize the I2C bus.
-     * @return true if successful, false otherwise
-     */
-    bool Initialize() noexcept override;
+  //==============================================//
+  // BASIC I2C OPERATIONS (BaseI2c Interface)    //
+  //==============================================//
 
-    /**
-     * @brief Deinitialize the I2C bus.
-     * @return true if successful, false otherwise
-     */
-    bool Deinitialize() noexcept override;
+  /**
+   * @brief Initialize the I2C bus.
+   * @return true if successful, false otherwise
+   */
+  bool Initialize() noexcept override;
 
-    /**
-     * @brief Write data to a slave device.
-     * @param device_addr 7-bit device address
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfI2cErr result code
-     */
-    HfI2cErr Write(uint8_t device_addr, const uint8_t* data,
-                   uint16_t length, uint32_t timeout_ms = 0) noexcept override;
+  /**
+   * @brief Deinitialize the I2C bus.
+   * @return true if successful, false otherwise
+   */
+  bool Deinitialize() noexcept override;
 
-    /**
-     * @brief Read data from a slave device.
-     * @param device_addr 7-bit device address
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfI2cErr result code
-     */
-    HfI2cErr Read(uint8_t device_addr, uint8_t* data,
-                  uint16_t length, uint32_t timeout_ms = 0) noexcept override;
+  /**
+   * @brief Write data to a slave device.
+   * @param device_addr 7-bit device address
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfI2cErr result code
+   */
+  HfI2cErr Write(uint8_t device_addr, const uint8_t *data, uint16_t length,
+                 uint32_t timeout_ms = 0) noexcept override;
 
-    /**
-     * @brief Write then read from a slave device without releasing the bus.
-     * @param device_addr 7-bit device address
-     * @param tx_data Data buffer to send
-     * @param tx_length Number of bytes to send
-     * @param rx_data Buffer to store received data
-     * @param rx_length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfI2cErr result code
-     */
-    HfI2cErr WriteRead(uint8_t device_addr, const uint8_t* tx_data, uint16_t tx_length,
-                       uint8_t* rx_data, uint16_t rx_length, uint32_t timeout_ms = 0) noexcept override;
+  /**
+   * @brief Read data from a slave device.
+   * @param device_addr 7-bit device address
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfI2cErr result code
+   */
+  HfI2cErr Read(uint8_t device_addr, uint8_t *data, uint16_t length,
+                uint32_t timeout_ms = 0) noexcept override;
 
-    //==============================================//
-    // ADVANCED I2C OPERATIONS                     //
-    //==============================================//
+  /**
+   * @brief Write then read from a slave device without releasing the bus.
+   * @param device_addr 7-bit device address
+   * @param tx_data Data buffer to send
+   * @param tx_length Number of bytes to send
+   * @param rx_data Buffer to store received data
+   * @param rx_length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfI2cErr result code
+   */
+  HfI2cErr WriteRead(uint8_t device_addr, const uint8_t *tx_data, uint16_t tx_length,
+                     uint8_t *rx_data, uint16_t rx_length,
+                     uint32_t timeout_ms = 0) noexcept override;
 
-    /**
-     * @brief Initialize with advanced configuration.
-     * @param config Advanced configuration parameters
-     * @return HfI2cErr result code
-     */
-    HfI2cErr initializeAdvanced(const I2cAdvancedConfig& config) noexcept;
+  //==============================================//
+  // ADVANCED I2C OPERATIONS                     //
+  //==============================================//
 
-    /**
-     * @brief Reconfigure the bus with new settings.
-     * @param config New configuration parameters
-     * @return HfI2cErr result code
-     */
-    HfI2cErr reconfigure(const I2cAdvancedConfig& config) noexcept;
+  /**
+   * @brief Initialize with advanced configuration.
+   * @param config Advanced configuration parameters
+   * @return HfI2cErr result code
+   */
+  HfI2cErr initializeAdvanced(const I2cAdvancedConfig &config) noexcept;
 
-    /**
-     * @brief Configure a specific device.
-     * @param deviceConfig Device-specific configuration
-     * @return HfI2cErr result code
-     */
-    HfI2cErr configureDevice(const I2cDeviceConfig& deviceConfig) noexcept;
+  /**
+   * @brief Reconfigure the bus with new settings.
+   * @param config New configuration parameters
+   * @return HfI2cErr result code
+   */
+  HfI2cErr reconfigure(const I2cAdvancedConfig &config) noexcept;
 
-    /**
-     * @brief Get current bus configuration.
-     * @return Current configuration
-     */
-    I2cAdvancedConfig getCurrentConfiguration() const noexcept;
+  /**
+   * @brief Configure a specific device.
+   * @param deviceConfig Device-specific configuration
+   * @return HfI2cErr result code
+   */
+  HfI2cErr configureDevice(const I2cDeviceConfig &deviceConfig) noexcept;
 
-    /**
-     * @brief Reset the I2C bus.
-     * @return HfI2cErr result code
-     */
-    HfI2cErr resetBus() noexcept;
+  /**
+   * @brief Get current bus configuration.
+   * @return Current configuration
+   */
+  I2cAdvancedConfig getCurrentConfiguration() const noexcept;
 
-    /**
-     * @brief Validate device presence.
-     * @param deviceAddress Device address to check
-     * @return true if device responds, false otherwise
-     */
-    bool validateDevice(uint16_t deviceAddress) noexcept;
+  /**
+   * @brief Reset the I2C bus.
+   * @return HfI2cErr result code
+   */
+  HfI2cErr resetBus() noexcept;
 
-    //==============================================//
-    // REGISTER-BASED OPERATIONS                   //
-    //==============================================//
+  /**
+   * @brief Validate device presence.
+   * @param deviceAddress Device address to check
+   * @return true if device responds, false otherwise
+   */
+  bool validateDevice(uint16_t deviceAddress) noexcept;
 
-    /**
-     * @brief Write to a device register.
-     * @param deviceAddr Device address
-     * @param regAddr Register address
-     * @param value Value to write
-     * @return HfI2cErr result code
-     */
-    HfI2cErr writeRegister(uint16_t deviceAddr, uint8_t regAddr, uint8_t value) noexcept;
+  //==============================================//
+  // REGISTER-BASED OPERATIONS                   //
+  //==============================================//
 
-    /**
-     * @brief Read from a device register.
-     * @param deviceAddr Device address
-     * @param regAddr Register address
-     * @param value Reference to store read value
-     * @return HfI2cErr result code
-     */
-    HfI2cErr readRegister(uint16_t deviceAddr, uint8_t regAddr, uint8_t& value) noexcept;
+  /**
+   * @brief Write to a device register.
+   * @param deviceAddr Device address
+   * @param regAddr Register address
+   * @param value Value to write
+   * @return HfI2cErr result code
+   */
+  HfI2cErr writeRegister(uint16_t deviceAddr, uint8_t regAddr, uint8_t value) noexcept;
 
-    /**
-     * @brief Write multiple registers.
-     * @param deviceAddr Device address
-     * @param startRegAddr Starting register address
-     * @param data Data to write
-     * @return HfI2cErr result code
-     */
-    HfI2cErr writeMultipleRegisters(uint16_t deviceAddr, uint8_t startRegAddr, const std::vector<uint8_t>& data) noexcept;
+  /**
+   * @brief Read from a device register.
+   * @param deviceAddr Device address
+   * @param regAddr Register address
+   * @param value Reference to store read value
+   * @return HfI2cErr result code
+   */
+  HfI2cErr readRegister(uint16_t deviceAddr, uint8_t regAddr, uint8_t &value) noexcept;
 
-    /**
-     * @brief Read multiple registers.
-     * @param deviceAddr Device address
-     * @param startRegAddr Starting register address
-     * @param data Reference to store read data
-     * @param count Number of registers to read
-     * @return HfI2cErr result code
-     */
-    HfI2cErr readMultipleRegisters(uint16_t deviceAddr, uint8_t startRegAddr, std::vector<uint8_t>& data, size_t count) noexcept;
+  /**
+   * @brief Write multiple registers.
+   * @param deviceAddr Device address
+   * @param startRegAddr Starting register address
+   * @param data Data to write
+   * @return HfI2cErr result code
+   */
+  HfI2cErr writeMultipleRegisters(uint16_t deviceAddr, uint8_t startRegAddr,
+                                  const std::vector<uint8_t> &data) noexcept;
 
-    //==============================================//
-    // ASYNCHRONOUS OPERATIONS                     //
-    //==============================================//
+  /**
+   * @brief Read multiple registers.
+   * @param deviceAddr Device address
+   * @param startRegAddr Starting register address
+   * @param data Reference to store read data
+   * @param count Number of registers to read
+   * @return HfI2cErr result code
+   */
+  HfI2cErr readMultipleRegisters(uint16_t deviceAddr, uint8_t startRegAddr,
+                                 std::vector<uint8_t> &data, size_t count) noexcept;
 
-    /**
-     * @brief Asynchronous write operation.
-     * @param deviceAddr Device address
-     * @param data Data to write
-     * @param callback Completion callback
-     * @param userData User data for callback
-     * @return HfI2cErr result code
-     */
-    HfI2cErr writeAsync(uint16_t deviceAddr, const std::vector<uint8_t>& data, I2cAsyncCallback callback, void* userData = nullptr) noexcept;
+  //==============================================//
+  // ASYNCHRONOUS OPERATIONS                     //
+  //==============================================//
 
-    /**
-     * @brief Asynchronous read operation.
-     * @param deviceAddr Device address
-     * @param length Number of bytes to read
-     * @param callback Completion callback
-     * @param userData User data for callback
-     * @return HfI2cErr result code
-     */
-    HfI2cErr readAsync(uint16_t deviceAddr, size_t length, I2cAsyncCallback callback, void* userData = nullptr) noexcept;
+  /**
+   * @brief Asynchronous write operation.
+   * @param deviceAddr Device address
+   * @param data Data to write
+   * @param callback Completion callback
+   * @param userData User data for callback
+   * @return HfI2cErr result code
+   */
+  HfI2cErr writeAsync(uint16_t deviceAddr, const std::vector<uint8_t> &data,
+                      I2cAsyncCallback callback, void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Cancel pending asynchronous operation.
-     * @param operationId Operation ID to cancel
-     * @return HfI2cErr result code
-     */
-    HfI2cErr cancelAsyncOperation(uint32_t operationId) noexcept;
+  /**
+   * @brief Asynchronous read operation.
+   * @param deviceAddr Device address
+   * @param length Number of bytes to read
+   * @param callback Completion callback
+   * @param userData User data for callback
+   * @return HfI2cErr result code
+   */
+  HfI2cErr readAsync(uint16_t deviceAddr, size_t length, I2cAsyncCallback callback,
+                     void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Set event callback for bus events.
-     * @param callback Event callback function
-     * @param userData User data for callback
-     */
-    void setEventCallback(I2cEventCallback callback, void* userData = nullptr) noexcept;
+  /**
+   * @brief Cancel pending asynchronous operation.
+   * @param operationId Operation ID to cancel
+   * @return HfI2cErr result code
+   */
+  HfI2cErr cancelAsyncOperation(uint32_t operationId) noexcept;
 
-    //==============================================//
-    // MULTI-BUFFER TRANSACTIONS                   //
-    //==============================================//
+  /**
+   * @brief Set event callback for bus events.
+   * @param callback Event callback function
+   * @param userData User data for callback
+   */
+  void setEventCallback(I2cEventCallback callback, void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Execute multi-buffer transaction.
-     * @param transaction Transaction descriptor
-     * @return HfI2cErr result code
-     */
-    HfI2cErr executeMultiBufferTransaction(const I2cMultiBufferTransaction& transaction) noexcept;
+  //==============================================//
+  // MULTI-BUFFER TRANSACTIONS                   //
+  //==============================================//
 
-    /**
-     * @brief Execute multi-buffer transaction asynchronously.
-     * @param transaction Transaction descriptor
-     * @param callback Completion callback
-     * @param userData User data for callback
-     * @return HfI2cErr result code
-     */
-    HfI2cErr executeMultiBufferTransactionAsync(const I2cMultiBufferTransaction& transaction, I2cAsyncCallback callback, void* userData = nullptr) noexcept;
+  /**
+   * @brief Execute multi-buffer transaction.
+   * @param transaction Transaction descriptor
+   * @return HfI2cErr result code
+   */
+  HfI2cErr executeMultiBufferTransaction(const I2cMultiBufferTransaction &transaction) noexcept;
 
-    //==============================================//
-    // CUSTOM COMMAND SEQUENCES                    //
-    //==============================================//
+  /**
+   * @brief Execute multi-buffer transaction asynchronously.
+   * @param transaction Transaction descriptor
+   * @param callback Completion callback
+   * @param userData User data for callback
+   * @return HfI2cErr result code
+   */
+  HfI2cErr executeMultiBufferTransactionAsync(const I2cMultiBufferTransaction &transaction,
+                                              I2cAsyncCallback callback,
+                                              void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Execute custom command sequence.
-     * @param commands Vector of custom commands
-     * @return HfI2cErr result code
-     */
-    HfI2cErr executeCustomSequence(const std::vector<I2cCustomCommand>& commands) noexcept;
+  //==============================================//
+  // CUSTOM COMMAND SEQUENCES                    //
+  //==============================================//
 
-    /**
-     * @brief Execute custom command sequence asynchronously.
-     * @param commands Vector of custom commands
-     * @param callback Completion callback
-     * @param userData User data for callback
-     * @return HfI2cErr result code
-     */
-    HfI2cErr executeCustomSequenceAsync(const std::vector<I2cCustomCommand>& commands, I2cAsyncCallback callback, void* userData = nullptr) noexcept;
+  /**
+   * @brief Execute custom command sequence.
+   * @param commands Vector of custom commands
+   * @return HfI2cErr result code
+   */
+  HfI2cErr executeCustomSequence(const std::vector<I2cCustomCommand> &commands) noexcept;
 
-    //==============================================//
-    // POWER MANAGEMENT                            //
-    //==============================================//
+  /**
+   * @brief Execute custom command sequence asynchronously.
+   * @param commands Vector of custom commands
+   * @param callback Completion callback
+   * @param userData User data for callback
+   * @return HfI2cErr result code
+   */
+  HfI2cErr executeCustomSequenceAsync(const std::vector<I2cCustomCommand> &commands,
+                                      I2cAsyncCallback callback, void *userData = nullptr) noexcept;
 
-    /**
-     * @brief Set power mode.
-     * @param mode Power mode to set
-     * @return HfI2cErr result code
-     */
-    HfI2cErr setPowerMode(HfI2cPowerMode mode) noexcept;
+  //==============================================//
+  // POWER MANAGEMENT                            //
+  //==============================================//
 
-    /**
-     * @brief Get current power mode.
-     * @return Current power mode
-     */
-    HfI2cPowerMode getPowerMode() const noexcept;
+  /**
+   * @brief Set power mode.
+   * @param mode Power mode to set
+   * @return HfI2cErr result code
+   */
+  HfI2cErr setPowerMode(HfI2cPowerMode mode) noexcept;
 
-    /**
-     * @brief Suspend bus operation for power saving.
-     * @return HfI2cErr result code
-     */
-    HfI2cErr suspendBus() noexcept;
+  /**
+   * @brief Get current power mode.
+   * @return Current power mode
+   */
+  HfI2cPowerMode getPowerMode() const noexcept;
 
-    /**
-     * @brief Resume bus operation from suspended state.
-     * @return HfI2cErr result code
-     */
-    HfI2cErr resumeBus() noexcept;
+  /**
+   * @brief Suspend bus operation for power saving.
+   * @return HfI2cErr result code
+   */
+  HfI2cErr suspendBus() noexcept;
 
-    //==============================================//
-    // STATISTICS AND DIAGNOSTICS                  //
-    //==============================================//
+  /**
+   * @brief Resume bus operation from suspended state.
+   * @return HfI2cErr result code
+   */
+  HfI2cErr resumeBus() noexcept;
 
-    /**
-     * @brief Get operation statistics.
-     * @return Current statistics
-     */
-    I2cStatistics getStatistics() const noexcept;
+  //==============================================//
+  // STATISTICS AND DIAGNOSTICS                  //
+  //==============================================//
 
-    /**
-     * @brief Reset operation statistics.
-     */
-    void resetStatistics() noexcept;
+  /**
+   * @brief Get operation statistics.
+   * @return Current statistics
+   */
+  I2cStatistics getStatistics() const noexcept;
 
-    /**
-     * @brief Get diagnostic information.
-     * @return Current diagnostics
-     */
-    I2cDiagnostics getDiagnostics() noexcept;
+  /**
+   * @brief Reset operation statistics.
+   */
+  void resetStatistics() noexcept;
 
-    /**
-     * @brief Check bus health status.
-     * @return true if bus is healthy, false otherwise
-     */
-    bool isBusHealthy() noexcept;
+  /**
+   * @brief Get diagnostic information.
+   * @return Current diagnostics
+   */
+  I2cDiagnostics getDiagnostics() noexcept;
 
-    //==============================================//
-    // DEVICE MANAGEMENT                           //
-    //==============================================//
+  /**
+   * @brief Check bus health status.
+   * @return true if bus is healthy, false otherwise
+   */
+  bool isBusHealthy() noexcept;
 
-    /**
-     * @brief Scan for devices on the bus.
-     * @param foundDevices Vector to store found device addresses
-     * @param startAddr Starting address for scan (default: 0x08)
-     * @param endAddr Ending address for scan (default: 0x77)
-     * @return Number of devices found
-     */
-    size_t scanDevices(std::vector<uint16_t>& foundDevices, uint16_t startAddr = 0x08, uint16_t endAddr = 0x77) noexcept;
+  //==============================================//
+  // DEVICE MANAGEMENT                           //
+  //==============================================//
 
-    /**
-     * @brief Add device configuration.
-     * @param deviceConfig Device configuration to add
-     * @return HfI2cErr result code
-     */
-    HfI2cErr addDevice(const I2cDeviceConfig& deviceConfig) noexcept;
+  /**
+   * @brief Scan for devices on the bus.
+   * @param foundDevices Vector to store found device addresses
+   * @param startAddr Starting address for scan (default: 0x08)
+   * @param endAddr Ending address for scan (default: 0x77)
+   * @return Number of devices found
+   */
+  size_t scanDevices(std::vector<uint16_t> &foundDevices, uint16_t startAddr = 0x08,
+                     uint16_t endAddr = 0x77) noexcept;
 
-    /**
-     * @brief Remove device configuration.
-     * @param deviceAddress Device address to remove
-     * @return HfI2cErr result code
-     */
-    HfI2cErr removeDevice(uint16_t deviceAddress) noexcept;
+  /**
+   * @brief Add device configuration.
+   * @param deviceConfig Device configuration to add
+   * @return HfI2cErr result code
+   */
+  HfI2cErr addDevice(const I2cDeviceConfig &deviceConfig) noexcept;
 
-    //==============================================//
-    // ENHANCED METHODS                             //
-    //==============================================//
+  /**
+   * @brief Remove device configuration.
+   * @param deviceAddress Device address to remove
+   * @return HfI2cErr result code
+   */
+  HfI2cErr removeDevice(uint16_t deviceAddress) noexcept;
 
-    /**
-     * @brief Check if the I2C bus is busy.
-     * @return true if busy, false if available
-     */
-    bool IsBusy() noexcept;
+  //==============================================//
+  // ENHANCED METHODS                             //
+  //==============================================//
 
-    /**
-     * @brief Reset the I2C bus in case of errors.
-     * @return true if reset successful, false otherwise
-     */
-    bool ResetBus() noexcept;
+  /**
+   * @brief Check if the I2C bus is busy.
+   * @return true if busy, false if available
+   */
+  bool IsBusy() noexcept;
 
-    /**
-     * @brief Get the last error that occurred.
-     * @return Last error code
-     */
-    HfI2cErr GetLastError() const noexcept {
-        return last_error_;
-    }
+  /**
+   * @brief Reset the I2C bus in case of errors.
+   * @return true if reset successful, false otherwise
+   */
+  bool ResetBus() noexcept;
 
-    /**
-     * @brief Set a new clock speed (requires reinitialization).
-     * @param clock_speed_hz New clock speed in Hz
-     * @return true if successful, false otherwise
-     */
-    bool SetClockSpeed(uint32_t clock_speed_hz) noexcept;
+  /**
+   * @brief Get the last error that occurred.
+   * @return Last error code
+   */
+  HfI2cErr GetLastError() const noexcept {
+    return last_error_;
+  }
 
-    /**
-     * @brief Enable or disable internal pull-up resistors.
-     * @param enable True to enable pull-ups, false to disable
-     * @return true if successful, false otherwise
-     */
-    bool SetPullUps(bool enable) noexcept;
+  /**
+   * @brief Set a new clock speed (requires reinitialization).
+   * @param clock_speed_hz New clock speed in Hz
+   * @return true if successful, false otherwise
+   */
+  bool SetClockSpeed(uint32_t clock_speed_hz) noexcept;
 
-    /**
-     * @brief Get detailed bus status information.
-     * @return Platform-specific status information
-     */
-    uint32_t GetBusStatus() noexcept;
+  /**
+   * @brief Enable or disable internal pull-up resistors.
+   * @param enable True to enable pull-ups, false to disable
+   * @return true if successful, false otherwise
+   */
+  bool SetPullUps(bool enable) noexcept;
 
-    /**
-     * @brief Perform a bus recovery sequence.
-     * @return true if recovery successful, false otherwise
-     */
-    bool RecoverBus() noexcept;
+  /**
+   * @brief Get detailed bus status information.
+   * @return Platform-specific status information
+   */
+  uint32_t GetBusStatus() noexcept;
+
+  /**
+   * @brief Perform a bus recovery sequence.
+   * @return true if recovery successful, false otherwise
+   */
+  bool RecoverBus() noexcept;
 
 private:
-    //==============================================//
-    // PRIVATE METHODS                              //
-    //==============================================//
+  //==============================================//
+  // PRIVATE METHODS                              //
+  //==============================================//
 
-    /**
-     * @brief Convert platform-specific error to HfI2cErr.
-     * @param platform_error Platform-specific error code
-     * @return Corresponding HfI2cErr
-     */
-    HfI2cErr ConvertPlatformError(int32_t platform_error) noexcept;
+  /**
+   * @brief Convert platform-specific error to HfI2cErr.
+   * @param platform_error Platform-specific error code
+   * @return Corresponding HfI2cErr
+   */
+  HfI2cErr ConvertPlatformError(int32_t platform_error) noexcept;
 
-    /**
-     * @brief Validate device address.
-     * @param device_addr Device address to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidDeviceAddress(uint8_t device_addr) const noexcept {
-        // Valid 7-bit I2C addresses are 0x08-0x77 (avoiding reserved addresses)
-        return (device_addr >= 0x08 && device_addr <= 0x77);
-    }
+  /**
+   * @brief Validate device address.
+   * @param device_addr Device address to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidDeviceAddress(uint8_t device_addr) const noexcept {
+    // Valid 7-bit I2C addresses are 0x08-0x77 (avoiding reserved addresses)
+    return (device_addr >= 0x08 && device_addr <= 0x77);
+  }
 
-    /**
-     * @brief Get timeout value (use default if timeout_ms is 0).
-     * @param timeout_ms Requested timeout
-     * @return Actual timeout to use
-     */
-    uint32_t GetTimeoutMs(uint32_t timeout_ms) const noexcept {
-        return (timeout_ms == 0) ? config_.timeout_ms : timeout_ms;
-    }
+  /**
+   * @brief Get timeout value (use default if timeout_ms is 0).
+   * @param timeout_ms Requested timeout
+   * @return Actual timeout to use
+   */
+  uint32_t GetTimeoutMs(uint32_t timeout_ms) const noexcept {
+    return (timeout_ms == 0) ? config_.timeout_ms : timeout_ms;
+  }
 
-    /**
-     * @brief Perform platform-specific initialization.
-     * @return true if successful, false otherwise
-     */
-    bool PlatformInitialize() noexcept;
+  /**
+   * @brief Perform platform-specific initialization.
+   * @return true if successful, false otherwise
+   */
+  bool PlatformInitialize() noexcept;
 
-    /**
-     * @brief Perform platform-specific deinitialization.
-     * @return true if successful, false otherwise
-     */
-    bool PlatformDeinitialize() noexcept;
+  /**
+   * @brief Perform platform-specific deinitialization.
+   * @return true if successful, false otherwise
+   */
+  bool PlatformDeinitialize() noexcept;
 
-    /**
-     * @brief Update operation statistics.
-     * @param success Operation success status
-     * @param bytesTransferred Number of bytes transferred
-     * @param operationTimeUs Operation time in microseconds
-     */
-    void UpdateStatistics(bool success, size_t bytesTransferred, uint64_t operationTimeUs) noexcept;
+  /**
+   * @brief Update operation statistics.
+   * @param success Operation success status
+   * @param bytesTransferred Number of bytes transferred
+   * @param operationTimeUs Operation time in microseconds
+   */
+  void UpdateStatistics(bool success, size_t bytesTransferred, uint64_t operationTimeUs) noexcept;
 
-    /**
-     * @brief Handle platform-specific error.
-     * @param error Platform error code
-     */
-    void HandlePlatformError(int32_t error) noexcept;
+  /**
+   * @brief Handle platform-specific error.
+   * @param error Platform error code
+   */
+  void HandlePlatformError(int32_t error) noexcept;
 
-    /**
-     * @brief Initialize ESP32 I2C master bus.
-     * @return HfI2cErr result code
-     */
-    HfI2cErr InitializeEsp32Master() noexcept;
+  /**
+   * @brief Initialize ESP32 I2C master bus.
+   * @return HfI2cErr result code
+   */
+  HfI2cErr InitializeEsp32Master() noexcept;
 
-    /**
-     * @brief Create device handle for ESP32.
-     * @param deviceAddr Device address
-     * @return Device handle or nullptr on failure
-     */
-    void* CreateEsp32DeviceHandle(uint16_t deviceAddr) noexcept;
+  /**
+   * @brief Create device handle for ESP32.
+   * @param deviceAddr Device address
+   * @return Device handle or nullptr on failure
+   */
+  void *CreateEsp32DeviceHandle(uint16_t deviceAddr) noexcept;
 
-    //==============================================//
-    // PRIVATE MEMBER VARIABLES                    //
-    //==============================================//
+  //==============================================//
+  // PRIVATE MEMBER VARIABLES                    //
+  //==============================================//
 
-    // Configuration
-    I2cAdvancedConfig advanced_config_;         ///< Advanced configuration
-    I2cBusConfig config_;                       ///< Basic configuration (for compatibility)
-    bool use_advanced_config_;                  ///< Flag indicating advanced config usage
+  // Configuration
+  I2cAdvancedConfig advanced_config_; ///< Advanced configuration
+  I2cBusConfig config_;               ///< Basic configuration (for compatibility)
+  bool use_advanced_config_;          ///< Flag indicating advanced config usage
 
-    // Platform-specific handles
-    void* platform_handle_;                    ///< Platform-specific I2C handle
-    void* master_bus_handle_;                  ///< ESP32 master bus handle
-    std::unordered_map<uint16_t, void*> device_handles_; ///< Device handles map
+  // Platform-specific handles
+  void *platform_handle_;                               ///< Platform-specific I2C handle
+  void *master_bus_handle_;                             ///< ESP32 master bus handle
+  std::unordered_map<uint16_t, void *> device_handles_; ///< Device handles map
 
-    // State management
-    mutable std::mutex mutex_;                  ///< Thread synchronization mutex
-    HfI2cErr last_error_;                      ///< Last error that occurred
-    uint64_t transaction_count_;               ///< Transaction counter
-    bool bus_locked_;                          ///< Bus lock status
-    bool advanced_initialized_;                ///< Advanced features initialized flag
+  // State management
+  mutable std::mutex mutex_;   ///< Thread synchronization mutex
+  HfI2cErr last_error_;        ///< Last error that occurred
+  uint64_t transaction_count_; ///< Transaction counter
+  bool bus_locked_;            ///< Bus lock status
+  bool advanced_initialized_;  ///< Advanced features initialized flag
 
-    // Device configurations
-    std::unordered_map<uint16_t, I2cDeviceConfig> device_configs_; ///< Device-specific configurations
+  // Device configurations
+  std::unordered_map<uint16_t, I2cDeviceConfig> device_configs_; ///< Device-specific configurations
 
-    // Asynchronous operation support
-    std::unordered_map<uint32_t, void*> async_operations_; ///< Active async operations
-    uint32_t next_operation_id_;               ///< Next operation ID
-    I2cEventCallback event_callback_;          ///< Event callback function
-    void* event_callback_userdata_;           ///< Event callback user data
+  // Asynchronous operation support
+  std::unordered_map<uint32_t, void *> async_operations_; ///< Active async operations
+  uint32_t next_operation_id_;                            ///< Next operation ID
+  I2cEventCallback event_callback_;                       ///< Event callback function
+  void *event_callback_userdata_;                         ///< Event callback user data
 
-    // Statistics and diagnostics
-    mutable I2cStatistics statistics_;         ///< Operation statistics
-    I2cDiagnostics diagnostics_;               ///< Diagnostic information
-    uint64_t last_operation_time_;             ///< Last operation timestamp
+  // Statistics and diagnostics
+  mutable I2cStatistics statistics_; ///< Operation statistics
+  I2cDiagnostics diagnostics_;       ///< Diagnostic information
+  uint64_t last_operation_time_;     ///< Last operation timestamp
 
-    // Power management
-    HfI2cPowerMode current_power_mode_;        ///< Current power mode
-    bool bus_suspended_;                       ///< Bus suspension state
+  // Power management
+  HfI2cPowerMode current_power_mode_; ///< Current power mode
+  bool bus_suspended_;                ///< Bus suspension state
 
-    // Platform-specific constants
-    static constexpr uint32_t DEFAULT_TIMEOUT_MS = 1000;
-    static constexpr uint32_t MAX_TRANSFER_SIZE = 4092;  // ESP32 limitation
-    static constexpr uint8_t MAX_DEVICES = 127;         // Maximum I2C devices
+  // Platform-specific constants
+  static constexpr uint32_t DEFAULT_TIMEOUT_MS = 1000;
+  static constexpr uint32_t MAX_TRANSFER_SIZE = 4092; // ESP32 limitation
+  static constexpr uint8_t MAX_DEVICES = 127;         // Maximum I2C devices
 };
 
 #endif // MCU_I2C_H

--- a/inc/mcu/McuNvsStorage.h
+++ b/inc/mcu/McuNvsStorage.h
@@ -18,12 +18,12 @@
 /**
  * @class McuNvsStorage
  * @brief MCU-integrated non-volatile storage implementation.
- * 
+ *
  * This class provides non-volatile storage using the microcontroller's built-in
  * storage mechanisms. On ESP32, it uses the NVS (Non-Volatile Storage) library.
  * The implementation handles platform-specific details while providing the
  * unified BaseNvsStorage API.
- * 
+ *
  * Features:
  * - Key-value storage using MCU's integrated NVS
  * - Multiple data type support (uint32_t, string, blob)
@@ -31,148 +31,148 @@
  * - Atomic operations and error handling
  * - Comprehensive status reporting
  * - Lazy initialization support
- * 
+ *
  * @note This implementation requires sufficient flash storage on the MCU
  */
 class McuNvsStorage : public BaseNvsStorage {
 public:
-    /**
-     * @brief Constructor with namespace specification.
-     * @param namespace_name Name of the storage namespace
-     */
-    explicit McuNvsStorage(const char* namespace_name) noexcept;
+  /**
+   * @brief Constructor with namespace specification.
+   * @param namespace_name Name of the storage namespace
+   */
+  explicit McuNvsStorage(const char *namespace_name) noexcept;
 
-    /**
-     * @brief Destructor - ensures proper cleanup.
-     */
-    ~McuNvsStorage() noexcept override;
+  /**
+   * @brief Destructor - ensures proper cleanup.
+   */
+  ~McuNvsStorage() noexcept override;
 
-    //==============================================//
-    // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
-    //==============================================//
+  //==============================================//
+  // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
+  //==============================================//
 
-    /**
-     * @brief Initialize the NVS system and open the namespace.
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr Initialize() noexcept override;
+  /**
+   * @brief Initialize the NVS system and open the namespace.
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr Initialize() noexcept override;
 
-    /**
-     * @brief Deinitialize the NVS system and close the namespace.
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr Deinitialize() noexcept override;
+  /**
+   * @brief Deinitialize the NVS system and close the namespace.
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr Deinitialize() noexcept override;
 
-    /**
-     * @brief Store a 32-bit unsigned integer value.
-     * @param key Storage key (null-terminated string)
-     * @param value Value to store
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr SetU32(const char* key, uint32_t value) noexcept override;
+  /**
+   * @brief Store a 32-bit unsigned integer value.
+   * @param key Storage key (null-terminated string)
+   * @param value Value to store
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr SetU32(const char *key, uint32_t value) noexcept override;
 
-    /**
-     * @brief Retrieve a 32-bit unsigned integer value.
-     * @param key Storage key (null-terminated string)
-     * @param value Reference to store the retrieved value
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr GetU32(const char* key, uint32_t& value) noexcept override;
+  /**
+   * @brief Retrieve a 32-bit unsigned integer value.
+   * @param key Storage key (null-terminated string)
+   * @param value Reference to store the retrieved value
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr GetU32(const char *key, uint32_t &value) noexcept override;
 
-    /**
-     * @brief Store a string value.
-     * @param key Storage key (null-terminated string)
-     * @param value String value to store
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr SetString(const char* key, const char* value) noexcept override;
+  /**
+   * @brief Store a string value.
+   * @param key Storage key (null-terminated string)
+   * @param value String value to store
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr SetString(const char *key, const char *value) noexcept override;
 
-    /**
-     * @brief Retrieve a string value.
-     * @param key Storage key (null-terminated string)
-     * @param buffer Buffer to store the retrieved string
-     * @param buffer_size Size of the buffer in bytes
-     * @param actual_size Actual size of the string (optional)
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr GetString(const char* key, char* buffer, size_t buffer_size, 
-                       size_t* actual_size = nullptr) noexcept override;
+  /**
+   * @brief Retrieve a string value.
+   * @param key Storage key (null-terminated string)
+   * @param buffer Buffer to store the retrieved string
+   * @param buffer_size Size of the buffer in bytes
+   * @param actual_size Actual size of the string (optional)
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr GetString(const char *key, char *buffer, size_t buffer_size,
+                     size_t *actual_size = nullptr) noexcept override;
 
-    /**
-     * @brief Store binary data (blob).
-     * @param key Storage key (null-terminated string)
-     * @param data Pointer to data to store
-     * @param data_size Size of data in bytes
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr SetBlob(const char* key, const void* data, size_t data_size) noexcept override;
+  /**
+   * @brief Store binary data (blob).
+   * @param key Storage key (null-terminated string)
+   * @param data Pointer to data to store
+   * @param data_size Size of data in bytes
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr SetBlob(const char *key, const void *data, size_t data_size) noexcept override;
 
-    /**
-     * @brief Retrieve binary data (blob).
-     * @param key Storage key (null-terminated string)
-     * @param buffer Buffer to store the retrieved data
-     * @param buffer_size Size of the buffer in bytes
-     * @param actual_size Actual size of the data (optional)
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr GetBlob(const char* key, void* buffer, size_t buffer_size,
-                     size_t* actual_size = nullptr) noexcept override;
+  /**
+   * @brief Retrieve binary data (blob).
+   * @param key Storage key (null-terminated string)
+   * @param buffer Buffer to store the retrieved data
+   * @param buffer_size Size of the buffer in bytes
+   * @param actual_size Actual size of the data (optional)
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr GetBlob(const char *key, void *buffer, size_t buffer_size,
+                   size_t *actual_size = nullptr) noexcept override;
 
-    /**
-     * @brief Remove a key from storage.
-     * @param key Storage key to remove
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr EraseKey(const char* key) noexcept override;
+  /**
+   * @brief Remove a key from storage.
+   * @param key Storage key to remove
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr EraseKey(const char *key) noexcept override;
 
-    /**
-     * @brief Commit any pending writes to non-volatile storage.
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr Commit() noexcept override;
+  /**
+   * @brief Commit any pending writes to non-volatile storage.
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr Commit() noexcept override;
 
-    /**
-     * @brief Check if a key exists in storage.
-     * @param key Storage key to check
-     * @return true if key exists, false otherwise
-     */
-    bool KeyExists(const char* key) noexcept override;
+  /**
+   * @brief Check if a key exists in storage.
+   * @param key Storage key to check
+   * @return true if key exists, false otherwise
+   */
+  bool KeyExists(const char *key) noexcept override;
 
-    /**
-     * @brief Get the size of a stored value.
-     * @param key Storage key
-     * @param size Reference to store the size
-     * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
-     */
-    HfNvsErr GetSize(const char* key, size_t& size) noexcept override;
+  /**
+   * @brief Get the size of a stored value.
+   * @param key Storage key
+   * @param size Reference to store the size
+   * @return HfNvsErr::NVS_SUCCESS if successful, error code otherwise
+   */
+  HfNvsErr GetSize(const char *key, size_t &size) noexcept override;
 
-    /**
-     * @brief Get description of this NVS implementation.
-     * @return Description string
-     */
-    const char* GetDescription() const noexcept override;
+  /**
+   * @brief Get description of this NVS implementation.
+   * @return Description string
+   */
+  const char *GetDescription() const noexcept override;
 
-    /**
-     * @brief Get maximum key length supported.
-     * @return Maximum key length in characters
-     */
-    size_t GetMaxKeyLength() const noexcept override;
+  /**
+   * @brief Get maximum key length supported.
+   * @return Maximum key length in characters
+   */
+  size_t GetMaxKeyLength() const noexcept override;
 
-    /**
-     * @brief Get maximum value size supported.
-     * @return Maximum value size in bytes
-     */
-    size_t GetMaxValueSize() const noexcept override;
+  /**
+   * @brief Get maximum value size supported.
+   * @return Maximum value size in bytes
+   */
+  size_t GetMaxValueSize() const noexcept override;
 
 private:
-    /**
-     * @brief Convert MCU-specific error to HfNvsErr.
-     * @param mcu_error MCU-specific error code
-     * @return Corresponding HfNvsErr value
-     */
-    HfNvsErr ConvertMcuError(int mcu_error) const noexcept;
+  /**
+   * @brief Convert MCU-specific error to HfNvsErr.
+   * @param mcu_error MCU-specific error code
+   * @return Corresponding HfNvsErr value
+   */
+  HfNvsErr ConvertMcuError(int mcu_error) const noexcept;
 
-    void* nvs_handle_;  ///< Platform-specific NVS handle
+  void *nvs_handle_; ///< Platform-specific NVS handle
 };
 
 #endif // MCU_NVS_STORAGE_H_

--- a/inc/mcu/McuPeriodicTimer.h
+++ b/inc/mcu/McuPeriodicTimer.h
@@ -18,11 +18,11 @@
 /**
  * @class McuPeriodicTimer
  * @brief MCU-integrated periodic timer implementation.
- * 
+ *
  * This class provides periodic timer functionality using the microcontroller's built-in
  * timer peripherals. On ESP32, it uses the ESP timer API. The implementation handles
  * platform-specific details while providing the unified BasePeriodicTimer API.
- * 
+ *
  * Features:
  * - High-precision periodic timing using MCU's integrated timers
  * - Microsecond resolution timing
@@ -30,147 +30,147 @@
  * - Start/stop control with period adjustment
  * - Comprehensive error handling and status reporting
  * - Lazy initialization support
- * 
+ *
  * @note This implementation uses hardware timers for precise timing
  */
 class McuPeriodicTimer : public BasePeriodicTimer {
 public:
-    /**
-     * @brief Constructor with callback specification.
-     * @param callback Callback function to be called on timer expiry
-     * @param user_data User data passed to callback function
-     */
-    McuPeriodicTimer(TimerCallback callback = nullptr, void* user_data = nullptr) noexcept;
+  /**
+   * @brief Constructor with callback specification.
+   * @param callback Callback function to be called on timer expiry
+   * @param user_data User data passed to callback function
+   */
+  McuPeriodicTimer(TimerCallback callback = nullptr, void *user_data = nullptr) noexcept;
 
-    /**
-     * @brief Destructor - ensures timer is stopped and resources are freed.
-     */
-    ~McuPeriodicTimer() noexcept override;
+  /**
+   * @brief Destructor - ensures timer is stopped and resources are freed.
+   */
+  ~McuPeriodicTimer() noexcept override;
 
-    // Copy/move constructors and assignment operators
-    McuPeriodicTimer(const McuPeriodicTimer&) = delete;
-    McuPeriodicTimer& operator=(const McuPeriodicTimer&) = delete;
-    McuPeriodicTimer(McuPeriodicTimer&&) = delete;
-    McuPeriodicTimer& operator=(McuPeriodicTimer&&) = delete;
+  // Copy/move constructors and assignment operators
+  McuPeriodicTimer(const McuPeriodicTimer &) = delete;
+  McuPeriodicTimer &operator=(const McuPeriodicTimer &) = delete;
+  McuPeriodicTimer(McuPeriodicTimer &&) = delete;
+  McuPeriodicTimer &operator=(McuPeriodicTimer &&) = delete;
 
-    //==============================================//
-    // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
-    //==============================================//
+  //==============================================//
+  // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
+  //==============================================//
 
-    /**
-     * @brief Initialize the timer.
-     * @return Success or specific error code
-     */
-    HfTimerErr Initialize() noexcept override;
+  /**
+   * @brief Initialize the timer.
+   * @return Success or specific error code
+   */
+  HfTimerErr Initialize() noexcept override;
 
-    /**
-     * @brief Deinitialize the timer and free resources.
-     * @return Success or specific error code
-     */
-    HfTimerErr Deinitialize() noexcept override;
+  /**
+   * @brief Deinitialize the timer and free resources.
+   * @return Success or specific error code
+   */
+  HfTimerErr Deinitialize() noexcept override;
 
-    /**
-     * @brief Start the timer with specified period.
-     * @param period_us Timer period in microseconds
-     * @return Success or specific error code
-     */
-    HfTimerErr Start(uint64_t period_us) noexcept override;
+  /**
+   * @brief Start the timer with specified period.
+   * @param period_us Timer period in microseconds
+   * @return Success or specific error code
+   */
+  HfTimerErr Start(uint64_t period_us) noexcept override;
 
-    /**
-     * @brief Stop the timer.
-     * @return Success or specific error code
-     */
-    HfTimerErr Stop() noexcept override;
+  /**
+   * @brief Stop the timer.
+   * @return Success or specific error code
+   */
+  HfTimerErr Stop() noexcept override;
 
-    /**
-     * @brief Change timer period (timer can be running or stopped).
-     * @param new_period_us New period in microseconds
-     * @return Success or specific error code
-     */
-    HfTimerErr SetPeriod(uint64_t new_period_us) noexcept override;
+  /**
+   * @brief Change timer period (timer can be running or stopped).
+   * @param new_period_us New period in microseconds
+   * @return Success or specific error code
+   */
+  HfTimerErr SetPeriod(uint64_t new_period_us) noexcept override;
 
-    /**
-     * @brief Get current timer period.
-     * @param period_us Reference to store current period
-     * @return Success or specific error code
-     */
-    HfTimerErr GetPeriod(uint64_t& period_us) noexcept override;
+  /**
+   * @brief Get current timer period.
+   * @param period_us Reference to store current period
+   * @return Success or specific error code
+   */
+  HfTimerErr GetPeriod(uint64_t &period_us) noexcept override;
 
-    /**
-     * @brief Get timer statistics and status information.
-     * @param callback_count Number of callbacks executed
-     * @param missed_callbacks Number of missed callbacks (if supported)
-     * @param last_error Last error that occurred
-     * @return Success or specific error code
-     */
-    HfTimerErr GetStats(uint64_t& callback_count, uint64_t& missed_callbacks,
-                       HfTimerErr& last_error) noexcept override;
+  /**
+   * @brief Get timer statistics and status information.
+   * @param callback_count Number of callbacks executed
+   * @param missed_callbacks Number of missed callbacks (if supported)
+   * @param last_error Last error that occurred
+   * @return Success or specific error code
+   */
+  HfTimerErr GetStats(uint64_t &callback_count, uint64_t &missed_callbacks,
+                      HfTimerErr &last_error) noexcept override;
 
-    /**
-     * @brief Reset timer statistics.
-     * @return Success or specific error code
-     */
-    HfTimerErr ResetStats() noexcept override;
+  /**
+   * @brief Reset timer statistics.
+   * @return Success or specific error code
+   */
+  HfTimerErr ResetStats() noexcept override;
 
-    /**
-     * @brief Get description of this timer implementation.
-     * @return Description string
-     */
-    const char* GetDescription() const noexcept override;
+  /**
+   * @brief Get description of this timer implementation.
+   * @return Description string
+   */
+  const char *GetDescription() const noexcept override;
 
-    /**
-     * @brief Get minimum supported timer period.
-     * @return Minimum period in microseconds
-     */
-    uint64_t GetMinPeriod() const noexcept override;
+  /**
+   * @brief Get minimum supported timer period.
+   * @return Minimum period in microseconds
+   */
+  uint64_t GetMinPeriod() const noexcept override;
 
-    /**
-     * @brief Get maximum supported timer period.
-     * @return Maximum period in microseconds
-     */
-    uint64_t GetMaxPeriod() const noexcept override;
+  /**
+   * @brief Get maximum supported timer period.
+   * @return Maximum period in microseconds
+   */
+  uint64_t GetMaxPeriod() const noexcept override;
 
-    /**
-     * @brief Get timer resolution.
-     * @return Timer resolution in microseconds
-     */
-    uint64_t GetResolution() const noexcept override;
+  /**
+   * @brief Get timer resolution.
+   * @return Timer resolution in microseconds
+   */
+  uint64_t GetResolution() const noexcept override;
 
 private:
-    hf_timer_handle_t timer_handle_;     ///< Platform-specific timer handle
-    uint64_t period_us_;                 ///< Current timer period in microseconds
-    TimerStats stats_;                   ///< Timer statistics
+  hf_timer_handle_t timer_handle_; ///< Platform-specific timer handle
+  uint64_t period_us_;             ///< Current timer period in microseconds
+  TimerStats stats_;               ///< Timer statistics
 
-    /**
-     * @brief Convert platform-specific error to HfTimerErr.
-     * @param platform_error Platform-specific error code
-     * @return Corresponding HfTimerErr
-     */
-    HfTimerErr ConvertError(int platform_error) const noexcept;
+  /**
+   * @brief Convert platform-specific error to HfTimerErr.
+   * @param platform_error Platform-specific error code
+   * @return Corresponding HfTimerErr
+   */
+  HfTimerErr ConvertError(int platform_error) const noexcept;
 
-    /**
-     * @brief Validate timer period.
-     * @param period_us Period to validate in microseconds
-     * @return True if valid, false otherwise
-     */
-    bool ValidatePeriod(uint64_t period_us) const noexcept;
+  /**
+   * @brief Validate timer period.
+   * @param period_us Period to validate in microseconds
+   * @return True if valid, false otherwise
+   */
+  bool ValidatePeriod(uint64_t period_us) const noexcept;
 
-    /**
-     * @brief Create platform-specific timer handle.
-     * @return Success if handle created successfully
-     */
-    bool CreateTimerHandle() noexcept;
+  /**
+   * @brief Create platform-specific timer handle.
+   * @return Success if handle created successfully
+   */
+  bool CreateTimerHandle() noexcept;
 
-    /**
-     * @brief Destroy platform-specific timer handle.
-     */
-    void DestroyTimerHandle() noexcept;
+  /**
+   * @brief Destroy platform-specific timer handle.
+   */
+  void DestroyTimerHandle() noexcept;
 
-    /**
-     * @brief Internal timer callback dispatcher.
-     * @param timer_handle Platform-specific timer handle
-     */
-    static void TimerCallbackDispatcher(hf_timer_handle_t timer_handle);
+  /**
+   * @brief Internal timer callback dispatcher.
+   * @param timer_handle Platform-specific timer handle
+   */
+  static void TimerCallbackDispatcher(hf_timer_handle_t timer_handle);
 };
 
 #endif // MCU_PERIODIC_TIMER_H

--- a/inc/mcu/McuPio.h
+++ b/inc/mcu/McuPio.h
@@ -1,11 +1,11 @@
 /**
  * @file McuPio.h
  * @brief ESP32 RMT-based Programmable IO Channel implementation.
- * 
+ *
  * This header provides a PIO implementation for ESP32 microcontrollers using
  * the RMT (Remote Control Transceiver) peripheral. The RMT peripheral provides
  * precise timing control and hardware buffering ideal for PIO operations.
- * 
+ *
  * Features:
  * - Up to 8 RMT channels (depending on ESP32 variant)
  * - Nanosecond-level timing precision
@@ -25,13 +25,13 @@
 
 // Forward declarations for ESP32 RMT types
 #ifdef HF_MCU_FAMILY_ESP32
-#include "driver/rmt_tx.h"
-#include "driver/rmt_rx.h"
 #include "driver/rmt_encoder.h"
+#include "driver/rmt_rx.h"
+#include "driver/rmt_tx.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "freertos/semphr.h"
+#include "freertos/task.h"
 
 #else
 // For non-ESP32 platforms, we'll provide stub types
@@ -43,19 +43,19 @@ struct rmt_symbol_word_t;
 /**
  * @class McuPio
  * @brief ESP32 RMT-based Programmable IO Channel implementation.
- * 
+ *
  * This class implements the BasePio interface using the ESP32's RMT peripheral.
  * The RMT peripheral is specifically designed for generating and receiving
  * infrared remote control signals, but it's versatile enough to handle many
  * types of precisely-timed digital protocols.
- * 
+ *
  * Key ESP32 RMT features utilized:
  * - Hardware symbol encoding with configurable timing
  * - Built-in carrier generation for IR protocols
  * - Configurable idle levels and end markers
  * - Interrupt-driven operation with minimal CPU overhead
  * - Support for both transmission and reception
- * 
+ *
  * Limitations:
  * - Maximum symbol duration depends on RMT clock configuration
  * - Symbol buffer size is limited by available memory
@@ -63,263 +63,267 @@ struct rmt_symbol_word_t;
  */
 class McuPio : public BasePio {
 public:
-    /**
-     * @brief Constructor
-     */
-    McuPio() noexcept;
+  /**
+   * @brief Constructor
+   */
+  McuPio() noexcept;
 
-    /**
-     * @brief Destructor
-     */
-    ~McuPio() noexcept override;
+  /**
+   * @brief Destructor
+   */
+  ~McuPio() noexcept override;
 
-    // Disable copy constructor and assignment operator
-    McuPio(const McuPio&) = delete;
-    McuPio& operator=(const McuPio&) = delete;
+  // Disable copy constructor and assignment operator
+  McuPio(const McuPio &) = delete;
+  McuPio &operator=(const McuPio &) = delete;
 
-    // Allow move operations
-    McuPio(McuPio&&) noexcept = default;
-    McuPio& operator=(McuPio&&) noexcept = default;
+  // Allow move operations
+  McuPio(McuPio &&) noexcept = default;
+  McuPio &operator=(McuPio &&) noexcept = default;
 
-    //==============================================//
-    // BasePio Interface Implementation
-    //==============================================//
+  //==============================================//
+  // BasePio Interface Implementation
+  //==============================================//
 
-    HfPioErr Initialize() noexcept override;
-    HfPioErr Deinitialize() noexcept override;
-    bool IsInitialized() const noexcept override;
+  HfPioErr Initialize() noexcept override;
+  HfPioErr Deinitialize() noexcept override;
+  bool IsInitialized() const noexcept override;
 
-    HfPioErr ConfigureChannel(uint8_t channel_id, const PioChannelConfig& config) noexcept override;
+  HfPioErr ConfigureChannel(uint8_t channel_id, const PioChannelConfig &config) noexcept override;
 
-    HfPioErr Transmit(uint8_t channel_id, const PioSymbol* symbols, size_t symbol_count, bool wait_completion = false) noexcept override;
+  HfPioErr Transmit(uint8_t channel_id, const PioSymbol *symbols, size_t symbol_count,
+                    bool wait_completion = false) noexcept override;
 
-    HfPioErr StartReceive(uint8_t channel_id, PioSymbol* buffer, size_t buffer_size, uint32_t timeout_us = 0) noexcept override;
-    HfPioErr StopReceive(uint8_t channel_id, size_t& symbols_received) noexcept override;
+  HfPioErr StartReceive(uint8_t channel_id, PioSymbol *buffer, size_t buffer_size,
+                        uint32_t timeout_us = 0) noexcept override;
+  HfPioErr StopReceive(uint8_t channel_id, size_t &symbols_received) noexcept override;
 
-    bool IsChannelBusy(uint8_t channel_id) const noexcept override;
-    HfPioErr GetChannelStatus(uint8_t channel_id, PioChannelStatus& status) const noexcept override;
-    HfPioErr GetCapabilities(PioCapabilities& capabilities) const noexcept override;
+  bool IsChannelBusy(uint8_t channel_id) const noexcept override;
+  HfPioErr GetChannelStatus(uint8_t channel_id, PioChannelStatus &status) const noexcept override;
+  HfPioErr GetCapabilities(PioCapabilities &capabilities) const noexcept override;
 
-    void SetTransmitCallback(PioTransmitCallback callback, void* user_data = nullptr) noexcept override;
-    void SetReceiveCallback(PioReceiveCallback callback, void* user_data = nullptr) noexcept override;
-    void SetErrorCallback(PioErrorCallback callback, void* user_data = nullptr) noexcept override;
-    void ClearCallbacks() noexcept override;    
-    
-    //==============================================//
-    // Advanced Low-Level RMT Control Methods
-    //==============================================//
+  void SetTransmitCallback(PioTransmitCallback callback,
+                           void *user_data = nullptr) noexcept override;
+  void SetReceiveCallback(PioReceiveCallback callback, void *user_data = nullptr) noexcept override;
+  void SetErrorCallback(PioErrorCallback callback, void *user_data = nullptr) noexcept override;
+  void ClearCallbacks() noexcept override;
 
-    /**
-     * @brief Transmit raw RMT symbols directly (bypassing PioSymbol conversion)
-     * @param channel_id Channel identifier
-     * @param rmt_symbols Array of raw RMT symbols
-     * @param symbol_count Number of RMT symbols
-     * @param wait_completion If true, block until transmission is complete
-     * @return Error code indicating success or failure
-     * @note This provides direct RMT access similar to rmt_wrapper.hpp
-     */
-    HfPioErr TransmitRawRmtSymbols(uint8_t channel_id, const rmt_symbol_word_t* rmt_symbols, 
-                                   size_t symbol_count, bool wait_completion = false) noexcept;
+  //==============================================//
+  // Advanced Low-Level RMT Control Methods
+  //==============================================//
 
-    /**
-     * @brief Receive raw RMT symbols directly (bypassing PioSymbol conversion)
-     * @param channel_id Channel identifier
-     * @param rmt_buffer Buffer to store raw RMT symbols
-     * @param buffer_size Size of buffer in RMT symbols
-     * @param symbols_received [out] Number of symbols actually received
-     * @param timeout_us Timeout in microseconds
-     * @return Error code indicating success or failure
-     * @note This provides direct RMT access similar to rmt_wrapper.hpp
-     */
-    HfPioErr ReceiveRawRmtSymbols(uint8_t channel_id, rmt_symbol_word_t* rmt_buffer, 
-                                  size_t buffer_size, size_t& symbols_received, 
-                                  uint32_t timeout_us = 10000) noexcept;
+  /**
+   * @brief Transmit raw RMT symbols directly (bypassing PioSymbol conversion)
+   * @param channel_id Channel identifier
+   * @param rmt_symbols Array of raw RMT symbols
+   * @param symbol_count Number of RMT symbols
+   * @param wait_completion If true, block until transmission is complete
+   * @return Error code indicating success or failure
+   * @note This provides direct RMT access similar to rmt_wrapper.hpp
+   */
+  HfPioErr TransmitRawRmtSymbols(uint8_t channel_id, const rmt_symbol_word_t *rmt_symbols,
+                                 size_t symbol_count, bool wait_completion = false) noexcept;
 
-    /**
-     * @brief Configure advanced RMT channel settings
-     * @param channel_id Channel identifier
-     * @param memory_blocks Number of memory blocks (symbols) to allocate
-     * @param enable_dma Enable DMA mode for large transfers
-     * @param queue_depth Transmit queue depth
-     * @return Error code indicating success or failure
-     */
-    HfPioErr ConfigureAdvancedRmt(uint8_t channel_id, size_t memory_blocks = 64, 
-                                  bool enable_dma = false, uint32_t queue_depth = 4) noexcept;
+  /**
+   * @brief Receive raw RMT symbols directly (bypassing PioSymbol conversion)
+   * @param channel_id Channel identifier
+   * @param rmt_buffer Buffer to store raw RMT symbols
+   * @param buffer_size Size of buffer in RMT symbols
+   * @param symbols_received [out] Number of symbols actually received
+   * @param timeout_us Timeout in microseconds
+   * @return Error code indicating success or failure
+   * @note This provides direct RMT access similar to rmt_wrapper.hpp
+   */
+  HfPioErr ReceiveRawRmtSymbols(uint8_t channel_id, rmt_symbol_word_t *rmt_buffer,
+                                size_t buffer_size, size_t &symbols_received,
+                                uint32_t timeout_us = 10000) noexcept;
 
-    /**
-     * @brief Create WS2812-optimized encoder with configurable timing
-     * @param channel_id Channel identifier
-     * @param resolution_hz RMT resolution for timing calculations
-     * @param t0h_ns High time for '0' bit in nanoseconds (default: 400ns)
-     * @param t0l_ns Low time for '0' bit in nanoseconds (default: 850ns)
-     * @param t1h_ns High time for '1' bit in nanoseconds (default: 800ns)
-     * @param t1l_ns Low time for '1' bit in nanoseconds (default: 450ns)
-     * @return Error code indicating success or failure
-     */
-    HfPioErr CreateWS2812Encoder(uint8_t channel_id, uint32_t resolution_hz = 10000000,
-                                 uint32_t t0h_ns = 400, uint32_t t0l_ns = 850,
-                                 uint32_t t1h_ns = 800, uint32_t t1l_ns = 450) noexcept;
+  /**
+   * @brief Configure advanced RMT channel settings
+   * @param channel_id Channel identifier
+   * @param memory_blocks Number of memory blocks (symbols) to allocate
+   * @param enable_dma Enable DMA mode for large transfers
+   * @param queue_depth Transmit queue depth
+   * @return Error code indicating success or failure
+   */
+  HfPioErr ConfigureAdvancedRmt(uint8_t channel_id, size_t memory_blocks = 64,
+                                bool enable_dma = false, uint32_t queue_depth = 4) noexcept;
 
-    /**
-     * @brief Transmit WS2812/NeoPixel data using optimized encoder
-     * @param channel_id Channel identifier  
-     * @param grb_data GRB pixel data (Green, Red, Blue format)
-     * @param length Number of bytes
-     * @param wait_completion If true, block until transmission is complete
-     * @return Error code indicating success or failure
-     */
-    HfPioErr TransmitWS2812(uint8_t channel_id, const uint8_t* grb_data, size_t length,
-                            bool wait_completion = false) noexcept;
+  /**
+   * @brief Create WS2812-optimized encoder with configurable timing
+   * @param channel_id Channel identifier
+   * @param resolution_hz RMT resolution for timing calculations
+   * @param t0h_ns High time for '0' bit in nanoseconds (default: 400ns)
+   * @param t0l_ns Low time for '0' bit in nanoseconds (default: 850ns)
+   * @param t1h_ns High time for '1' bit in nanoseconds (default: 800ns)
+   * @param t1l_ns Low time for '1' bit in nanoseconds (default: 450ns)
+   * @return Error code indicating success or failure
+   */
+  HfPioErr CreateWS2812Encoder(uint8_t channel_id, uint32_t resolution_hz = 10000000,
+                               uint32_t t0h_ns = 400, uint32_t t0l_ns = 850, uint32_t t1h_ns = 800,
+                               uint32_t t1l_ns = 450) noexcept;
 
-    //==============================================//
-    // ESP32-Specific Methods (continued)
-    //==============================================//
+  /**
+   * @brief Transmit WS2812/NeoPixel data using optimized encoder
+   * @param channel_id Channel identifier
+   * @param grb_data GRB pixel data (Green, Red, Blue format)
+   * @param length Number of bytes
+   * @param wait_completion If true, block until transmission is complete
+   * @return Error code indicating success or failure
+   */
+  HfPioErr TransmitWS2812(uint8_t channel_id, const uint8_t *grb_data, size_t length,
+                          bool wait_completion = false) noexcept;
 
-    /**
-     * @brief Configure carrier modulation for IR protocols
-     * @param channel_id Channel identifier
-     * @param carrier_freq_hz Carrier frequency in Hz (0 to disable)
-     * @param duty_cycle Carrier duty cycle (0.0 to 1.0)
-     * @return Error code indicating success or failure
-     */
-    HfPioErr ConfigureCarrier(uint8_t channel_id, uint32_t carrier_freq_hz, float duty_cycle) noexcept;
+  //==============================================//
+  // ESP32-Specific Methods (continued)
+  //==============================================//
 
-    /**
-     * @brief Enable/disable loopback mode for testing
-     * @param channel_id Channel identifier
-     * @param enable true to enable loopback, false to disable
-     * @return Error code indicating success or failure
-     */
-    HfPioErr EnableLoopback(uint8_t channel_id, bool enable) noexcept;
+  /**
+   * @brief Configure carrier modulation for IR protocols
+   * @param channel_id Channel identifier
+   * @param carrier_freq_hz Carrier frequency in Hz (0 to disable)
+   * @param duty_cycle Carrier duty cycle (0.0 to 1.0)
+   * @return Error code indicating success or failure
+   */
+  HfPioErr ConfigureCarrier(uint8_t channel_id, uint32_t carrier_freq_hz,
+                            float duty_cycle) noexcept;
 
-    /**
-     * @brief Get the maximum number of symbols that can be transmitted in one operation
-     * @return Maximum symbol count
-     */
-    size_t GetMaxSymbolCount() const noexcept;
+  /**
+   * @brief Enable/disable loopback mode for testing
+   * @param channel_id Channel identifier
+   * @param enable true to enable loopback, false to disable
+   * @return Error code indicating success or failure
+   */
+  HfPioErr EnableLoopback(uint8_t channel_id, bool enable) noexcept;
+
+  /**
+   * @brief Get the maximum number of symbols that can be transmitted in one operation
+   * @return Maximum symbol count
+   */
+  size_t GetMaxSymbolCount() const noexcept;
 
 private:
-    //==============================================//
-    // Internal Structures
-    //==============================================//
+  //==============================================//
+  // Internal Structures
+  //==============================================//
 
-    struct ChannelState {
-        bool configured;
-        bool busy;
-        PioChannelConfig config;
-        PioChannelStatus status;
-        
+  struct ChannelState {
+    bool configured;
+    bool busy;
+    PioChannelConfig config;
+    PioChannelStatus status;
+
 #ifdef HF_MCU_FAMILY_ESP32
-        rmt_channel_handle_t* tx_channel;
-        rmt_channel_handle_t* rx_channel;
-        rmt_encoder_handle_t* encoder;
-        rmt_encoder_handle_t* bytes_encoder;    // For byte-level protocols
-        rmt_encoder_handle_t* ws2812_encoder;   // For WS2812/NeoPixel
+    rmt_channel_handle_t *tx_channel;
+    rmt_channel_handle_t *rx_channel;
+    rmt_encoder_handle_t *encoder;
+    rmt_encoder_handle_t *bytes_encoder;  // For byte-level protocols
+    rmt_encoder_handle_t *ws2812_encoder; // For WS2812/NeoPixel
 #else
-        void* tx_channel;
-        void* rx_channel;
-        void* encoder;
-        void* bytes_encoder;
-        void* ws2812_encoder;
+    void *tx_channel;
+    void *rx_channel;
+    void *encoder;
+    void *bytes_encoder;
+    void *ws2812_encoder;
 #endif
-        
-        // Buffers
-        PioSymbol* rx_buffer;
-        size_t rx_buffer_size;
-        size_t rx_symbols_received;
-        
-        // Timing
-        uint64_t last_operation_time;
-        
-        ChannelState() noexcept
-            : configured(false), busy(false), config(), status()
-            , tx_channel(nullptr), rx_channel(nullptr), encoder(nullptr)
-            , bytes_encoder(nullptr), ws2812_encoder(nullptr)
-            , rx_buffer(nullptr), rx_buffer_size(0), rx_symbols_received(0)
-            , last_operation_time(0) {}
-    };
 
-    //==============================================//
-    // Member Variables
-    //==============================================//
+    // Buffers
+    PioSymbol *rx_buffer;
+    size_t rx_buffer_size;
+    size_t rx_symbols_received;
 
-    static constexpr uint8_t MAX_CHANNELS = 8;  // ESP32 RMT has up to 8 channels
-    static constexpr size_t MAX_SYMBOLS_PER_TRANSMISSION = 64;
-    static constexpr uint32_t DEFAULT_RESOLUTION_NS = 1000; // 1 microsecond
-    static constexpr uint32_t RMT_CLK_SRC_FREQ = 80000000; // 80 MHz APB clock
+    // Timing
+    uint64_t last_operation_time;
 
-    bool initialized_;
-    std::array<ChannelState, MAX_CHANNELS> channels_;
-    mutable std::mutex state_mutex_;
+    ChannelState() noexcept
+        : configured(false), busy(false), config(), status(), tx_channel(nullptr),
+          rx_channel(nullptr), encoder(nullptr), bytes_encoder(nullptr), ws2812_encoder(nullptr),
+          rx_buffer(nullptr), rx_buffer_size(0), rx_symbols_received(0), last_operation_time(0) {}
+  };
 
-    // Callbacks
-    PioTransmitCallback transmit_callback_;
-    PioReceiveCallback receive_callback_;
-    PioErrorCallback error_callback_;
-    void* callback_user_data_;
+  //==============================================//
+  // Member Variables
+  //==============================================//
 
-    //==============================================//
-    // Internal Helper Methods
-    //==============================================//
+  static constexpr uint8_t MAX_CHANNELS = 8; // ESP32 RMT has up to 8 channels
+  static constexpr size_t MAX_SYMBOLS_PER_TRANSMISSION = 64;
+  static constexpr uint32_t DEFAULT_RESOLUTION_NS = 1000; // 1 microsecond
+  static constexpr uint32_t RMT_CLK_SRC_FREQ = 80000000;  // 80 MHz APB clock
 
-    /**
-     * @brief Validate channel ID
-     */
-    bool IsValidChannelId(uint8_t channel_id) const noexcept;
+  bool initialized_;
+  std::array<ChannelState, MAX_CHANNELS> channels_;
+  mutable std::mutex state_mutex_;
 
-    /**
-     * @brief Convert PioSymbol array to RMT symbol format
-     */
+  // Callbacks
+  PioTransmitCallback transmit_callback_;
+  PioReceiveCallback receive_callback_;
+  PioErrorCallback error_callback_;
+  void *callback_user_data_;
+
+  //==============================================//
+  // Internal Helper Methods
+  //==============================================//
+
+  /**
+   * @brief Validate channel ID
+   */
+  bool IsValidChannelId(uint8_t channel_id) const noexcept;
+
+  /**
+   * @brief Convert PioSymbol array to RMT symbol format
+   */
 #ifdef HF_MCU_FAMILY_ESP32
-    HfPioErr ConvertToRmtSymbols(const PioSymbol* symbols, size_t symbol_count, 
-                                rmt_symbol_word_t* rmt_symbols, size_t& rmt_symbol_count) noexcept;
+  HfPioErr ConvertToRmtSymbols(const PioSymbol *symbols, size_t symbol_count,
+                               rmt_symbol_word_t *rmt_symbols, size_t &rmt_symbol_count) noexcept;
 
-    /**
-     * @brief Convert RMT symbols back to PioSymbol format
-     */
-    HfPioErr ConvertFromRmtSymbols(const rmt_symbol_word_t* rmt_symbols, size_t rmt_symbol_count,
-                                  PioSymbol* symbols, size_t& symbol_count) noexcept;
+  /**
+   * @brief Convert RMT symbols back to PioSymbol format
+   */
+  HfPioErr ConvertFromRmtSymbols(const rmt_symbol_word_t *rmt_symbols, size_t rmt_symbol_count,
+                                 PioSymbol *symbols, size_t &symbol_count) noexcept;
 
-    /**
-     * @brief Calculate RMT clock divider for desired resolution
-     */
-    uint32_t CalculateClockDivider(uint32_t resolution_ns) const noexcept;
+  /**
+   * @brief Calculate RMT clock divider for desired resolution
+   */
+  uint32_t CalculateClockDivider(uint32_t resolution_ns) const noexcept;
 
-    /**
-     * @brief Static callback for RMT transmission complete
-     */
-    static bool OnTransmitComplete(rmt_channel_handle_t* channel, const rmt_tx_done_event_data_t* edata, void* user_ctx);
+  /**
+   * @brief Static callback for RMT transmission complete
+   */
+  static bool OnTransmitComplete(rmt_channel_handle_t *channel,
+                                 const rmt_tx_done_event_data_t *edata, void *user_ctx);
 
-    /**
-     * @brief Static callback for RMT reception complete
-     */
-    static bool OnReceiveComplete(rmt_channel_handle_t* channel, const rmt_rx_done_event_data_t* edata, void* user_ctx);
+  /**
+   * @brief Static callback for RMT reception complete
+   */
+  static bool OnReceiveComplete(rmt_channel_handle_t *channel,
+                                const rmt_rx_done_event_data_t *edata, void *user_ctx);
 #endif
 
-    /**
-     * @brief Initialize a specific channel
-     */
-    HfPioErr InitializeChannel(uint8_t channel_id) noexcept;
+  /**
+   * @brief Initialize a specific channel
+   */
+  HfPioErr InitializeChannel(uint8_t channel_id) noexcept;
 
-    /**
-     * @brief Deinitialize a specific channel
-     */
-    HfPioErr DeinitializeChannel(uint8_t channel_id) noexcept;
+  /**
+   * @brief Deinitialize a specific channel
+   */
+  HfPioErr DeinitializeChannel(uint8_t channel_id) noexcept;
 
-    /**
-     * @brief Validate symbol array
-     */
-    HfPioErr ValidateSymbols(const PioSymbol* symbols, size_t symbol_count) const noexcept;
+  /**
+   * @brief Validate symbol array
+   */
+  HfPioErr ValidateSymbols(const PioSymbol *symbols, size_t symbol_count) const noexcept;
 
-    /**
-     * @brief Update channel status
-     */
-    void UpdateChannelStatus(uint8_t channel_id) noexcept;
+  /**
+   * @brief Update channel status
+   */
+  void UpdateChannelStatus(uint8_t channel_id) noexcept;
 
-    /**
-     * @brief Invoke error callback if set
-     */
-    void InvokeErrorCallback(uint8_t channel_id, HfPioErr error) noexcept;
+  /**
+   * @brief Invoke error callback if set
+   */
+  void InvokeErrorCallback(uint8_t channel_id, HfPioErr error) noexcept;
 };
 
 #endif // MCU_PIO_H

--- a/inc/mcu/McuPwm.h
+++ b/inc/mcu/McuPwm.h
@@ -1,11 +1,11 @@
 /**
  * @file McuPwm.h
  * @brief MCU-integrated PWM controller implementation for ESP32C6.
- * 
+ *
  * This header provides a PWM implementation for microcontrollers with
  * built-in PWM peripherals. On ESP32C6, this wraps the LEDC (LED Controller)
  * peripheral which provides high-resolution PWM generation.
- * 
+ *
  * Features:
  * - Up to 8 PWM channels using LEDC peripheral
  * - Configurable frequency and resolution per channel
@@ -26,11 +26,11 @@
 /**
  * @class McuPwm
  * @brief PWM implementation for microcontrollers with integrated PWM peripherals.
- * 
+ *
  * This class provides PWM generation using the microcontroller's built-in
  * PWM peripheral. On ESP32C6, it uses the LEDC (LED Controller) peripheral
  * which offers high-resolution PWM with hardware fade support.
- * 
+ *
  * ESP32C6 LEDC Features:
  * - 8 independent PWM channels
  * - 4 timer groups for different frequency domains
@@ -38,7 +38,7 @@
  * - Hardware fade functionality
  * - Interrupt support for period complete events
  * - Low power mode support
- * 
+ *
  * Key Design Features:
  * - Thread-safe channel management
  * - Automatic timer allocation and management
@@ -49,278 +49,281 @@
  */
 class McuPwm : public BasePwm {
 public:
-    //==============================================================================
-    // CONSTANTS
-    //==============================================================================
-    
-    static constexpr uint8_t MAX_CHANNELS = 8;     ///< Maximum PWM channels
-    static constexpr uint8_t MAX_TIMERS = 4;       ///< Maximum timer groups
-    static constexpr uint8_t MAX_RESOLUTION = 14;  ///< Maximum resolution bits
-    static constexpr uint32_t MIN_FREQUENCY = 1;   ///< Minimum frequency (Hz)
-    static constexpr uint32_t MAX_FREQUENCY = 40000000; ///< Maximum frequency (Hz)
-    
-    //==============================================================================
-    // CONSTRUCTOR AND DESTRUCTOR
-    //==============================================================================
-    
-    /**
-     * @brief Constructor for MCU PWM controller
-     * @param base_clock_hz Base clock frequency for timers (default: 80MHz)
-     */
-    explicit McuPwm(uint32_t base_clock_hz = 80000000) noexcept;
-    
-    /**
-     * @brief Destructor - ensures clean shutdown
-     */
-    virtual ~McuPwm() noexcept override;
-    
-    // Prevent copying and moving
-    McuPwm(const McuPwm&) = delete;
-    McuPwm& operator=(const McuPwm&) = delete;
-    McuPwm(McuPwm&&) = delete;
-    McuPwm& operator=(McuPwm&&) = delete;
-    
-    //==============================================================================
-    // LIFECYCLE (BasePwm Interface)
-    //==============================================================================
-    
-    HfPwmErr Initialize() noexcept override;
-    HfPwmErr Deinitialize() noexcept override;
-    bool IsInitialized() const noexcept override;
-    
-    //==============================================================================
-    // CHANNEL MANAGEMENT (BasePwm Interface)
-    //==============================================================================
-    
-    HfPwmErr ConfigureChannel(HfChannelId channel_id, const PwmChannelConfig& config) noexcept override;
-    HfPwmErr EnableChannel(HfChannelId channel_id) noexcept override;
-    HfPwmErr DisableChannel(HfChannelId channel_id) noexcept override;
-    bool IsChannelEnabled(HfChannelId channel_id) const noexcept override;
-    
-    //==============================================================================
-    // PWM CONTROL (BasePwm Interface)
-    //==============================================================================
-    
-    HfPwmErr SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept override;
-    HfPwmErr SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept override;
-    HfPwmErr SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept override;
-    HfPwmErr SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept override;
-    
-    //==============================================================================
-    // ADVANCED FEATURES (BasePwm Interface)
-    //==============================================================================
-    
-    HfPwmErr StartAll() noexcept override;
-    HfPwmErr StopAll() noexcept override;
-    HfPwmErr UpdateAll() noexcept override;
-    HfPwmErr SetComplementaryOutput(HfChannelId primary_channel, 
-                                  HfChannelId complementary_channel, 
+  //==============================================================================
+  // CONSTANTS
+  //==============================================================================
+
+  static constexpr uint8_t MAX_CHANNELS = 8;          ///< Maximum PWM channels
+  static constexpr uint8_t MAX_TIMERS = 4;            ///< Maximum timer groups
+  static constexpr uint8_t MAX_RESOLUTION = 14;       ///< Maximum resolution bits
+  static constexpr uint32_t MIN_FREQUENCY = 1;        ///< Minimum frequency (Hz)
+  static constexpr uint32_t MAX_FREQUENCY = 40000000; ///< Maximum frequency (Hz)
+
+  //==============================================================================
+  // CONSTRUCTOR AND DESTRUCTOR
+  //==============================================================================
+
+  /**
+   * @brief Constructor for MCU PWM controller
+   * @param base_clock_hz Base clock frequency for timers (default: 80MHz)
+   */
+  explicit McuPwm(uint32_t base_clock_hz = 80000000) noexcept;
+
+  /**
+   * @brief Destructor - ensures clean shutdown
+   */
+  virtual ~McuPwm() noexcept override;
+
+  // Prevent copying and moving
+  McuPwm(const McuPwm &) = delete;
+  McuPwm &operator=(const McuPwm &) = delete;
+  McuPwm(McuPwm &&) = delete;
+  McuPwm &operator=(McuPwm &&) = delete;
+
+  //==============================================================================
+  // LIFECYCLE (BasePwm Interface)
+  //==============================================================================
+
+  HfPwmErr Initialize() noexcept override;
+  HfPwmErr Deinitialize() noexcept override;
+  bool IsInitialized() const noexcept override;
+
+  //==============================================================================
+  // CHANNEL MANAGEMENT (BasePwm Interface)
+  //==============================================================================
+
+  HfPwmErr ConfigureChannel(HfChannelId channel_id,
+                            const PwmChannelConfig &config) noexcept override;
+  HfPwmErr EnableChannel(HfChannelId channel_id) noexcept override;
+  HfPwmErr DisableChannel(HfChannelId channel_id) noexcept override;
+  bool IsChannelEnabled(HfChannelId channel_id) const noexcept override;
+
+  //==============================================================================
+  // PWM CONTROL (BasePwm Interface)
+  //==============================================================================
+
+  HfPwmErr SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept override;
+  HfPwmErr SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept override;
+  HfPwmErr SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept override;
+  HfPwmErr SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept override;
+
+  //==============================================================================
+  // ADVANCED FEATURES (BasePwm Interface)
+  //==============================================================================
+
+  HfPwmErr StartAll() noexcept override;
+  HfPwmErr StopAll() noexcept override;
+  HfPwmErr UpdateAll() noexcept override;
+  HfPwmErr SetComplementaryOutput(HfChannelId primary_channel, HfChannelId complementary_channel,
                                   uint32_t deadtime_ns) noexcept override;
-    
-    //==============================================================================
-    // STATUS AND INFORMATION (BasePwm Interface)
-    //==============================================================================
-    
-    float GetDutyCycle(HfChannelId channel_id) const noexcept override;
-    HfFrequencyHz GetFrequency(HfChannelId channel_id) const noexcept override;
-    HfPwmErr GetChannelStatus(HfChannelId channel_id, PwmChannelStatus& status) const noexcept override;
-    HfPwmErr GetCapabilities(PwmCapabilities& capabilities) const noexcept override;
-    HfPwmErr GetLastError(HfChannelId channel_id) const noexcept override;
-    
-    //==============================================================================
-    // CALLBACKS (BasePwm Interface)
-    //==============================================================================
-    
-    void SetPeriodCallback(PwmPeriodCallback callback, void* user_data = nullptr) noexcept override;
-    void SetFaultCallback(PwmFaultCallback callback, void* user_data = nullptr) noexcept override;
-    
-    //==============================================================================
-    // ESP32C6-SPECIFIC FEATURES
-    //==============================================================================
-    
-    /**
-     * @brief Set hardware fade for smooth duty cycle transitions
-     * @param channel_id Channel identifier
-     * @param target_duty_cycle Target duty cycle (0.0 - 1.0)
-     * @param fade_time_ms Fade duration in milliseconds
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetHardwareFade(HfChannelId channel_id, float target_duty_cycle, uint32_t fade_time_ms) noexcept;
-    
-    /**
-     * @brief Stop hardware fade for a channel
-     * @param channel_id Channel identifier
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr StopHardwareFade(HfChannelId channel_id) noexcept;
-    
-    /**
-     * @brief Check if hardware fade is active on a channel
-     * @param channel_id Channel identifier
-     * @return true if fade is active, false otherwise
-     */
-    bool IsFadeActive(HfChannelId channel_id) const noexcept;
-    
-    /**
-     * @brief Set idle output level for a channel
-     * @param channel_id Channel identifier
-     * @param idle_level Idle level (0 or 1)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetIdleLevel(HfChannelId channel_id, uint8_t idle_level) noexcept;
-    
-    /**
-     * @brief Get current timer assignment for a channel
-     * @param channel_id Channel identifier
-     * @return Timer number (0-3), or -1 if channel not configured
-     */
-    int8_t GetTimerAssignment(HfChannelId channel_id) const noexcept;
-    
-    /**
-     * @brief Force a specific timer for a channel (advanced usage)
-     * @param channel_id Channel identifier
-     * @param timer_id Timer identifier (0-3)
-     * @return PWM_SUCCESS on success, error code on failure
-     * @note Use with caution - automatic timer allocation is usually better
-     */
-    HfPwmErr ForceTimerAssignment(HfChannelId channel_id, uint8_t timer_id) noexcept;
+
+  //==============================================================================
+  // STATUS AND INFORMATION (BasePwm Interface)
+  //==============================================================================
+
+  float GetDutyCycle(HfChannelId channel_id) const noexcept override;
+  HfFrequencyHz GetFrequency(HfChannelId channel_id) const noexcept override;
+  HfPwmErr GetChannelStatus(HfChannelId channel_id,
+                            PwmChannelStatus &status) const noexcept override;
+  HfPwmErr GetCapabilities(PwmCapabilities &capabilities) const noexcept override;
+  HfPwmErr GetLastError(HfChannelId channel_id) const noexcept override;
+
+  //==============================================================================
+  // CALLBACKS (BasePwm Interface)
+  //==============================================================================
+
+  void SetPeriodCallback(PwmPeriodCallback callback, void *user_data = nullptr) noexcept override;
+  void SetFaultCallback(PwmFaultCallback callback, void *user_data = nullptr) noexcept override;
+
+  //==============================================================================
+  // ESP32C6-SPECIFIC FEATURES
+  //==============================================================================
+
+  /**
+   * @brief Set hardware fade for smooth duty cycle transitions
+   * @param channel_id Channel identifier
+   * @param target_duty_cycle Target duty cycle (0.0 - 1.0)
+   * @param fade_time_ms Fade duration in milliseconds
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetHardwareFade(HfChannelId channel_id, float target_duty_cycle,
+                           uint32_t fade_time_ms) noexcept;
+
+  /**
+   * @brief Stop hardware fade for a channel
+   * @param channel_id Channel identifier
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr StopHardwareFade(HfChannelId channel_id) noexcept;
+
+  /**
+   * @brief Check if hardware fade is active on a channel
+   * @param channel_id Channel identifier
+   * @return true if fade is active, false otherwise
+   */
+  bool IsFadeActive(HfChannelId channel_id) const noexcept;
+
+  /**
+   * @brief Set idle output level for a channel
+   * @param channel_id Channel identifier
+   * @param idle_level Idle level (0 or 1)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetIdleLevel(HfChannelId channel_id, uint8_t idle_level) noexcept;
+
+  /**
+   * @brief Get current timer assignment for a channel
+   * @param channel_id Channel identifier
+   * @return Timer number (0-3), or -1 if channel not configured
+   */
+  int8_t GetTimerAssignment(HfChannelId channel_id) const noexcept;
+
+  /**
+   * @brief Force a specific timer for a channel (advanced usage)
+   * @param channel_id Channel identifier
+   * @param timer_id Timer identifier (0-3)
+   * @return PWM_SUCCESS on success, error code on failure
+   * @note Use with caution - automatic timer allocation is usually better
+   */
+  HfPwmErr ForceTimerAssignment(HfChannelId channel_id, uint8_t timer_id) noexcept;
 
 private:
-    //==============================================================================
-    // INTERNAL STRUCTURES
-    //==============================================================================
-    
-    /**
-     * @brief Internal channel state
-     */
-    struct ChannelState {
-        bool configured;                    ///< Channel is configured
-        bool enabled;                       ///< Channel is enabled
-        PwmChannelConfig config;            ///< Channel configuration
-        uint8_t assigned_timer;             ///< Assigned timer (0-3)
-        uint32_t raw_duty_value;            ///< Current raw duty value
-        HfPwmErr last_error;                ///< Last error for this channel
-        bool fade_active;                   ///< Hardware fade is active
-        
-        ChannelState() noexcept
-            : configured(false), enabled(false), assigned_timer(0xFF)
-            , raw_duty_value(0), last_error(HfPwmErr::PWM_SUCCESS), fade_active(false) {}
-    };
-    
-    /**
-     * @brief Internal timer state
-     */
-    struct TimerState {
-        bool in_use;                        ///< Timer is in use
-        uint32_t frequency_hz;              ///< Timer frequency
-        uint8_t resolution_bits;            ///< Timer resolution
-        uint8_t channel_count;              ///< Number of channels using this timer
-        
-        TimerState() noexcept
-            : in_use(false), frequency_hz(0), resolution_bits(0), channel_count(0) {}
-    };
-    
-    /**
-     * @brief Complementary output pair configuration
-     */
-    struct ComplementaryPair {
-        uint8_t primary_channel;            ///< Primary channel
-        uint8_t complementary_channel;      ///< Complementary channel
-        uint32_t deadtime_ns;              ///< Deadtime in nanoseconds
-        bool active;                        ///< Pair is active
-        
-        ComplementaryPair() noexcept
-            : primary_channel(0xFF), complementary_channel(0xFF), deadtime_ns(0), active(false) {}
-    };
-    
-    //==============================================================================
-    // INTERNAL METHODS
-    //==============================================================================
-    
-    /**
-     * @brief Validate channel ID
-     * @param channel_id Channel to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidChannelId(HfChannelId channel_id) const noexcept;
-    
-    /**
-     * @brief Find or allocate a timer for the given frequency and resolution
-     * @param frequency_hz Required frequency
-     * @param resolution_bits Required resolution
-     * @return Timer ID (0-3), or -1 if no timer available
-     */
-    int8_t FindOrAllocateTimer(uint32_t frequency_hz, uint8_t resolution_bits) noexcept;
-    
-    /**
-     * @brief Release a timer if no longer needed
-     * @param timer_id Timer to potentially release
-     */
-    void ReleaseTimerIfUnused(uint8_t timer_id) noexcept;
-    
-    /**
-     * @brief Configure platform timer
-     * @param timer_id Timer to configure
-     * @param frequency_hz Timer frequency
-     * @param resolution_bits Timer resolution
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr ConfigurePlatformTimer(uint8_t timer_id, uint32_t frequency_hz, uint8_t resolution_bits) noexcept;
-    
-    /**
-     * @brief Configure platform channel
-     * @param channel_id Channel to configure
-     * @param config Channel configuration
-     * @param timer_id Assigned timer
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr ConfigurePlatformChannel(HfChannelId channel_id, const PwmChannelConfig& config, uint8_t timer_id) noexcept;
-    
-    /**
-     * @brief Update platform duty cycle
-     * @param channel_id Channel to update
-     * @param raw_duty_value Raw duty value
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr UpdatePlatformDuty(HfChannelId channel_id, uint32_t raw_duty_value) noexcept;
-    
-    /**
-     * @brief Set error for a channel
-     * @param channel_id Channel identifier
-     * @param error Error to set
-     */
-    void SetChannelError(HfChannelId channel_id, HfPwmErr error) noexcept;
-    
-    /**
-     * @brief Platform-specific interrupt handler
-     * @param channel_id Channel that generated interrupt
-     */
-    static void IRAM_ATTR InterruptHandler(HfChannelId channel_id, void* user_data) noexcept;
-    
-    /**
-     * @brief Handle fade complete interrupt
-     * @param channel_id Channel that completed fade
-     */
-    void HandleFadeComplete(HfChannelId channel_id) noexcept;
-    
-    //==============================================================================
-    // MEMBER VARIABLES
-    //==============================================================================
-    
-    mutable std::mutex mutex_;                      ///< Thread safety mutex
-    bool initialized_;                              ///< Initialization state
-    uint32_t base_clock_hz_;                        ///< Base clock frequency
-    
-    std::array<ChannelState, MAX_CHANNELS> channels_;  ///< Channel states
-    std::array<TimerState, MAX_TIMERS> timers_;         ///< Timer states
-    std::array<ComplementaryPair, MAX_CHANNELS/2> complementary_pairs_; ///< Complementary pairs
-    
-    PwmPeriodCallback period_callback_;             ///< Period complete callback
-    void* period_callback_user_data_;               ///< Period callback user data
-    PwmFaultCallback fault_callback_;               ///< Fault callback
-    void* fault_callback_user_data_;                ///< Fault callback user data
-    
-    HfPwmErr last_global_error_;                    ///< Last global error
+  //==============================================================================
+  // INTERNAL STRUCTURES
+  //==============================================================================
+
+  /**
+   * @brief Internal channel state
+   */
+  struct ChannelState {
+    bool configured;         ///< Channel is configured
+    bool enabled;            ///< Channel is enabled
+    PwmChannelConfig config; ///< Channel configuration
+    uint8_t assigned_timer;  ///< Assigned timer (0-3)
+    uint32_t raw_duty_value; ///< Current raw duty value
+    HfPwmErr last_error;     ///< Last error for this channel
+    bool fade_active;        ///< Hardware fade is active
+
+    ChannelState() noexcept
+        : configured(false), enabled(false), assigned_timer(0xFF), raw_duty_value(0),
+          last_error(HfPwmErr::PWM_SUCCESS), fade_active(false) {}
+  };
+
+  /**
+   * @brief Internal timer state
+   */
+  struct TimerState {
+    bool in_use;             ///< Timer is in use
+    uint32_t frequency_hz;   ///< Timer frequency
+    uint8_t resolution_bits; ///< Timer resolution
+    uint8_t channel_count;   ///< Number of channels using this timer
+
+    TimerState() noexcept : in_use(false), frequency_hz(0), resolution_bits(0), channel_count(0) {}
+  };
+
+  /**
+   * @brief Complementary output pair configuration
+   */
+  struct ComplementaryPair {
+    uint8_t primary_channel;       ///< Primary channel
+    uint8_t complementary_channel; ///< Complementary channel
+    uint32_t deadtime_ns;          ///< Deadtime in nanoseconds
+    bool active;                   ///< Pair is active
+
+    ComplementaryPair() noexcept
+        : primary_channel(0xFF), complementary_channel(0xFF), deadtime_ns(0), active(false) {}
+  };
+
+  //==============================================================================
+  // INTERNAL METHODS
+  //==============================================================================
+
+  /**
+   * @brief Validate channel ID
+   * @param channel_id Channel to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidChannelId(HfChannelId channel_id) const noexcept;
+
+  /**
+   * @brief Find or allocate a timer for the given frequency and resolution
+   * @param frequency_hz Required frequency
+   * @param resolution_bits Required resolution
+   * @return Timer ID (0-3), or -1 if no timer available
+   */
+  int8_t FindOrAllocateTimer(uint32_t frequency_hz, uint8_t resolution_bits) noexcept;
+
+  /**
+   * @brief Release a timer if no longer needed
+   * @param timer_id Timer to potentially release
+   */
+  void ReleaseTimerIfUnused(uint8_t timer_id) noexcept;
+
+  /**
+   * @brief Configure platform timer
+   * @param timer_id Timer to configure
+   * @param frequency_hz Timer frequency
+   * @param resolution_bits Timer resolution
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr ConfigurePlatformTimer(uint8_t timer_id, uint32_t frequency_hz,
+                                  uint8_t resolution_bits) noexcept;
+
+  /**
+   * @brief Configure platform channel
+   * @param channel_id Channel to configure
+   * @param config Channel configuration
+   * @param timer_id Assigned timer
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr ConfigurePlatformChannel(HfChannelId channel_id, const PwmChannelConfig &config,
+                                    uint8_t timer_id) noexcept;
+
+  /**
+   * @brief Update platform duty cycle
+   * @param channel_id Channel to update
+   * @param raw_duty_value Raw duty value
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr UpdatePlatformDuty(HfChannelId channel_id, uint32_t raw_duty_value) noexcept;
+
+  /**
+   * @brief Set error for a channel
+   * @param channel_id Channel identifier
+   * @param error Error to set
+   */
+  void SetChannelError(HfChannelId channel_id, HfPwmErr error) noexcept;
+
+  /**
+   * @brief Platform-specific interrupt handler
+   * @param channel_id Channel that generated interrupt
+   */
+  static void IRAM_ATTR InterruptHandler(HfChannelId channel_id, void *user_data) noexcept;
+
+  /**
+   * @brief Handle fade complete interrupt
+   * @param channel_id Channel that completed fade
+   */
+  void HandleFadeComplete(HfChannelId channel_id) noexcept;
+
+  //==============================================================================
+  // MEMBER VARIABLES
+  //==============================================================================
+
+  mutable std::mutex mutex_; ///< Thread safety mutex
+  bool initialized_;         ///< Initialization state
+  uint32_t base_clock_hz_;   ///< Base clock frequency
+
+  std::array<ChannelState, MAX_CHANNELS> channels_;                     ///< Channel states
+  std::array<TimerState, MAX_TIMERS> timers_;                           ///< Timer states
+  std::array<ComplementaryPair, MAX_CHANNELS / 2> complementary_pairs_; ///< Complementary pairs
+
+  PwmPeriodCallback period_callback_; ///< Period complete callback
+  void *period_callback_user_data_;   ///< Period callback user data
+  PwmFaultCallback fault_callback_;   ///< Fault callback
+  void *fault_callback_user_data_;    ///< Fault callback user data
+
+  HfPwmErr last_global_error_; ///< Last global error
 };
 
 #endif // MCU_PWM_H

--- a/inc/mcu/McuSelect.h
+++ b/inc/mcu/McuSelect.h
@@ -1,7 +1,7 @@
 /**
  * @file McuSelect.h
  * @brief Centralized MCU platform selection and configuration header.
- * 
+ *
  * This header provides a SINGLE POINT OF CONTROL for MCU platform selection.
  * To select your target MCU, uncomment exactly ONE of the MCU selection defines below.
  * All platform-specific configuration is automatically handled based on your selection.
@@ -17,12 +17,12 @@
  * STEP 1: Select your target MCU by uncommenting exactly ONE define below
  * STEP 2: Comment out all other MCU defines (they should have // in front)
  * STEP 3: Build your project - all platform-specific code will be configured automatically
- * 
+ *
  * EXAMPLES:
  * - For ESP32-C6:  uncomment "#define HF_TARGET_MCU_ESP32C6"
  * - For ESP32:      uncomment "#define HF_TARGET_MCU_ESP32"
  * - For STM32F4:    uncomment "#define HF_TARGET_MCU_STM32F4"
- * 
+ *
  * NOTE: If you get "Multiple target MCUs" error, you have more than one uncommented.
  *       If you get "No target MCU" error, you need to uncomment exactly one.
  */
@@ -32,7 +32,7 @@
 //==============================================================================
 // Uncomment exactly ONE of the following lines to select your target MCU:
 
-#define HF_TARGET_MCU_ESP32C6       // ESP32-C6 RISC-V MCU (Primary target)
+#define HF_TARGET_MCU_ESP32C6 // ESP32-C6 RISC-V MCU (Primary target)
 // #define HF_TARGET_MCU_ESP32       // ESP32 Classic Xtensa MCU
 // #define HF_TARGET_MCU_STM32F4     // STM32F4 series ARM Cortex-M4
 // #define HF_TARGET_MCU_STM32H7     // STM32H7 series ARM Cortex-M7
@@ -44,87 +44,87 @@
 
 // ESP32-C6 Configuration
 #ifdef HF_TARGET_MCU_ESP32C6
-    #define HF_MCU_ESP32C6
-    #define HF_MCU_FAMILY_ESP32
-    #define HF_MCU_NAME "ESP32-C6"
-    #define HF_MCU_ARCHITECTURE "RISC-V RV32IMAC"
-    #define HF_MCU_VARIANT_C6
-    
-    // ESP32-C6 specific includes
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
-    
-    #include "driver/gpio.h"
-    #include "driver/adc.h"
-    #include "driver/i2c.h"
-    #include "driver/spi_master.h"
-    #include "driver/uart.h"
-    #include "driver/twai.h"
-    #include "driver/ledc.h"
-    #include "freertos/FreeRTOS.h"
-    #include "freertos/task.h"
-    #include "freertos/semphr.h"
-    
-    #ifdef __cplusplus
-    }
-    #endif
+#define HF_MCU_ESP32C6
+#define HF_MCU_FAMILY_ESP32
+#define HF_MCU_NAME "ESP32-C6"
+#define HF_MCU_ARCHITECTURE "RISC-V RV32IMAC"
+#define HF_MCU_VARIANT_C6
+
+// ESP32-C6 specific includes
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "driver/adc.h"
+#include "driver/gpio.h"
+#include "driver/i2c.h"
+#include "driver/ledc.h"
+#include "driver/spi_master.h"
+#include "driver/twai.h"
+#include "driver/uart.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 // ESP32 Classic Configuration
 #elif defined(HF_TARGET_MCU_ESP32)
-    #define HF_MCU_ESP32
-    #define HF_MCU_FAMILY_ESP32
-    #define HF_MCU_NAME "ESP32"
-    #define HF_MCU_ARCHITECTURE "Xtensa LX6"
-    #define HF_MCU_VARIANT_CLASSIC
-    
-    // ESP32 Classic specific includes
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
-    
-    #include "driver/gpio.h"
-    #include "driver/adc.h"
-    #include "driver/i2c.h"
-    #include "driver/spi_master.h"
-    #include "driver/uart.h"
-    #include "driver/can.h"  // Note: Different from ESP32-C6 TWAI
-    #include "driver/ledc.h"
-    #include "freertos/FreeRTOS.h"
-    #include "freertos/task.h"
-    #include "freertos/semphr.h"
-    
-    #ifdef __cplusplus
-    }
-    #endif
+#define HF_MCU_ESP32
+#define HF_MCU_FAMILY_ESP32
+#define HF_MCU_NAME "ESP32"
+#define HF_MCU_ARCHITECTURE "Xtensa LX6"
+#define HF_MCU_VARIANT_CLASSIC
+
+// ESP32 Classic specific includes
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "driver/adc.h"
+#include "driver/can.h" // Note: Different from ESP32-C6 TWAI
+#include "driver/gpio.h"
+#include "driver/i2c.h"
+#include "driver/ledc.h"
+#include "driver/spi_master.h"
+#include "driver/uart.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 // STM32F4 Configuration
 #elif defined(HF_TARGET_MCU_STM32F4)
-    #define HF_MCU_STM32F4
-    #define HF_MCU_FAMILY_STM32
-    #define HF_MCU_NAME "STM32F4"
-    #define HF_MCU_ARCHITECTURE "ARM Cortex-M4"
-    #error "STM32F4 platform not yet implemented - please implement STM32F4 support"
+#define HF_MCU_STM32F4
+#define HF_MCU_FAMILY_STM32
+#define HF_MCU_NAME "STM32F4"
+#define HF_MCU_ARCHITECTURE "ARM Cortex-M4"
+#error "STM32F4 platform not yet implemented - please implement STM32F4 support"
 
 // STM32H7 Configuration
 #elif defined(HF_TARGET_MCU_STM32H7)
-    #define HF_MCU_STM32H7
-    #define HF_MCU_FAMILY_STM32
-    #define HF_MCU_NAME "STM32H7"
-    #define HF_MCU_ARCHITECTURE "ARM Cortex-M7"
-    #error "STM32H7 platform not yet implemented - please implement STM32H7 support"
+#define HF_MCU_STM32H7
+#define HF_MCU_FAMILY_STM32
+#define HF_MCU_NAME "STM32H7"
+#define HF_MCU_ARCHITECTURE "ARM Cortex-M7"
+#error "STM32H7 platform not yet implemented - please implement STM32H7 support"
 
 // RP2040 Configuration
 #elif defined(HF_TARGET_MCU_RP2040)
-    #define HF_MCU_RP2040
-    #define HF_MCU_FAMILY_RP2040
-    #define HF_MCU_NAME "RP2040"
-    #define HF_MCU_ARCHITECTURE "ARM Cortex-M0+"
-    #error "RP2040 platform not yet implemented - please implement RP2040 support"
+#define HF_MCU_RP2040
+#define HF_MCU_FAMILY_RP2040
+#define HF_MCU_NAME "RP2040"
+#define HF_MCU_ARCHITECTURE "ARM Cortex-M0+"
+#error "RP2040 platform not yet implemented - please implement RP2040 support"
 
 // No MCU Selected - Error
 #else
-    #error "No MCU selected! Please uncomment exactly one HF_TARGET_MCU_* define in McuSelect.h"
+#error "No MCU selected! Please uncomment exactly one HF_TARGET_MCU_* define in McuSelect.h"
 #endif
 
 //==============================================================================
@@ -132,17 +132,22 @@
 //==============================================================================
 
 // Count the number of selected target MCUs
-#define HF_TARGET_COUNT (defined(HF_TARGET_MCU_ESP32C6) + defined(HF_TARGET_MCU_ESP32) + defined(HF_TARGET_MCU_STM32F4) + defined(HF_TARGET_MCU_STM32H7) + defined(HF_TARGET_MCU_RP2040))
+#define HF_TARGET_COUNT                                                                            \
+  (defined(HF_TARGET_MCU_ESP32C6) + defined(HF_TARGET_MCU_ESP32) +                                 \
+   defined(HF_TARGET_MCU_STM32F4) + defined(HF_TARGET_MCU_STM32H7) +                               \
+   defined(HF_TARGET_MCU_RP2040))
 
 #if HF_TARGET_COUNT > 1
-    #error "Multiple target MCUs are selected. Please uncomment exactly ONE HF_TARGET_MCU_* define in McuSelect.h"
+#error                                                                                             \
+    "Multiple target MCUs are selected. Please uncomment exactly ONE HF_TARGET_MCU_* define in McuSelect.h"
 #elif HF_TARGET_COUNT == 0
-    #error "No target MCU is selected. Please uncomment exactly ONE HF_TARGET_MCU_* define in McuSelect.h"
+#error                                                                                             \
+    "No target MCU is selected. Please uncomment exactly ONE HF_TARGET_MCU_* define in McuSelect.h"
 #endif
 
 // Validate that the selected MCU has a corresponding platform family defined
 #if !defined(HF_MCU_FAMILY_ESP32) && !defined(HF_MCU_FAMILY_STM32) && !defined(HF_MCU_FAMILY_RP2040)
-    #error "No MCU family is defined. This indicates an error in McuSelect.h configuration."
+#error "No MCU family is defined. This indicates an error in McuSelect.h configuration."
 #endif
 
 //==============================================================================
@@ -151,107 +156,107 @@
 
 // ESP32-C6 Specific Capabilities (Primary Target)
 #ifdef HF_MCU_ESP32C6
-    // GPIO capabilities
-    #define HF_MCU_HAS_GPIO                 1
-    #define HF_MCU_GPIO_MAX_PINS            31      // ESP32-C6 has 31 GPIO pins (0-30)
-    #define HF_MCU_GPIO_HAS_PULLUP          1
-    #define HF_MCU_GPIO_HAS_PULLDOWN        1
-    #define HF_MCU_GPIO_HAS_INTERRUPTS      1
-    
-    // ADC capabilities (ESP32-C6 specific)
-    #define HF_MCU_HAS_ADC                  1
-    #define HF_MCU_ADC_MAX_CHANNELS         7       // ESP32-C6 has 7 ADC channels
-    #define HF_MCU_ADC_MAX_RESOLUTION       12
-    #define HF_MCU_ADC_HAS_ATTENUATION      1
-    #define HF_MCU_ADC_NUM_UNITS            1       // ESP32-C6 has only ADC1
-    
-    // I2C capabilities
-    #define HF_MCU_HAS_I2C                  1
-    #define HF_MCU_I2C_MAX_PORTS            1       // ESP32-C6 has 1 I2C port
-    #define HF_MCU_I2C_MAX_FREQ_HZ          1000000
-    #define HF_MCU_I2C_HAS_SLAVE_MODE       1
-    
-    // SPI capabilities
-    #define HF_MCU_HAS_SPI                  1
-    #define HF_MCU_SPI_MAX_HOSTS            2       // ESP32-C6 has SPI2 and SPI3
-    #define HF_MCU_SPI_MAX_FREQ_HZ          60000000
-    #define HF_MCU_SPI_HAS_DMA              1
-    
-    // UART capabilities
-    #define HF_MCU_HAS_UART                 1
-    #define HF_MCU_UART_MAX_PORTS           2       // ESP32-C6 has UART0 and UART1
-    #define HF_MCU_UART_MAX_BAUDRATE        5000000
-    #define HF_MCU_UART_HAS_FLOW_CONTROL    1
-    
-    // CAN capabilities (TWAI)
-    #define HF_MCU_HAS_CAN                  1
-    #define HF_MCU_CAN_MAX_CONTROLLERS      1
-    #define HF_MCU_CAN_HAS_LISTEN_ONLY      1
-    #define HF_MCU_CAN_HAS_SELF_TEST        1
-    #define HF_MCU_CAN_PROTOCOL             "TWAI"
-    
-    // PWM capabilities (LEDC)
-    #define HF_MCU_HAS_PWM                  1
-    #define HF_MCU_PWM_MAX_CHANNELS         8       // ESP32-C6 has 8 LEDC channels
-    #define HF_MCU_PWM_MAX_FREQ_HZ          40000000
-    #define HF_MCU_PWM_MAX_RESOLUTION       14      // ESP32-C6 max is 14-bit
-    
-    // RMT capabilities (not PIO)
-    #define HF_MCU_HAS_PIO                  0
-    #define HF_MCU_HAS_RMT                  1
-    #define HF_MCU_RMT_MAX_CHANNELS         4       // ESP32-C6 has 4 RMT channels
+// GPIO capabilities
+#define HF_MCU_HAS_GPIO 1
+#define HF_MCU_GPIO_MAX_PINS 31 // ESP32-C6 has 31 GPIO pins (0-30)
+#define HF_MCU_GPIO_HAS_PULLUP 1
+#define HF_MCU_GPIO_HAS_PULLDOWN 1
+#define HF_MCU_GPIO_HAS_INTERRUPTS 1
+
+// ADC capabilities (ESP32-C6 specific)
+#define HF_MCU_HAS_ADC 1
+#define HF_MCU_ADC_MAX_CHANNELS 7 // ESP32-C6 has 7 ADC channels
+#define HF_MCU_ADC_MAX_RESOLUTION 12
+#define HF_MCU_ADC_HAS_ATTENUATION 1
+#define HF_MCU_ADC_NUM_UNITS 1 // ESP32-C6 has only ADC1
+
+// I2C capabilities
+#define HF_MCU_HAS_I2C 1
+#define HF_MCU_I2C_MAX_PORTS 1 // ESP32-C6 has 1 I2C port
+#define HF_MCU_I2C_MAX_FREQ_HZ 1000000
+#define HF_MCU_I2C_HAS_SLAVE_MODE 1
+
+// SPI capabilities
+#define HF_MCU_HAS_SPI 1
+#define HF_MCU_SPI_MAX_HOSTS 2 // ESP32-C6 has SPI2 and SPI3
+#define HF_MCU_SPI_MAX_FREQ_HZ 60000000
+#define HF_MCU_SPI_HAS_DMA 1
+
+// UART capabilities
+#define HF_MCU_HAS_UART 1
+#define HF_MCU_UART_MAX_PORTS 2 // ESP32-C6 has UART0 and UART1
+#define HF_MCU_UART_MAX_BAUDRATE 5000000
+#define HF_MCU_UART_HAS_FLOW_CONTROL 1
+
+// CAN capabilities (TWAI)
+#define HF_MCU_HAS_CAN 1
+#define HF_MCU_CAN_MAX_CONTROLLERS 1
+#define HF_MCU_CAN_HAS_LISTEN_ONLY 1
+#define HF_MCU_CAN_HAS_SELF_TEST 1
+#define HF_MCU_CAN_PROTOCOL "TWAI"
+
+// PWM capabilities (LEDC)
+#define HF_MCU_HAS_PWM 1
+#define HF_MCU_PWM_MAX_CHANNELS 8 // ESP32-C6 has 8 LEDC channels
+#define HF_MCU_PWM_MAX_FREQ_HZ 40000000
+#define HF_MCU_PWM_MAX_RESOLUTION 14 // ESP32-C6 max is 14-bit
+
+// RMT capabilities (not PIO)
+#define HF_MCU_HAS_PIO 0
+#define HF_MCU_HAS_RMT 1
+#define HF_MCU_RMT_MAX_CHANNELS 4 // ESP32-C6 has 4 RMT channels
 
 // ESP32 Classic Capabilities (Secondary Support)
 #elif defined(HF_MCU_ESP32)
-    // GPIO capabilities
-    #define HF_MCU_HAS_GPIO                 1
-    #define HF_MCU_GPIO_MAX_PINS            40      // ESP32 has 40 GPIO pins
-    #define HF_MCU_GPIO_HAS_PULLUP          1
-    #define HF_MCU_GPIO_HAS_PULLDOWN        1
-    #define HF_MCU_GPIO_HAS_INTERRUPTS      1
-    
-    // ADC capabilities
-    #define HF_MCU_HAS_ADC                  1
-    #define HF_MCU_ADC_MAX_CHANNELS         18
-    #define HF_MCU_ADC_MAX_RESOLUTION       12
-    #define HF_MCU_ADC_HAS_ATTENUATION      1
-    #define HF_MCU_ADC_NUM_UNITS            2
-    
-    // I2C capabilities
-    #define HF_MCU_HAS_I2C                  1
-    #define HF_MCU_I2C_MAX_PORTS            2
-    #define HF_MCU_I2C_MAX_FREQ_HZ          1000000
-    #define HF_MCU_I2C_HAS_SLAVE_MODE       1
-    
-    // SPI capabilities
-    #define HF_MCU_HAS_SPI                  1
-    #define HF_MCU_SPI_MAX_HOSTS            3
-    #define HF_MCU_SPI_MAX_FREQ_HZ          80000000
-    #define HF_MCU_SPI_HAS_DMA              1
-    
-    // UART capabilities
-    #define HF_MCU_HAS_UART                 1
-    #define HF_MCU_UART_MAX_PORTS           3
-    #define HF_MCU_UART_MAX_BAUDRATE        5000000
-    #define HF_MCU_UART_HAS_FLOW_CONTROL    1
-    
-    // CAN capabilities
-    #define HF_MCU_HAS_CAN                  1
-    #define HF_MCU_CAN_MAX_CONTROLLERS      1
-    #define HF_MCU_CAN_HAS_LISTEN_ONLY      1
-    #define HF_MCU_CAN_HAS_SELF_TEST        1
-    #define HF_MCU_CAN_PROTOCOL             "CAN"
-    
-    // PWM capabilities
-    #define HF_MCU_HAS_PWM                  1
-    #define HF_MCU_PWM_MAX_CHANNELS         16
-    #define HF_MCU_PWM_MAX_FREQ_HZ          40000000
-    #define HF_MCU_PWM_MAX_RESOLUTION       20
-    
-    // RMT capabilities
-    #define HF_MCU_HAS_PIO                  0
-    #define HF_MCU_HAS_RMT                  1
-    #define HF_MCU_RMT_MAX_CHANNELS         8
+// GPIO capabilities
+#define HF_MCU_HAS_GPIO 1
+#define HF_MCU_GPIO_MAX_PINS 40 // ESP32 has 40 GPIO pins
+#define HF_MCU_GPIO_HAS_PULLUP 1
+#define HF_MCU_GPIO_HAS_PULLDOWN 1
+#define HF_MCU_GPIO_HAS_INTERRUPTS 1
+
+// ADC capabilities
+#define HF_MCU_HAS_ADC 1
+#define HF_MCU_ADC_MAX_CHANNELS 18
+#define HF_MCU_ADC_MAX_RESOLUTION 12
+#define HF_MCU_ADC_HAS_ATTENUATION 1
+#define HF_MCU_ADC_NUM_UNITS 2
+
+// I2C capabilities
+#define HF_MCU_HAS_I2C 1
+#define HF_MCU_I2C_MAX_PORTS 2
+#define HF_MCU_I2C_MAX_FREQ_HZ 1000000
+#define HF_MCU_I2C_HAS_SLAVE_MODE 1
+
+// SPI capabilities
+#define HF_MCU_HAS_SPI 1
+#define HF_MCU_SPI_MAX_HOSTS 3
+#define HF_MCU_SPI_MAX_FREQ_HZ 80000000
+#define HF_MCU_SPI_HAS_DMA 1
+
+// UART capabilities
+#define HF_MCU_HAS_UART 1
+#define HF_MCU_UART_MAX_PORTS 3
+#define HF_MCU_UART_MAX_BAUDRATE 5000000
+#define HF_MCU_UART_HAS_FLOW_CONTROL 1
+
+// CAN capabilities
+#define HF_MCU_HAS_CAN 1
+#define HF_MCU_CAN_MAX_CONTROLLERS 1
+#define HF_MCU_CAN_HAS_LISTEN_ONLY 1
+#define HF_MCU_CAN_HAS_SELF_TEST 1
+#define HF_MCU_CAN_PROTOCOL "CAN"
+
+// PWM capabilities
+#define HF_MCU_HAS_PWM 1
+#define HF_MCU_PWM_MAX_CHANNELS 16
+#define HF_MCU_PWM_MAX_FREQ_HZ 40000000
+#define HF_MCU_PWM_MAX_RESOLUTION 20
+
+// RMT capabilities
+#define HF_MCU_HAS_PIO 0
+#define HF_MCU_HAS_RMT 1
+#define HF_MCU_RMT_MAX_CHANNELS 8
 
 #endif
 
@@ -261,75 +266,75 @@
 
 // ESP32-C6 Type Mappings
 #ifdef HF_MCU_ESP32C6
-    // GPIO type mappings
-    #define HF_MCU_GPIO_NUM_TYPE            gpio_num_t
-    #define HF_MCU_GPIO_MODE_TYPE           gpio_mode_t
-    #define HF_MCU_GPIO_PULL_TYPE           gpio_pull_mode_t
-    #define HF_MCU_GPIO_INTR_TYPE           gpio_int_type_t
-    #define HF_MCU_GPIO_INVALID             GPIO_NUM_NC
-    
-    // ADC type mappings
-    #define HF_MCU_ADC_CHANNEL_TYPE         adc_channel_t
-    #define HF_MCU_ADC_UNIT_TYPE            adc_unit_t
-    #define HF_MCU_ADC_ATTEN_TYPE           adc_atten_t
-    #define HF_MCU_ADC_BITS_TYPE            adc_bits_width_t
-    
-    // I2C type mappings
-    #define HF_MCU_I2C_PORT_TYPE            i2c_port_t
-    #define HF_MCU_I2C_MODE_TYPE            i2c_mode_t
-    
-    // SPI type mappings
-    #define HF_MCU_SPI_HOST_TYPE            spi_host_device_t
-    
-    // UART type mappings
-    #define HF_MCU_UART_PORT_TYPE           uart_port_t
-    
-    // CAN type mappings (TWAI for ESP32-C6)
-    #define HF_MCU_CAN_MODE_TYPE            twai_mode_t
-    #define HF_MCU_CAN_TIMING_TYPE          twai_timing_config_t
-    #define HF_MCU_CAN_FILTER_TYPE          twai_filter_config_t
-    #define HF_MCU_CAN_MSG_TYPE             twai_message_t
-    
-    // PWM type mappings
-    #define HF_MCU_PWM_CHANNEL_TYPE         ledc_channel_t
-    #define HF_MCU_PWM_TIMER_TYPE           ledc_timer_t
-    #define HF_MCU_PWM_MODE_TYPE            ledc_mode_t
+// GPIO type mappings
+#define HF_MCU_GPIO_NUM_TYPE gpio_num_t
+#define HF_MCU_GPIO_MODE_TYPE gpio_mode_t
+#define HF_MCU_GPIO_PULL_TYPE gpio_pull_mode_t
+#define HF_MCU_GPIO_INTR_TYPE gpio_int_type_t
+#define HF_MCU_GPIO_INVALID GPIO_NUM_NC
+
+// ADC type mappings
+#define HF_MCU_ADC_CHANNEL_TYPE adc_channel_t
+#define HF_MCU_ADC_UNIT_TYPE adc_unit_t
+#define HF_MCU_ADC_ATTEN_TYPE adc_atten_t
+#define HF_MCU_ADC_BITS_TYPE adc_bits_width_t
+
+// I2C type mappings
+#define HF_MCU_I2C_PORT_TYPE i2c_port_t
+#define HF_MCU_I2C_MODE_TYPE i2c_mode_t
+
+// SPI type mappings
+#define HF_MCU_SPI_HOST_TYPE spi_host_device_t
+
+// UART type mappings
+#define HF_MCU_UART_PORT_TYPE uart_port_t
+
+// CAN type mappings (TWAI for ESP32-C6)
+#define HF_MCU_CAN_MODE_TYPE twai_mode_t
+#define HF_MCU_CAN_TIMING_TYPE twai_timing_config_t
+#define HF_MCU_CAN_FILTER_TYPE twai_filter_config_t
+#define HF_MCU_CAN_MSG_TYPE twai_message_t
+
+// PWM type mappings
+#define HF_MCU_PWM_CHANNEL_TYPE ledc_channel_t
+#define HF_MCU_PWM_TIMER_TYPE ledc_timer_t
+#define HF_MCU_PWM_MODE_TYPE ledc_mode_t
 
 // ESP32 Classic Type Mappings
 #elif defined(HF_MCU_ESP32)
-    // GPIO type mappings
-    #define HF_MCU_GPIO_NUM_TYPE            gpio_num_t
-    #define HF_MCU_GPIO_MODE_TYPE           gpio_mode_t
-    #define HF_MCU_GPIO_PULL_TYPE           gpio_pull_mode_t
-    #define HF_MCU_GPIO_INTR_TYPE           gpio_int_type_t
-    #define HF_MCU_GPIO_INVALID             GPIO_NUM_NC
-    
-    // ADC type mappings
-    #define HF_MCU_ADC_CHANNEL_TYPE         adc_channel_t
-    #define HF_MCU_ADC_UNIT_TYPE            adc_unit_t
-    #define HF_MCU_ADC_ATTEN_TYPE           adc_atten_t
-    #define HF_MCU_ADC_BITS_TYPE            adc_bits_width_t
-    
-    // I2C type mappings
-    #define HF_MCU_I2C_PORT_TYPE            i2c_port_t
-    #define HF_MCU_I2C_MODE_TYPE            i2c_mode_t
-    
-    // SPI type mappings
-    #define HF_MCU_SPI_HOST_TYPE            spi_host_device_t
-    
-    // UART type mappings
-    #define HF_MCU_UART_PORT_TYPE           uart_port_t
-    
-    // CAN type mappings (Classic CAN for ESP32)
-    #define HF_MCU_CAN_MODE_TYPE            can_mode_t
-    #define HF_MCU_CAN_TIMING_TYPE          can_timing_config_t
-    #define HF_MCU_CAN_FILTER_TYPE          can_filter_config_t
-    #define HF_MCU_CAN_MSG_TYPE             can_message_t
-    
-    // PWM type mappings
-    #define HF_MCU_PWM_CHANNEL_TYPE         ledc_channel_t
-    #define HF_MCU_PWM_TIMER_TYPE           ledc_timer_t
-    #define HF_MCU_PWM_MODE_TYPE            ledc_mode_t
+// GPIO type mappings
+#define HF_MCU_GPIO_NUM_TYPE gpio_num_t
+#define HF_MCU_GPIO_MODE_TYPE gpio_mode_t
+#define HF_MCU_GPIO_PULL_TYPE gpio_pull_mode_t
+#define HF_MCU_GPIO_INTR_TYPE gpio_int_type_t
+#define HF_MCU_GPIO_INVALID GPIO_NUM_NC
+
+// ADC type mappings
+#define HF_MCU_ADC_CHANNEL_TYPE adc_channel_t
+#define HF_MCU_ADC_UNIT_TYPE adc_unit_t
+#define HF_MCU_ADC_ATTEN_TYPE adc_atten_t
+#define HF_MCU_ADC_BITS_TYPE adc_bits_width_t
+
+// I2C type mappings
+#define HF_MCU_I2C_PORT_TYPE i2c_port_t
+#define HF_MCU_I2C_MODE_TYPE i2c_mode_t
+
+// SPI type mappings
+#define HF_MCU_SPI_HOST_TYPE spi_host_device_t
+
+// UART type mappings
+#define HF_MCU_UART_PORT_TYPE uart_port_t
+
+// CAN type mappings (Classic CAN for ESP32)
+#define HF_MCU_CAN_MODE_TYPE can_mode_t
+#define HF_MCU_CAN_TIMING_TYPE can_timing_config_t
+#define HF_MCU_CAN_FILTER_TYPE can_filter_config_t
+#define HF_MCU_CAN_MSG_TYPE can_message_t
+
+// PWM type mappings
+#define HF_MCU_PWM_CHANNEL_TYPE ledc_channel_t
+#define HF_MCU_PWM_TIMER_TYPE ledc_timer_t
+#define HF_MCU_PWM_MODE_TYPE ledc_mode_t
 #endif
 
 //==============================================================================
@@ -338,53 +343,53 @@
 
 // ESP32-C6 Configuration Constants
 #ifdef HF_MCU_ESP32C6
-    // Default timeout values
-    #define HF_MCU_DEFAULT_TIMEOUT_MS       1000
-    #define HF_MCU_I2C_TIMEOUT_MS           500     // Reduced for faster response
-    #define HF_MCU_SPI_TIMEOUT_MS           1000
-    #define HF_MCU_UART_TIMEOUT_MS          1000
-    #define HF_MCU_CAN_TIMEOUT_MS           500
-    
-    // Buffer sizes (optimized for ESP32-C6)
-    #define HF_MCU_UART_RX_BUFFER_SIZE      512     // Increased for motor control
-    #define HF_MCU_UART_TX_BUFFER_SIZE      256
-    #define HF_MCU_I2C_BUFFER_SIZE          64      // Reduced for ESP32-C6
-    #define HF_MCU_SPI_BUFFER_SIZE          256
-    #define HF_MCU_CAN_RX_QUEUE_SIZE        16      // Optimized for ESP32-C6
-    #define HF_MCU_CAN_TX_QUEUE_SIZE        16
-    
-    // Stack sizes for tasks (optimized for RISC-V)
-    #define HF_MCU_TASK_STACK_SIZE          3072    // Reduced for RISC-V efficiency
-    #define HF_MCU_TASK_PRIORITY            5
-    
-    // ADC specific constants
-    #define HF_MCU_ADC_DEFAULT_VREF         1100    // mV, ESP32-C6 default
-    #define HF_MCU_ADC_MAX_VOLTAGE          3300    // mV, with 11dB attenuation
+// Default timeout values
+#define HF_MCU_DEFAULT_TIMEOUT_MS 1000
+#define HF_MCU_I2C_TIMEOUT_MS 500 // Reduced for faster response
+#define HF_MCU_SPI_TIMEOUT_MS 1000
+#define HF_MCU_UART_TIMEOUT_MS 1000
+#define HF_MCU_CAN_TIMEOUT_MS 500
+
+// Buffer sizes (optimized for ESP32-C6)
+#define HF_MCU_UART_RX_BUFFER_SIZE 512 // Increased for motor control
+#define HF_MCU_UART_TX_BUFFER_SIZE 256
+#define HF_MCU_I2C_BUFFER_SIZE 64 // Reduced for ESP32-C6
+#define HF_MCU_SPI_BUFFER_SIZE 256
+#define HF_MCU_CAN_RX_QUEUE_SIZE 16 // Optimized for ESP32-C6
+#define HF_MCU_CAN_TX_QUEUE_SIZE 16
+
+// Stack sizes for tasks (optimized for RISC-V)
+#define HF_MCU_TASK_STACK_SIZE 3072 // Reduced for RISC-V efficiency
+#define HF_MCU_TASK_PRIORITY 5
+
+// ADC specific constants
+#define HF_MCU_ADC_DEFAULT_VREF 1100 // mV, ESP32-C6 default
+#define HF_MCU_ADC_MAX_VOLTAGE 3300  // mV, with 11dB attenuation
 
 // ESP32 Classic Configuration Constants
 #elif defined(HF_MCU_ESP32)
-    // Default timeout values
-    #define HF_MCU_DEFAULT_TIMEOUT_MS       1000
-    #define HF_MCU_I2C_TIMEOUT_MS           1000
-    #define HF_MCU_SPI_TIMEOUT_MS           1000
-    #define HF_MCU_UART_TIMEOUT_MS          1000
-    #define HF_MCU_CAN_TIMEOUT_MS           1000
-    
-    // Buffer sizes
-    #define HF_MCU_UART_RX_BUFFER_SIZE      256
-    #define HF_MCU_UART_TX_BUFFER_SIZE      256
-    #define HF_MCU_I2C_BUFFER_SIZE          128
-    #define HF_MCU_SPI_BUFFER_SIZE          256
-    #define HF_MCU_CAN_RX_QUEUE_SIZE        32
-    #define HF_MCU_CAN_TX_QUEUE_SIZE        32
-    
-    // Stack sizes for tasks
-    #define HF_MCU_TASK_STACK_SIZE          4096
-    #define HF_MCU_TASK_PRIORITY            5
-    
-    // ADC specific constants
-    #define HF_MCU_ADC_DEFAULT_VREF         1100    // mV
-    #define HF_MCU_ADC_MAX_VOLTAGE          3900    // mV, with 11dB attenuation
+// Default timeout values
+#define HF_MCU_DEFAULT_TIMEOUT_MS 1000
+#define HF_MCU_I2C_TIMEOUT_MS 1000
+#define HF_MCU_SPI_TIMEOUT_MS 1000
+#define HF_MCU_UART_TIMEOUT_MS 1000
+#define HF_MCU_CAN_TIMEOUT_MS 1000
+
+// Buffer sizes
+#define HF_MCU_UART_RX_BUFFER_SIZE 256
+#define HF_MCU_UART_TX_BUFFER_SIZE 256
+#define HF_MCU_I2C_BUFFER_SIZE 128
+#define HF_MCU_SPI_BUFFER_SIZE 256
+#define HF_MCU_CAN_RX_QUEUE_SIZE 32
+#define HF_MCU_CAN_TX_QUEUE_SIZE 32
+
+// Stack sizes for tasks
+#define HF_MCU_TASK_STACK_SIZE 4096
+#define HF_MCU_TASK_PRIORITY 5
+
+// ADC specific constants
+#define HF_MCU_ADC_DEFAULT_VREF 1100 // mV
+#define HF_MCU_ADC_MAX_VOLTAGE 3900  // mV, with 11dB attenuation
 #endif
 
 //==============================================================================
@@ -392,9 +397,9 @@
 //==============================================================================
 /*
  * In your .cpp files, use the family-level defines for platform-specific code:
- * 
+ *
  * #include "McuSelect.h"   // Always include this first
- * 
+ *
  * #ifdef HF_MCU_FAMILY_ESP32
  *     // ESP32-specific code (works for both ESP32 and ESP32-C6)
  *     #include "esp_log.h"

--- a/inc/mcu/McuSpi.h
+++ b/inc/mcu/McuSpi.h
@@ -39,217 +39,216 @@
  */
 class McuSpi : public BaseSpi {
 public:
-    /**
-     * @brief Constructor with configuration.
-     * @param config SPI bus configuration parameters
-     */
-    explicit McuSpi(const SpiBusConfig& config) noexcept;
+  /**
+   * @brief Constructor with configuration.
+   * @param config SPI bus configuration parameters
+   */
+  explicit McuSpi(const SpiBusConfig &config) noexcept;
 
-    /**
-     * @brief Destructor - ensures proper cleanup.
-     */
-    ~McuSpi() noexcept override;
+  /**
+   * @brief Destructor - ensures proper cleanup.
+   */
+  ~McuSpi() noexcept override;
 
-    //==============================================//
-    // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
-    //==============================================//
+  //==============================================//
+  // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
+  //==============================================//
 
-    /**
-     * @brief Initialize the SPI bus.
-     * @return true if successful, false otherwise
-     */
-    bool Initialize() noexcept override;
+  /**
+   * @brief Initialize the SPI bus.
+   * @return true if successful, false otherwise
+   */
+  bool Initialize() noexcept override;
 
-    /**
-     * @brief Deinitialize the SPI bus.
-     * @return true if successful, false otherwise
-     */
-    bool Deinitialize() noexcept override;
+  /**
+   * @brief Deinitialize the SPI bus.
+   * @return true if successful, false otherwise
+   */
+  bool Deinitialize() noexcept override;
 
-    /**
-     * @brief Perform a full-duplex SPI transfer.
-     * @param tx_data Transmit data buffer (can be nullptr for read-only)
-     * @param rx_data Receive data buffer (can be nullptr for write-only)
-     * @param length Number of bytes to transfer
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfSpiErr result code
-     */
-    HfSpiErr Transfer(const uint8_t* tx_data, uint8_t* rx_data,
-                      uint16_t length, uint32_t timeout_ms = 0) noexcept override;
+  /**
+   * @brief Perform a full-duplex SPI transfer.
+   * @param tx_data Transmit data buffer (can be nullptr for read-only)
+   * @param rx_data Receive data buffer (can be nullptr for write-only)
+   * @param length Number of bytes to transfer
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfSpiErr result code
+   */
+  HfSpiErr Transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                    uint32_t timeout_ms = 0) noexcept override;
 
-    /**
-     * @brief Assert/deassert the chip select signal.
-     * @param active True to assert CS, false to deassert
-     * @return HfSpiErr result code
-     */
-    HfSpiErr SetChipSelect(bool active) noexcept override;
+  /**
+   * @brief Assert/deassert the chip select signal.
+   * @param active True to assert CS, false to deassert
+   * @return HfSpiErr result code
+   */
+  HfSpiErr SetChipSelect(bool active) noexcept override;
 
-    //==============================================//
-    // ENHANCED METHODS                             //
-    //==============================================//
+  //==============================================//
+  // ENHANCED METHODS                             //
+  //==============================================//
 
-    /**
-     * @brief Check if the SPI bus is busy.
-     * @return true if busy, false if available
-     */
-    bool IsBusy() noexcept;
+  /**
+   * @brief Check if the SPI bus is busy.
+   * @return true if busy, false if available
+   */
+  bool IsBusy() noexcept;
 
-    /**
-     * @brief Get the last error that occurred.
-     * @return Last error code
-     */
-    HfSpiErr GetLastError() const noexcept {
-        return last_error_;
-    }
+  /**
+   * @brief Get the last error that occurred.
+   * @return Last error code
+   */
+  HfSpiErr GetLastError() const noexcept {
+    return last_error_;
+  }
 
-    /**
-     * @brief Set a new clock speed (requires reinitialization).
-     * @param clock_speed_hz New clock speed in Hz
-     * @return true if successful, false otherwise
-     */
-    bool SetClockSpeed(uint32_t clock_speed_hz) noexcept;
+  /**
+   * @brief Set a new clock speed (requires reinitialization).
+   * @param clock_speed_hz New clock speed in Hz
+   * @return true if successful, false otherwise
+   */
+  bool SetClockSpeed(uint32_t clock_speed_hz) noexcept;
 
-    /**
-     * @brief Set a new SPI mode (requires reinitialization).
-     * @param mode New SPI mode (0-3)
-     * @return true if successful, false otherwise
-     */
-    bool SetMode(uint8_t mode) noexcept;
+  /**
+   * @brief Set a new SPI mode (requires reinitialization).
+   * @param mode New SPI mode (0-3)
+   * @return true if successful, false otherwise
+   */
+  bool SetMode(uint8_t mode) noexcept;
 
-    /**
-     * @brief Enable or disable DMA for transfers (if supported).
-     * @param enable True to enable DMA, false to disable
-     * @return true if successful, false otherwise
-     */
-    bool SetDmaEnabled(bool enable) noexcept;
+  /**
+   * @brief Enable or disable DMA for transfers (if supported).
+   * @param enable True to enable DMA, false to disable
+   * @return true if successful, false otherwise
+   */
+  bool SetDmaEnabled(bool enable) noexcept;
 
-    /**
-     * @brief Get detailed bus status information.
-     * @return Platform-specific status information
-     */
-    uint32_t GetBusStatus() noexcept;
+  /**
+   * @brief Get detailed bus status information.
+   * @return Platform-specific status information
+   */
+  uint32_t GetBusStatus() noexcept;
 
-    /**
-     * @brief Perform multiple transfers with CS held active.
-     * @param transfers Array of transfer descriptors
-     * @param num_transfers Number of transfers
-     * @return HfSpiErr result code
-     */
-    struct SpiTransfer {
-        const uint8_t* tx_data;     ///< Transmit data (can be nullptr)
-        uint8_t* rx_data;           ///< Receive data (can be nullptr)
-        uint16_t length;            ///< Number of bytes
-        uint32_t timeout_ms;        ///< Transfer timeout (0 = use default)
-    };
-    
-    HfSpiErr TransferSequence(const SpiTransfer* transfers, uint8_t num_transfers) noexcept;
+  /**
+   * @brief Perform multiple transfers with CS held active.
+   * @param transfers Array of transfer descriptors
+   * @param num_transfers Number of transfers
+   * @return HfSpiErr result code
+   */
+  struct SpiTransfer {
+    const uint8_t *tx_data; ///< Transmit data (can be nullptr)
+    uint8_t *rx_data;       ///< Receive data (can be nullptr)
+    uint16_t length;        ///< Number of bytes
+    uint32_t timeout_ms;    ///< Transfer timeout (0 = use default)
+  };
 
-    /**
-     * @brief Perform a transfer with custom timing.
-     * @param tx_data Transmit data buffer
-     * @param rx_data Receive data buffer
-     * @param length Number of bytes to transfer
-     * @param cs_hold_time_us Time to hold CS active after transfer (microseconds)
-     * @param timeout_ms Timeout in milliseconds
-     * @return HfSpiErr result code
-     */
-    HfSpiErr TransferWithTiming(const uint8_t* tx_data, uint8_t* rx_data,
-                                uint16_t length, uint32_t cs_hold_time_us,
-                                uint32_t timeout_ms = 0) noexcept;
+  HfSpiErr TransferSequence(const SpiTransfer *transfers, uint8_t num_transfers) noexcept;
 
-    /**
-     * @brief Write data to a specific register address.
-     * @param reg_addr Register address
-     * @param data Data to write
-     * @param length Number of bytes to write
-     * @return HfSpiErr result code
-     */
-    HfSpiErr WriteRegister(uint8_t reg_addr, const uint8_t* data, uint16_t length) noexcept;
+  /**
+   * @brief Perform a transfer with custom timing.
+   * @param tx_data Transmit data buffer
+   * @param rx_data Receive data buffer
+   * @param length Number of bytes to transfer
+   * @param cs_hold_time_us Time to hold CS active after transfer (microseconds)
+   * @param timeout_ms Timeout in milliseconds
+   * @return HfSpiErr result code
+   */
+  HfSpiErr TransferWithTiming(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                              uint32_t cs_hold_time_us, uint32_t timeout_ms = 0) noexcept;
 
-    /**
-     * @brief Read data from a specific register address.
-     * @param reg_addr Register address
-     * @param data Buffer to store read data
-     * @param length Number of bytes to read
-     * @return HfSpiErr result code
-     */
-    HfSpiErr ReadRegister(uint8_t reg_addr, uint8_t* data, uint16_t length) noexcept;
+  /**
+   * @brief Write data to a specific register address.
+   * @param reg_addr Register address
+   * @param data Data to write
+   * @param length Number of bytes to write
+   * @return HfSpiErr result code
+   */
+  HfSpiErr WriteRegister(uint8_t reg_addr, const uint8_t *data, uint16_t length) noexcept;
+
+  /**
+   * @brief Read data from a specific register address.
+   * @param reg_addr Register address
+   * @param data Buffer to store read data
+   * @param length Number of bytes to read
+   * @return HfSpiErr result code
+   */
+  HfSpiErr ReadRegister(uint8_t reg_addr, uint8_t *data, uint16_t length) noexcept;
 
 private:
-    //==============================================//
-    // PRIVATE METHODS                              //
-    //==============================================//
+  //==============================================//
+  // PRIVATE METHODS                              //
+  //==============================================//
 
-    /**
-     * @brief Convert platform-specific error to HfSpiErr.
-     * @param platform_error Platform-specific error code
-     * @return Corresponding HfSpiErr
-     */
-    HfSpiErr ConvertPlatformError(int32_t platform_error) noexcept;
+  /**
+   * @brief Convert platform-specific error to HfSpiErr.
+   * @param platform_error Platform-specific error code
+   * @return Corresponding HfSpiErr
+   */
+  HfSpiErr ConvertPlatformError(int32_t platform_error) noexcept;
 
-    /**
-     * @brief Validate SPI mode.
-     * @param mode SPI mode to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidMode(uint8_t mode) const noexcept {
-        return mode <= 3;
-    }
+  /**
+   * @brief Validate SPI mode.
+   * @param mode SPI mode to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidMode(uint8_t mode) const noexcept {
+    return mode <= 3;
+  }
 
-    /**
-     * @brief Validate clock speed.
-     * @param clock_speed_hz Clock speed to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidClockSpeed(uint32_t clock_speed_hz) const noexcept {
-        // Typical range: 1kHz to 80MHz (platform dependent)
-        return (clock_speed_hz >= 1000 && clock_speed_hz <= 80000000);
-    }
+  /**
+   * @brief Validate clock speed.
+   * @param clock_speed_hz Clock speed to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidClockSpeed(uint32_t clock_speed_hz) const noexcept {
+    // Typical range: 1kHz to 80MHz (platform dependent)
+    return (clock_speed_hz >= 1000 && clock_speed_hz <= 80000000);
+  }
 
-    /**
-     * @brief Get timeout value (use default if timeout_ms is 0).
-     * @param timeout_ms Requested timeout
-     * @return Actual timeout to use
-     */
-    uint32_t GetTimeoutMs(uint32_t timeout_ms) const noexcept {
-        return (timeout_ms == 0) ? config_.timeout_ms : timeout_ms;
-    }
+  /**
+   * @brief Get timeout value (use default if timeout_ms is 0).
+   * @param timeout_ms Requested timeout
+   * @return Actual timeout to use
+   */
+  uint32_t GetTimeoutMs(uint32_t timeout_ms) const noexcept {
+    return (timeout_ms == 0) ? config_.timeout_ms : timeout_ms;
+  }
 
-    /**
-     * @brief Perform platform-specific initialization.
-     * @return true if successful, false otherwise
-     */
-    bool PlatformInitialize() noexcept;
+  /**
+   * @brief Perform platform-specific initialization.
+   * @return true if successful, false otherwise
+   */
+  bool PlatformInitialize() noexcept;
 
-    /**
-     * @brief Perform platform-specific deinitialization.
-     * @return true if successful, false otherwise
-     */
-    bool PlatformDeinitialize() noexcept;
+  /**
+   * @brief Perform platform-specific deinitialization.
+   * @return true if successful, false otherwise
+   */
+  bool PlatformDeinitialize() noexcept;
 
-    /**
-     * @brief Internal transfer implementation.
-     * @param tx_data Transmit data buffer
-     * @param rx_data Receive data buffer
-     * @param length Number of bytes to transfer
-     * @param timeout_ms Timeout in milliseconds
-     * @param manage_cs Whether to manage CS automatically
-     * @return HfSpiErr result code
-     */
-    HfSpiErr InternalTransfer(const uint8_t* tx_data, uint8_t* rx_data,
-                              uint16_t length, uint32_t timeout_ms, bool manage_cs) noexcept;
+  /**
+   * @brief Internal transfer implementation.
+   * @param tx_data Transmit data buffer
+   * @param rx_data Receive data buffer
+   * @param length Number of bytes to transfer
+   * @param timeout_ms Timeout in milliseconds
+   * @param manage_cs Whether to manage CS automatically
+   * @return HfSpiErr result code
+   */
+  HfSpiErr InternalTransfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                            uint32_t timeout_ms, bool manage_cs) noexcept;
 
-    //==============================================//
-    // PRIVATE MEMBERS                              //
-    //==============================================//
+  //==============================================//
+  // PRIVATE MEMBERS                              //
+  //==============================================//
 
-    mutable std::mutex mutex_;           ///< Thread safety mutex
-    hf_spi_handle_t platform_handle_;    ///< Platform-specific SPI handle
-    HfSpiErr last_error_;                ///< Last error that occurred
-    uint32_t transaction_count_;         ///< Number of transactions performed
-    bool cs_active_;                     ///< Current CS state
-    bool dma_enabled_;                   ///< DMA enable state
-    uint16_t max_transfer_size_;         ///< Maximum transfer size in bytes
+  mutable std::mutex mutex_;        ///< Thread safety mutex
+  hf_spi_handle_t platform_handle_; ///< Platform-specific SPI handle
+  HfSpiErr last_error_;             ///< Last error that occurred
+  uint32_t transaction_count_;      ///< Number of transactions performed
+  bool cs_active_;                  ///< Current CS state
+  bool dma_enabled_;                ///< DMA enable state
+  uint16_t max_transfer_size_;      ///< Maximum transfer size in bytes
 };
 
 #endif // MCU_SPI_H

--- a/inc/mcu/McuTypes.h
+++ b/inc/mcu/McuTypes.h
@@ -1,7 +1,7 @@
 /**
  * @file McuTypes.h
  * @brief MCU-specific type definitions for hardware abstraction (hf_* types).
- * 
+ *
  * This header defines all MCU-specific types and constants that are used
  * throughout the internal interface wrap layer. By centralizing these definitions,
  * porting to new MCUs only requires updating this single file.
@@ -12,9 +12,9 @@
 #ifndef MCU_TYPES_H
 #define MCU_TYPES_H
 
-#include <cstdint>
 #include "HardwareTypes.h"
-#include "McuSelect.h"  // Central MCU platform selection
+#include "McuSelect.h" // Central MCU platform selection
+#include <cstdint>
 
 //==============================================================================
 // MCU-SPECIFIC TYPES (FOR INTERNAL MCU LAYER USE ONLY)
@@ -25,11 +25,11 @@
  * @details Used internally by MCU implementations for platform-specific ADC setup.
  */
 enum class hf_adc_resolution_t : uint8_t {
-    HF_ADC_RES_9BIT = 9,
-    HF_ADC_RES_10BIT = 10,
-    HF_ADC_RES_11BIT = 11,
-    HF_ADC_RES_12BIT = 12,
-    HF_ADC_RES_13BIT = 13,
+  HF_ADC_RES_9BIT = 9,
+  HF_ADC_RES_10BIT = 10,
+  HF_ADC_RES_11BIT = 11,
+  HF_ADC_RES_12BIT = 12,
+  HF_ADC_RES_13BIT = 13,
 };
 
 /**
@@ -37,10 +37,10 @@ enum class hf_adc_resolution_t : uint8_t {
  * @details Used internally by MCU implementations for platform-specific ADC setup.
  */
 enum class hf_adc_attenuation_t : uint8_t {
-    HF_ADC_ATTEN_DB_0 = 0,     ///< No attenuation (1.1V max)
-    HF_ADC_ATTEN_DB_2_5 = 1,   ///< 2.5dB attenuation (1.5V max)
-    HF_ADC_ATTEN_DB_6 = 2,     ///< 6dB attenuation (2.2V max)
-    HF_ADC_ATTEN_DB_11 = 3,    ///< 11dB attenuation (3.9V max)
+  HF_ADC_ATTEN_DB_0 = 0,   ///< No attenuation (1.1V max)
+  HF_ADC_ATTEN_DB_2_5 = 1, ///< 2.5dB attenuation (1.5V max)
+  HF_ADC_ATTEN_DB_6 = 2,   ///< 6dB attenuation (2.2V max)
+  HF_ADC_ATTEN_DB_11 = 3,  ///< 11dB attenuation (3.9V max)
 };
 
 /**
@@ -48,122 +48,122 @@ enum class hf_adc_attenuation_t : uint8_t {
  * @details Used internally by MCU implementations for platform-specific ADC setup.
  */
 enum class hf_adc_unit_t : uint8_t {
-    HF_ADC_UNIT_1 = 1,         ///< SAR ADC 1
-    HF_ADC_UNIT_2 = 2,         ///< SAR ADC 2
+  HF_ADC_UNIT_1 = 1, ///< SAR ADC 1
+  HF_ADC_UNIT_2 = 2, ///< SAR ADC 2
 };
 
 /**
  * @brief MCU-specific GPIO mode configuration.
  */
 enum class hf_gpio_mode_t : uint8_t {
-    HF_GPIO_MODE_INPUT = 0,
-    HF_GPIO_MODE_OUTPUT,
-    HF_GPIO_MODE_OUTPUT_OD,
+  HF_GPIO_MODE_INPUT = 0,
+  HF_GPIO_MODE_OUTPUT,
+  HF_GPIO_MODE_OUTPUT_OD,
 };
 
 /**
  * @brief MCU-specific GPIO pull resistor configuration.
  */
 enum class hf_gpio_pull_t : uint8_t {
-    HF_GPIO_PULL_NONE = 0,
-    HF_GPIO_PULL_UP,
-    HF_GPIO_PULL_DOWN,
+  HF_GPIO_PULL_NONE = 0,
+  HF_GPIO_PULL_UP,
+  HF_GPIO_PULL_DOWN,
 };
 
 /**
  * @brief MCU-specific GPIO interrupt trigger configuration.
  */
 enum class hf_gpio_intr_type_t : uint8_t {
-    HF_GPIO_INTR_DISABLE = 0,
-    HF_GPIO_INTR_POSEDGE,
-    HF_GPIO_INTR_NEGEDGE,
-    HF_GPIO_INTR_ANYEDGE,
-    HF_GPIO_INTR_LOW_LEVEL,
-    HF_GPIO_INTR_HIGH_LEVEL,
+  HF_GPIO_INTR_DISABLE = 0,
+  HF_GPIO_INTR_POSEDGE,
+  HF_GPIO_INTR_NEGEDGE,
+  HF_GPIO_INTR_ANYEDGE,
+  HF_GPIO_INTR_LOW_LEVEL,
+  HF_GPIO_INTR_HIGH_LEVEL,
 };
 
 /**
  * @brief MCU-specific GPIO drive capability.
  */
 enum class hf_gpio_drive_cap_t : uint8_t {
-    HF_GPIO_DRIVE_CAP_0 = 0,   ///< Minimum drive capability (5mA)
-    HF_GPIO_DRIVE_CAP_1,       ///< Medium drive capability (10mA)
-    HF_GPIO_DRIVE_CAP_2,       ///< High drive capability (20mA)
-    HF_GPIO_DRIVE_CAP_3,       ///< Maximum drive capability (40mA)
+  HF_GPIO_DRIVE_CAP_0 = 0, ///< Minimum drive capability (5mA)
+  HF_GPIO_DRIVE_CAP_1,     ///< Medium drive capability (10mA)
+  HF_GPIO_DRIVE_CAP_2,     ///< High drive capability (20mA)
+  HF_GPIO_DRIVE_CAP_3,     ///< Maximum drive capability (40mA)
 };
 
 /**
  * @brief MCU-specific I2C mode configuration.
  */
 enum class hf_i2c_mode_t : uint8_t {
-    HF_I2C_MODE_SLAVE = 0,
-    HF_I2C_MODE_MASTER,
+  HF_I2C_MODE_SLAVE = 0,
+  HF_I2C_MODE_MASTER,
 };
 
 /**
  * @brief MCU-specific SPI mode configuration.
  */
 enum class hf_spi_mode_t : uint8_t {
-    HF_SPI_MODE_0 = 0,         ///< CPOL=0, CPHA=0
-    HF_SPI_MODE_1 = 1,         ///< CPOL=0, CPHA=1
-    HF_SPI_MODE_2 = 2,         ///< CPOL=1, CPHA=0
-    HF_SPI_MODE_3 = 3,         ///< CPOL=1, CPHA=1
+  HF_SPI_MODE_0 = 0, ///< CPOL=0, CPHA=0
+  HF_SPI_MODE_1 = 1, ///< CPOL=0, CPHA=1
+  HF_SPI_MODE_2 = 2, ///< CPOL=1, CPHA=0
+  HF_SPI_MODE_3 = 3, ///< CPOL=1, CPHA=1
 };
 
 /**
  * @brief MCU-specific UART data bits configuration.
  */
 enum class hf_uart_data_bits_t : uint8_t {
-    HF_UART_DATA_5_BITS = 0,
-    HF_UART_DATA_6_BITS = 1,
-    HF_UART_DATA_7_BITS = 2,
-    HF_UART_DATA_8_BITS = 3,
+  HF_UART_DATA_5_BITS = 0,
+  HF_UART_DATA_6_BITS = 1,
+  HF_UART_DATA_7_BITS = 2,
+  HF_UART_DATA_8_BITS = 3,
 };
 
 /**
  * @brief MCU-specific UART parity configuration.
  */
 enum class hf_uart_parity_t : uint8_t {
-    HF_UART_PARITY_DISABLE = 0,
-    HF_UART_PARITY_EVEN = 2,
-    HF_UART_PARITY_ODD = 3,
+  HF_UART_PARITY_DISABLE = 0,
+  HF_UART_PARITY_EVEN = 2,
+  HF_UART_PARITY_ODD = 3,
 };
 
 /**
  * @brief MCU-specific UART stop bits configuration.
  */
 enum class hf_uart_stop_bits_t : uint8_t {
-    HF_UART_STOP_BITS_1 = 1,
-    HF_UART_STOP_BITS_1_5 = 2,
-    HF_UART_STOP_BITS_2 = 3,
+  HF_UART_STOP_BITS_1 = 1,
+  HF_UART_STOP_BITS_1_5 = 2,
+  HF_UART_STOP_BITS_2 = 3,
 };
 
 /**
  * @brief MCU-specific UART flow control configuration.
  */
 enum class hf_uart_flow_ctrl_t : uint8_t {
-    HF_UART_HW_FLOWCTRL_DISABLE = 0,
-    HF_UART_HW_FLOWCTRL_RTS = 1,
-    HF_UART_HW_FLOWCTRL_CTS = 2,
-    HF_UART_HW_FLOWCTRL_CTS_RTS = 3,
+  HF_UART_HW_FLOWCTRL_DISABLE = 0,
+  HF_UART_HW_FLOWCTRL_RTS = 1,
+  HF_UART_HW_FLOWCTRL_CTS = 2,
+  HF_UART_HW_FLOWCTRL_CTS_RTS = 3,
 };
 
 /**
  * @brief MCU-specific CAN mode configuration.
  */
 enum class hf_can_mode_t : uint8_t {
-    HF_CAN_MODE_NORMAL = 0,
-    HF_CAN_MODE_NO_ACK = 1,
-    HF_CAN_MODE_LISTEN_ONLY = 2,
+  HF_CAN_MODE_NORMAL = 0,
+  HF_CAN_MODE_NO_ACK = 1,
+  HF_CAN_MODE_LISTEN_ONLY = 2,
 };
 
 /**
  * @brief MCU-specific PWM mode configuration.
  */
 enum class hf_pwm_mode_t : uint8_t {
-    HF_PWM_MODE_UP = 0,
-    HF_PWM_MODE_DOWN = 1,
-    HF_PWM_MODE_UP_DOWN = 2,
+  HF_PWM_MODE_UP = 0,
+  HF_PWM_MODE_DOWN = 1,
+  HF_PWM_MODE_UP_DOWN = 2,
 };
 
 //==============================================================================
@@ -171,29 +171,29 @@ enum class hf_pwm_mode_t : uint8_t {
 //==============================================================================
 
 // Basic hardware identifiers (map platform-agnostic to MCU types)
-using hf_gpio_num_t = HfPinNumber;             ///< GPIO pin number
-using hf_i2c_port_t = HfPortNumber;            ///< I2C port number
-using hf_spi_host_t = HfHostId;                ///< SPI host identifier
-using hf_uart_port_t = HfPortNumber;           ///< UART port number
-using hf_adc_channel_t = HfChannelId;          ///< ADC channel identifier
-using hf_pwm_channel_t = HfChannelId;          ///< PWM channel identifier
+using hf_gpio_num_t = HfPinNumber;    ///< GPIO pin number
+using hf_i2c_port_t = HfPortNumber;   ///< I2C port number
+using hf_spi_host_t = HfHostId;       ///< SPI host identifier
+using hf_uart_port_t = HfPortNumber;  ///< UART port number
+using hf_adc_channel_t = HfChannelId; ///< ADC channel identifier
+using hf_pwm_channel_t = HfChannelId; ///< PWM channel identifier
 
 // Communication parameters
-using hf_i2c_freq_t = HfFrequencyHz;           ///< I2C frequency in Hz
-using hf_spi_freq_t = HfFrequencyHz;           ///< SPI frequency in Hz
-using hf_pwm_freq_t = HfFrequencyHz;           ///< PWM frequency in Hz
-using hf_uart_baudrate_t = HfBaudRate;         ///< UART baud rate
-using hf_can_baudrate_t = HfBaudRate;          ///< CAN baud rate
+using hf_i2c_freq_t = HfFrequencyHz;   ///< I2C frequency in Hz
+using hf_spi_freq_t = HfFrequencyHz;   ///< SPI frequency in Hz
+using hf_pwm_freq_t = HfFrequencyHz;   ///< PWM frequency in Hz
+using hf_uart_baudrate_t = HfBaudRate; ///< UART baud rate
+using hf_can_baudrate_t = HfBaudRate;  ///< CAN baud rate
 
 // Data and timing types
-using hf_timeout_ms_t = HfTimeoutMs;           ///< Timeout in milliseconds
-using hf_adc_value_t = uint32_t;             ///< ADC reading value
-using hf_pwm_duty_t = uint32_t;              ///< PWM duty cycle value
-using hf_can_message_id_t = uint32_t;        ///< CAN message ID
-using hf_i2c_address_t = uint8_t;            ///< I2C device address
+using hf_timeout_ms_t = HfTimeoutMs;  ///< Timeout in milliseconds
+using hf_adc_value_t = uint32_t;      ///< ADC reading value
+using hf_pwm_duty_t = uint32_t;       ///< PWM duty cycle value
+using hf_can_message_id_t = uint32_t; ///< CAN message ID
+using hf_i2c_address_t = uint8_t;     ///< I2C device address
 
 // Platform-specific handles
-using hf_timer_handle_t = void*;             ///< Timer handle (platform-specific)
+using hf_timer_handle_t = void *; ///< Timer handle (platform-specific)
 
 //==============================================================================
 // MCU-SPECIFIC STRUCTURES FOR TIMERS AND PWM
@@ -204,18 +204,15 @@ using hf_timer_handle_t = void*;             ///< Timer handle (platform-specifi
  * @details Used internally by MCU implementations for detailed timer monitoring.
  */
 struct TimerStats {
-    uint64_t callback_count;      ///< Number of callbacks executed
-    uint64_t missed_callbacks;    ///< Number of missed callbacks
-    uint64_t start_count;         ///< Number of times timer was started
-    uint64_t stop_count;          ///< Number of times timer was stopped
-    HfTimerErr last_error;        ///< Last error that occurred
-    
-    TimerStats() noexcept 
-        : callback_count(0)
-        , missed_callbacks(0)
-        , start_count(0)
-        , stop_count(0)
-        , last_error(HfTimerErr::TIMER_SUCCESS) {}
+  uint64_t callback_count;   ///< Number of callbacks executed
+  uint64_t missed_callbacks; ///< Number of missed callbacks
+  uint64_t start_count;      ///< Number of times timer was started
+  uint64_t stop_count;       ///< Number of times timer was stopped
+  HfTimerErr last_error;     ///< Last error that occurred
+
+  TimerStats() noexcept
+      : callback_count(0), missed_callbacks(0), start_count(0), stop_count(0),
+        last_error(HfTimerErr::TIMER_SUCCESS) {}
 };
 
 //==============================================================================

--- a/inc/mcu/McuUart.h
+++ b/inc/mcu/McuUart.h
@@ -14,8 +14,8 @@
 
 #include "BaseUart.h"
 #include "McuTypes.h"
-#include <mutex>
 #include <cstdarg>
+#include <mutex>
 
 /**
  * @class McuUart
@@ -40,278 +40,276 @@
  */
 class McuUart : public BaseUart {
 public:
-    /**
-     * @brief Constructor with port and configuration.
-     * @param port Platform-agnostic UART port number
-     * @param config UART configuration parameters
-     */
-    McuUart(HfPortNumber port, const UartConfig& config) noexcept;
+  /**
+   * @brief Constructor with port and configuration.
+   * @param port Platform-agnostic UART port number
+   * @param config UART configuration parameters
+   */
+  McuUart(HfPortNumber port, const UartConfig &config) noexcept;
 
-    /**
-     * @brief Destructor - ensures proper cleanup.
-     */
-    ~McuUart() noexcept override;
+  /**
+   * @brief Destructor - ensures proper cleanup.
+   */
+  ~McuUart() noexcept override;
 
-    //==============================================//
-    // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
-    //==============================================//
+  //==============================================//
+  // OVERRIDDEN PURE VIRTUAL FUNCTIONS            //
+  //==============================================//
 
-    /**
-     * @brief Initialize the UART driver.
-     * @return true if successful, false otherwise
-     */
-    bool Initialize() noexcept override;
+  /**
+   * @brief Initialize the UART driver.
+   * @return true if successful, false otherwise
+   */
+  bool Initialize() noexcept override;
 
-    /**
-     * @brief Deinitialize the UART driver.
-     * @return true if successful, false otherwise
-     */
-    bool Deinitialize() noexcept override;
+  /**
+   * @brief Deinitialize the UART driver.
+   * @return true if successful, false otherwise
+   */
+  bool Deinitialize() noexcept override;
 
-    /**
-     * @brief Write data to the UART.
-     * @param data Data buffer to transmit
-     * @param length Number of bytes to write
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfUartErr result code
-     */
-    HfUartErr Write(const uint8_t* data, uint16_t length,
-                    uint32_t timeout_ms = 0) noexcept override;
+  /**
+   * @brief Write data to the UART.
+   * @param data Data buffer to transmit
+   * @param length Number of bytes to write
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfUartErr result code
+   */
+  HfUartErr Write(const uint8_t *data, uint16_t length, uint32_t timeout_ms = 0) noexcept override;
 
-    /**
-     * @brief Read data from the UART.
-     * @param data Buffer to store received data
-     * @param length Number of bytes to read
-     * @param timeout_ms Timeout in milliseconds (0 = use default)
-     * @return HfUartErr result code
-     */
-    HfUartErr Read(uint8_t* data, uint16_t length,
-                   uint32_t timeout_ms = 0) noexcept override;
+  /**
+   * @brief Read data from the UART.
+   * @param data Buffer to store received data
+   * @param length Number of bytes to read
+   * @param timeout_ms Timeout in milliseconds (0 = use default)
+   * @return HfUartErr result code
+   */
+  HfUartErr Read(uint8_t *data, uint16_t length, uint32_t timeout_ms = 0) noexcept override;
 
-    /**
-     * @brief Get the number of bytes available to read.
-     * @return Number of bytes available in the receive buffer
-     */
-    uint16_t BytesAvailable() noexcept override;
+  /**
+   * @brief Get the number of bytes available to read.
+   * @return Number of bytes available in the receive buffer
+   */
+  uint16_t BytesAvailable() noexcept override;
 
-    /**
-     * @brief Flush the transmit buffer.
-     * @return HfUartErr result code
-     */
-    HfUartErr FlushTx() noexcept override;
+  /**
+   * @brief Flush the transmit buffer.
+   * @return HfUartErr result code
+   */
+  HfUartErr FlushTx() noexcept override;
 
-    /**
-     * @brief Flush the receive buffer.
-     * @return HfUartErr result code
-     */
-    HfUartErr FlushRx() noexcept override;
+  /**
+   * @brief Flush the receive buffer.
+   * @return HfUartErr result code
+   */
+  HfUartErr FlushRx() noexcept override;
 
-    /**
-     * @brief Printf-style formatted output.
-     * @param format Format string
-     * @param ... Format arguments
-     * @return Number of characters written, or -1 on error
-     */
-    int Printf(const char* format, ...) noexcept override;
+  /**
+   * @brief Printf-style formatted output.
+   * @param format Format string
+   * @param ... Format arguments
+   * @return Number of characters written, or -1 on error
+   */
+  int Printf(const char *format, ...) noexcept override;
 
-    //==============================================//
-    // ENHANCED METHODS                             //
-    //==============================================//
+  //==============================================//
+  // ENHANCED METHODS                             //
+  //==============================================//
 
-    /**
-     * @brief Check if the UART is busy transmitting.
-     * @return true if busy, false if idle
-     */
-    bool IsTxBusy() noexcept;
+  /**
+   * @brief Check if the UART is busy transmitting.
+   * @return true if busy, false if idle
+   */
+  bool IsTxBusy() noexcept;
 
-    /**
-     * @brief Get the last error that occurred.
-     * @return Last error code
-     */
-    HfUartErr GetLastError() const noexcept {
-        return last_error_;
-    }
+  /**
+   * @brief Get the last error that occurred.
+   * @return Last error code
+   */
+  HfUartErr GetLastError() const noexcept {
+    return last_error_;
+  }
 
-    /**
-     * @brief Set a new baud rate (requires reinitialization).
-     * @param baud_rate New baud rate in bits per second
-     * @return true if successful, false otherwise
-     */
-    bool SetBaudRate(uint32_t baud_rate) noexcept;
+  /**
+   * @brief Set a new baud rate (requires reinitialization).
+   * @param baud_rate New baud rate in bits per second
+   * @return true if successful, false otherwise
+   */
+  bool SetBaudRate(uint32_t baud_rate) noexcept;
 
-    /**
-     * @brief Enable or disable hardware flow control.
-     * @param enable True to enable flow control, false to disable
-     * @return true if successful, false otherwise
-     */
-    bool SetFlowControl(bool enable) noexcept;
+  /**
+   * @brief Enable or disable hardware flow control.
+   * @param enable True to enable flow control, false to disable
+   * @return true if successful, false otherwise
+   */
+  bool SetFlowControl(bool enable) noexcept;
 
-    /**
-     * @brief Get detailed UART status information.
-     * @return Platform-specific status information
-     */
-    uint32_t GetUartStatus() noexcept;
+  /**
+   * @brief Get detailed UART status information.
+   * @return Platform-specific status information
+   */
+  uint32_t GetUartStatus() noexcept;
 
-    /**
-     * @brief Set RTS line manually (if not using automatic flow control).
-     * @param active True to assert RTS, false to deassert
-     * @return true if successful, false otherwise
-     */
-    bool SetRTS(bool active) noexcept;
+  /**
+   * @brief Set RTS line manually (if not using automatic flow control).
+   * @param active True to assert RTS, false to deassert
+   * @return true if successful, false otherwise
+   */
+  bool SetRTS(bool active) noexcept;
 
-    /**
-     * @brief Get CTS line status.
-     * @return true if CTS is asserted, false otherwise
-     */
-    bool GetCTS() noexcept;
+  /**
+   * @brief Get CTS line status.
+   * @return true if CTS is asserted, false otherwise
+   */
+  bool GetCTS() noexcept;
 
-    /**
-     * @brief Send a break condition.
-     * @param duration_ms Duration of break in milliseconds
-     * @return true if successful, false otherwise
-     */
-    bool SendBreak(uint32_t duration_ms) noexcept;
+  /**
+   * @brief Send a break condition.
+   * @param duration_ms Duration of break in milliseconds
+   * @return true if successful, false otherwise
+   */
+  bool SendBreak(uint32_t duration_ms) noexcept;
 
-    /**
-     * @brief Detect if a break condition was received.
-     * @return true if break detected, false otherwise
-     */
-    bool IsBreakDetected() noexcept;
+  /**
+   * @brief Detect if a break condition was received.
+   * @return true if break detected, false otherwise
+   */
+  bool IsBreakDetected() noexcept;
 
-    /**
-     * @brief Get the number of bytes in the transmit buffer.
-     * @return Number of bytes waiting to be transmitted
-     */
-    uint16_t TxBytesWaiting() noexcept;
+  /**
+   * @brief Get the number of bytes in the transmit buffer.
+   * @return Number of bytes waiting to be transmitted
+   */
+  uint16_t TxBytesWaiting() noexcept;
 
-    /**
-     * @brief Enable or disable loopback mode (for testing).
-     * @param enable True to enable loopback, false to disable
-     * @return true if successful, false otherwise
-     */
-    bool SetLoopback(bool enable) noexcept;
+  /**
+   * @brief Enable or disable loopback mode (for testing).
+   * @param enable True to enable loopback, false to disable
+   * @return true if successful, false otherwise
+   */
+  bool SetLoopback(bool enable) noexcept;
 
-    /**
-     * @brief Wait for all data to be transmitted.
-     * @param timeout_ms Maximum time to wait in milliseconds
-     * @return true if all data transmitted, false if timeout
-     */
-    bool WaitTransmitComplete(uint32_t timeout_ms) noexcept;
+  /**
+   * @brief Wait for all data to be transmitted.
+   * @param timeout_ms Maximum time to wait in milliseconds
+   * @return true if all data transmitted, false if timeout
+   */
+  bool WaitTransmitComplete(uint32_t timeout_ms) noexcept;
 
-    /**
-     * @brief Read data with specific termination character.
-     * @param data Buffer to store received data
-     * @param max_length Maximum number of bytes to read
-     * @param terminator Termination character
-     * @param timeout_ms Timeout in milliseconds
-     * @return Number of bytes read (including terminator if found)
-     */
-    uint16_t ReadUntil(uint8_t* data, uint16_t max_length, 
-                       uint8_t terminator, uint32_t timeout_ms) noexcept;
+  /**
+   * @brief Read data with specific termination character.
+   * @param data Buffer to store received data
+   * @param max_length Maximum number of bytes to read
+   * @param terminator Termination character
+   * @param timeout_ms Timeout in milliseconds
+   * @return Number of bytes read (including terminator if found)
+   */
+  uint16_t ReadUntil(uint8_t *data, uint16_t max_length, uint8_t terminator,
+                     uint32_t timeout_ms) noexcept;
 
-    /**
-     * @brief Read a line of text (terminated by \n or \r\n).
-     * @param buffer Buffer to store the line
-     * @param max_length Maximum number of characters to read
-     * @param timeout_ms Timeout in milliseconds
-     * @return Number of characters read (excluding terminator)
-     */
-    uint16_t ReadLine(char* buffer, uint16_t max_length, uint32_t timeout_ms) noexcept;
+  /**
+   * @brief Read a line of text (terminated by \n or \r\n).
+   * @param buffer Buffer to store the line
+   * @param max_length Maximum number of characters to read
+   * @param timeout_ms Timeout in milliseconds
+   * @return Number of characters read (excluding terminator)
+   */
+  uint16_t ReadLine(char *buffer, uint16_t max_length, uint32_t timeout_ms) noexcept;
 
 private:
-    //==============================================//
-    // PRIVATE METHODS                              //
-    //==============================================//
+  //==============================================//
+  // PRIVATE METHODS                              //
+  //==============================================//
 
-    /**
-     * @brief Convert platform-specific error to HfUartErr.
-     * @param platform_error Platform-specific error code
-     * @return Corresponding HfUartErr
-     */
-    HfUartErr ConvertPlatformError(int32_t platform_error) noexcept;
+  /**
+   * @brief Convert platform-specific error to HfUartErr.
+   * @param platform_error Platform-specific error code
+   * @return Corresponding HfUartErr
+   */
+  HfUartErr ConvertPlatformError(int32_t platform_error) noexcept;
 
-    /**
-     * @brief Validate baud rate.
-     * @param baud_rate Baud rate to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidBaudRate(uint32_t baud_rate) const noexcept {
-        // Common baud rates: 9600, 19200, 38400, 57600, 115200, etc.
-        // Allow range from 300 to 921600
-        return (baud_rate >= 300 && baud_rate <= 921600);
-    }
+  /**
+   * @brief Validate baud rate.
+   * @param baud_rate Baud rate to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidBaudRate(uint32_t baud_rate) const noexcept {
+    // Common baud rates: 9600, 19200, 38400, 57600, 115200, etc.
+    // Allow range from 300 to 921600
+    return (baud_rate >= 300 && baud_rate <= 921600);
+  }
 
-    /**
-     * @brief Validate data bits.
-     * @param data_bits Data bits to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidDataBits(uint8_t data_bits) const noexcept {
-        return (data_bits >= 5 && data_bits <= 8);
-    }
+  /**
+   * @brief Validate data bits.
+   * @param data_bits Data bits to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidDataBits(uint8_t data_bits) const noexcept {
+    return (data_bits >= 5 && data_bits <= 8);
+  }
 
-    /**
-     * @brief Validate parity setting.
-     * @param parity Parity to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidParity(uint8_t parity) const noexcept {
-        return (parity <= 2); // 0=None, 1=Even, 2=Odd
-    }
+  /**
+   * @brief Validate parity setting.
+   * @param parity Parity to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidParity(uint8_t parity) const noexcept {
+    return (parity <= 2); // 0=None, 1=Even, 2=Odd
+  }
 
-    /**
-     * @brief Validate stop bits.
-     * @param stop_bits Stop bits to validate
-     * @return true if valid, false otherwise
-     */
-    bool IsValidStopBits(uint8_t stop_bits) const noexcept {
-        return (stop_bits >= 1 && stop_bits <= 2);
-    }
+  /**
+   * @brief Validate stop bits.
+   * @param stop_bits Stop bits to validate
+   * @return true if valid, false otherwise
+   */
+  bool IsValidStopBits(uint8_t stop_bits) const noexcept {
+    return (stop_bits >= 1 && stop_bits <= 2);
+  }
 
-    /**
-     * @brief Get timeout value (use default if timeout_ms is 0).
-     * @param timeout_ms Requested timeout
-     * @return Actual timeout to use
-     */
-    uint32_t GetTimeoutMs(uint32_t timeout_ms) const noexcept {
-        return (timeout_ms == 0) ? config_.timeout_ms : timeout_ms;
-    }
+  /**
+   * @brief Get timeout value (use default if timeout_ms is 0).
+   * @param timeout_ms Requested timeout
+   * @return Actual timeout to use
+   */
+  uint32_t GetTimeoutMs(uint32_t timeout_ms) const noexcept {
+    return (timeout_ms == 0) ? config_.timeout_ms : timeout_ms;
+  }
 
-    /**
-     * @brief Perform platform-specific initialization.
-     * @return true if successful, false otherwise
-     */
-    bool PlatformInitialize() noexcept;
+  /**
+   * @brief Perform platform-specific initialization.
+   * @return true if successful, false otherwise
+   */
+  bool PlatformInitialize() noexcept;
 
-    /**
-     * @brief Perform platform-specific deinitialization.
-     * @return true if successful, false otherwise
-     */
-    bool PlatformDeinitialize() noexcept;
+  /**
+   * @brief Perform platform-specific deinitialization.
+   * @return true if successful, false otherwise
+   */
+  bool PlatformDeinitialize() noexcept;
 
-    /**
-     * @brief Internal printf implementation with buffer management.
-     * @param format Format string
-     * @param args Variable arguments list
-     * @return Number of characters written, or -1 on error
-     */
-    int InternalPrintf(const char* format, va_list args) noexcept;
+  /**
+   * @brief Internal printf implementation with buffer management.
+   * @param format Format string
+   * @param args Variable arguments list
+   * @return Number of characters written, or -1 on error
+   */
+  int InternalPrintf(const char *format, va_list args) noexcept;
 
-    //==============================================//
-    // PRIVATE MEMBERS                              //
-    //==============================================//
+  //==============================================//
+  // PRIVATE MEMBERS                              //
+  //==============================================//
 
-    mutable std::mutex mutex_;           ///< Thread safety mutex
-    hf_uart_handle_t platform_handle_;   ///< Platform-specific UART handle
-    HfUartErr last_error_;               ///< Last error that occurred
-    uint32_t bytes_transmitted_;         ///< Total bytes transmitted
-    uint32_t bytes_received_;            ///< Total bytes received
-    bool break_detected_;                ///< Break condition flag
-    bool tx_in_progress_;                ///< Transmission in progress flag
-    
-    // Printf buffer management
-    static constexpr uint16_t PRINTF_BUFFER_SIZE = 256; ///< Printf buffer size
-    char printf_buffer_[PRINTF_BUFFER_SIZE];     ///< Printf formatting buffer
+  mutable std::mutex mutex_;         ///< Thread safety mutex
+  hf_uart_handle_t platform_handle_; ///< Platform-specific UART handle
+  HfUartErr last_error_;             ///< Last error that occurred
+  uint32_t bytes_transmitted_;       ///< Total bytes transmitted
+  uint32_t bytes_received_;          ///< Total bytes received
+  bool break_detected_;              ///< Break condition flag
+  bool tx_in_progress_;              ///< Transmission in progress flag
+
+  // Printf buffer management
+  static constexpr uint16_t PRINTF_BUFFER_SIZE = 256; ///< Printf buffer size
+  char printf_buffer_[PRINTF_BUFFER_SIZE];            ///< Printf formatting buffer
 };
 
 #endif // MCU_UART_H

--- a/inc/thread_safe/SfAdc.h
+++ b/inc/thread_safe/SfAdc.h
@@ -24,34 +24,34 @@
 
 #include "BaseAdc.h"
 #include "McuTypes.h"
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
-#include <chrono>
-#include <atomic>
 #include <vector>
 
 /**
  * @class SfAdc
  * @brief Enhanced thread-safe ADC interface wrapper.
- * 
+ *
  * This class wraps any BaseAdc implementation with comprehensive thread safety.
  * It uses composition over inheritance to provide a robust, thread-safe interface
  * while maintaining full compatibility with the BaseAdc API.
- * 
+ *
  * Thread Safety Features:
  * - Reader-writer mutexes for concurrent read operations
  * - Atomic statistics tracking
  * - Configurable mutex timeouts
  * - Lock-free status queries where possible
  * - Batch operations with single lock acquisition
- * 
+ *
  * Usage:
  * @code
  * auto mcu_adc = std::make_unique<McuAdc>(config);
  * SfAdc safe_adc(std::move(mcu_adc));
  * safe_adc.Initialize();
- * 
+ *
  * // Thread-safe conversions
  * float voltage = 0.0f;
  * if (safe_adc.ReadVoltage(channel, voltage)) {
@@ -61,256 +61,256 @@
  */
 class SfAdc {
 public:
-    //==============================================================================
-    // CONSTRUCTION AND DESTRUCTION
-    //==============================================================================
-    
-    /**
-     * @brief Construct thread-safe ADC wrapper.
-     * @param adc_impl BaseAdc implementation to wrap (takes ownership)
-     */
-    explicit SfAdc(std::unique_ptr<BaseAdc> adc_impl) noexcept;
-    
-    /**
-     * @brief Destructor ensures proper cleanup and synchronization.
-     */
-    ~SfAdc() noexcept;
-    
-    // Non-copyable, movable
-    SfAdc(const SfAdc&) = delete;
-    SfAdc& operator=(const SfAdc&) = delete;
-    SfAdc(SfAdc&&) noexcept = default;
-    SfAdc& operator=(SfAdc&&) noexcept = default;
+  //==============================================================================
+  // CONSTRUCTION AND DESTRUCTION
+  //==============================================================================
 
-    //==============================================================================
-    // CONFIGURATION AND CONTROL
-    //==============================================================================
-    
-    /**
-     * @brief Set mutex acquisition timeout for all operations.
-     * @param timeout Maximum time to wait for mutex acquisition
-     */
-    void SetMutexTimeout(std::chrono::milliseconds timeout) noexcept;
-    
-    /**
-     * @brief Initialize ADC with thread safety.
-     * @return ADC error code
-     */
-    HfAdcErr Initialize() noexcept;
-    
-    /**
-     * @brief Deinitialize ADC with proper synchronization.
-     * @return ADC error code
-     */
-    HfAdcErr Deinitialize() noexcept;
-    
-    /**
-     * @brief Configure ADC channel with thread safety.
-     * @param channel_id Channel to configure
-     * @param config Channel configuration
-     * @return ADC error code
-     */
-    HfAdcErr ConfigureChannel(uint8_t channel_id, const AdcChannelConfig& config) noexcept;
+  /**
+   * @brief Construct thread-safe ADC wrapper.
+   * @param adc_impl BaseAdc implementation to wrap (takes ownership)
+   */
+  explicit SfAdc(std::unique_ptr<BaseAdc> adc_impl) noexcept;
 
-    //==============================================================================
-    // CONVERSION OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Read raw ADC value (thread-safe).
-     * @param channel_id Channel to read
-     * @param raw_value Output raw value
-     * @return ADC error code
-     */
-    HfAdcErr ReadRaw(uint8_t channel_id, uint16_t& raw_value) noexcept;
-    
-    /**
-     * @brief Read voltage value (thread-safe).
-     * @param channel_id Channel to read
-     * @param voltage Output voltage value
-     * @return ADC error code
-     */
-    HfAdcErr ReadVoltage(uint8_t channel_id, float& voltage) noexcept;
-    
-    /**
-     * @brief Start continuous conversion (thread-safe).
-     * @param channel_id Channel for continuous conversion
-     * @param sample_rate_hz Sampling rate
-     * @return ADC error code
-     */
-    HfAdcErr StartContinuous(uint8_t channel_id, uint32_t sample_rate_hz) noexcept;
-    
-    /**
-     * @brief Stop continuous conversion (thread-safe).
-     * @param channel_id Channel to stop
-     * @return ADC error code
-     */
-    HfAdcErr StopContinuous(uint8_t channel_id) noexcept;
+  /**
+   * @brief Destructor ensures proper cleanup and synchronization.
+   */
+  ~SfAdc() noexcept;
 
-    //==============================================================================
-    // BATCH OPERATIONS (OPTIMIZED FOR MULTI-CHANNEL)
-    //==============================================================================
-    
-    /**
-     * @brief Read multiple channels with single lock acquisition.
-     * @param channels Vector of channel IDs to read
-     * @param raw_values Output vector of raw values (same order as channels)
-     * @return ADC error code
-     */
-    HfAdcErr ReadRawBatch(const std::vector<uint8_t>& channels, 
-                          std::vector<uint16_t>& raw_values) noexcept;
-    
-    /**
-     * @brief Read multiple channel voltages with single lock acquisition.
-     * @param channels Vector of channel IDs to read
-     * @param voltages Output vector of voltage values (same order as channels)
-     * @return ADC error code
-     */
-    HfAdcErr ReadVoltageBatch(const std::vector<uint8_t>& channels, 
-                              std::vector<float>& voltages) noexcept;
+  // Non-copyable, movable
+  SfAdc(const SfAdc &) = delete;
+  SfAdc &operator=(const SfAdc &) = delete;
+  SfAdc(SfAdc &&) noexcept = default;
+  SfAdc &operator=(SfAdc &&) noexcept = default;
 
-    //==============================================================================
-    // STATUS AND DIAGNOSTICS (LOCK-FREE WHERE POSSIBLE)
-    //==============================================================================
-    
-    /**
-     * @brief Check if ADC is initialized (atomic read).
-     * @return true if initialized
-     */
-    bool IsInitialized() const noexcept;
-    
-    /**
-     * @brief Get maximum number of channels (lock-free).
-     * @return Maximum channels supported
-     */
-    uint8_t GetMaxChannels() const noexcept;
-    
-    /**
-     * @brief Check if channel is active (atomic read where possible).
-     * @param channel_id Channel to check
-     * @return true if channel is active
-     */
-    bool IsChannelActive(uint8_t channel_id) const noexcept;
-    
-    /**
-     * @brief Get ADC resolution for channel (lock-free where possible).
-     * @param channel_id Channel to query
-     * @return Resolution in bits
-     */
-    uint8_t GetChannelResolution(uint8_t channel_id) const noexcept;
+  //==============================================================================
+  // CONFIGURATION AND CONTROL
+  //==============================================================================
 
-    //==============================================================================
-    // CALLBACK MANAGEMENT
-    //==============================================================================
-    
-    /**
-     * @brief Set conversion complete callback (thread-safe).
-     * @param callback Callback function
-     * @param user_data User data pointer
-     * @return ADC error code
-     */
-    HfAdcErr SetConversionCallback(AdcConversionCallback callback, void* user_data) noexcept;
-    
-    /**
-     * @brief Set error callback (thread-safe).
-     * @param callback Error callback function
-     * @param user_data User data pointer
-     * @return ADC error code
-     */
-    HfAdcErr SetErrorCallback(AdcErrorCallback callback, void* user_data) noexcept;
+  /**
+   * @brief Set mutex acquisition timeout for all operations.
+   * @param timeout Maximum time to wait for mutex acquisition
+   */
+  void SetMutexTimeout(std::chrono::milliseconds timeout) noexcept;
 
-    //==============================================================================
-    // ADVANCED THREADING FEATURES
-    //==============================================================================
-    
-    /**
-     * @brief Acquire exclusive lock for extended operations.
-     * @param timeout_ms Maximum time to wait for lock
-     * @return true if lock acquired
-     */
-    bool Lock(uint32_t timeout_ms = UINT32_MAX) noexcept;
-    
-    /**
-     * @brief Release exclusive lock.
-     * @return true if lock released successfully
-     */
-    bool Unlock() noexcept;
-    
-    /**
-     * @brief Acquire shared lock for concurrent reads.
-     * @param timeout_ms Maximum time to wait for lock
-     * @return true if shared lock acquired
-     */
-    bool LockShared(uint32_t timeout_ms = UINT32_MAX) noexcept;
-    
-    /**
-     * @brief Release shared lock.
-     * @return true if shared lock released successfully
-     */
-    bool UnlockShared() noexcept;
+  /**
+   * @brief Initialize ADC with thread safety.
+   * @return ADC error code
+   */
+  HfAdcErr Initialize() noexcept;
 
-    //==============================================================================
-    // STATISTICS AND DIAGNOSTICS
-    //==============================================================================
-    
-    /**
-     * @brief Threading statistics structure.
-     */
-    struct ThreadingStats {
-        std::atomic<uint64_t> total_operations{0};
-        std::atomic<uint64_t> lock_acquisitions{0};
-        std::atomic<uint64_t> lock_timeouts{0};
-        std::atomic<uint64_t> concurrent_reads{0};
-        std::atomic<uint64_t> exclusive_operations{0};
-        std::atomic<uint32_t> max_wait_time_us{0};
-        std::atomic<uint32_t> current_readers{0};
-    };
-    
-    /**
-     * @brief Get threading statistics (atomic reads).
-     * @return Current threading statistics
-     */
-    ThreadingStats GetThreadingStats() const noexcept;
-    
-    /**
-     * @brief Reset threading statistics.
-     */
-    void ResetThreadingStats() noexcept;
+  /**
+   * @brief Deinitialize ADC with proper synchronization.
+   * @return ADC error code
+   */
+  HfAdcErr Deinitialize() noexcept;
+
+  /**
+   * @brief Configure ADC channel with thread safety.
+   * @param channel_id Channel to configure
+   * @param config Channel configuration
+   * @return ADC error code
+   */
+  HfAdcErr ConfigureChannel(uint8_t channel_id, const AdcChannelConfig &config) noexcept;
+
+  //==============================================================================
+  // CONVERSION OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Read raw ADC value (thread-safe).
+   * @param channel_id Channel to read
+   * @param raw_value Output raw value
+   * @return ADC error code
+   */
+  HfAdcErr ReadRaw(uint8_t channel_id, uint16_t &raw_value) noexcept;
+
+  /**
+   * @brief Read voltage value (thread-safe).
+   * @param channel_id Channel to read
+   * @param voltage Output voltage value
+   * @return ADC error code
+   */
+  HfAdcErr ReadVoltage(uint8_t channel_id, float &voltage) noexcept;
+
+  /**
+   * @brief Start continuous conversion (thread-safe).
+   * @param channel_id Channel for continuous conversion
+   * @param sample_rate_hz Sampling rate
+   * @return ADC error code
+   */
+  HfAdcErr StartContinuous(uint8_t channel_id, uint32_t sample_rate_hz) noexcept;
+
+  /**
+   * @brief Stop continuous conversion (thread-safe).
+   * @param channel_id Channel to stop
+   * @return ADC error code
+   */
+  HfAdcErr StopContinuous(uint8_t channel_id) noexcept;
+
+  //==============================================================================
+  // BATCH OPERATIONS (OPTIMIZED FOR MULTI-CHANNEL)
+  //==============================================================================
+
+  /**
+   * @brief Read multiple channels with single lock acquisition.
+   * @param channels Vector of channel IDs to read
+   * @param raw_values Output vector of raw values (same order as channels)
+   * @return ADC error code
+   */
+  HfAdcErr ReadRawBatch(const std::vector<uint8_t> &channels,
+                        std::vector<uint16_t> &raw_values) noexcept;
+
+  /**
+   * @brief Read multiple channel voltages with single lock acquisition.
+   * @param channels Vector of channel IDs to read
+   * @param voltages Output vector of voltage values (same order as channels)
+   * @return ADC error code
+   */
+  HfAdcErr ReadVoltageBatch(const std::vector<uint8_t> &channels,
+                            std::vector<float> &voltages) noexcept;
+
+  //==============================================================================
+  // STATUS AND DIAGNOSTICS (LOCK-FREE WHERE POSSIBLE)
+  //==============================================================================
+
+  /**
+   * @brief Check if ADC is initialized (atomic read).
+   * @return true if initialized
+   */
+  bool IsInitialized() const noexcept;
+
+  /**
+   * @brief Get maximum number of channels (lock-free).
+   * @return Maximum channels supported
+   */
+  uint8_t GetMaxChannels() const noexcept;
+
+  /**
+   * @brief Check if channel is active (atomic read where possible).
+   * @param channel_id Channel to check
+   * @return true if channel is active
+   */
+  bool IsChannelActive(uint8_t channel_id) const noexcept;
+
+  /**
+   * @brief Get ADC resolution for channel (lock-free where possible).
+   * @param channel_id Channel to query
+   * @return Resolution in bits
+   */
+  uint8_t GetChannelResolution(uint8_t channel_id) const noexcept;
+
+  //==============================================================================
+  // CALLBACK MANAGEMENT
+  //==============================================================================
+
+  /**
+   * @brief Set conversion complete callback (thread-safe).
+   * @param callback Callback function
+   * @param user_data User data pointer
+   * @return ADC error code
+   */
+  HfAdcErr SetConversionCallback(AdcConversionCallback callback, void *user_data) noexcept;
+
+  /**
+   * @brief Set error callback (thread-safe).
+   * @param callback Error callback function
+   * @param user_data User data pointer
+   * @return ADC error code
+   */
+  HfAdcErr SetErrorCallback(AdcErrorCallback callback, void *user_data) noexcept;
+
+  //==============================================================================
+  // ADVANCED THREADING FEATURES
+  //==============================================================================
+
+  /**
+   * @brief Acquire exclusive lock for extended operations.
+   * @param timeout_ms Maximum time to wait for lock
+   * @return true if lock acquired
+   */
+  bool Lock(uint32_t timeout_ms = UINT32_MAX) noexcept;
+
+  /**
+   * @brief Release exclusive lock.
+   * @return true if lock released successfully
+   */
+  bool Unlock() noexcept;
+
+  /**
+   * @brief Acquire shared lock for concurrent reads.
+   * @param timeout_ms Maximum time to wait for lock
+   * @return true if shared lock acquired
+   */
+  bool LockShared(uint32_t timeout_ms = UINT32_MAX) noexcept;
+
+  /**
+   * @brief Release shared lock.
+   * @return true if shared lock released successfully
+   */
+  bool UnlockShared() noexcept;
+
+  //==============================================================================
+  // STATISTICS AND DIAGNOSTICS
+  //==============================================================================
+
+  /**
+   * @brief Threading statistics structure.
+   */
+  struct ThreadingStats {
+    std::atomic<uint64_t> total_operations{0};
+    std::atomic<uint64_t> lock_acquisitions{0};
+    std::atomic<uint64_t> lock_timeouts{0};
+    std::atomic<uint64_t> concurrent_reads{0};
+    std::atomic<uint64_t> exclusive_operations{0};
+    std::atomic<uint32_t> max_wait_time_us{0};
+    std::atomic<uint32_t> current_readers{0};
+  };
+
+  /**
+   * @brief Get threading statistics (atomic reads).
+   * @return Current threading statistics
+   */
+  ThreadingStats GetThreadingStats() const noexcept;
+
+  /**
+   * @brief Reset threading statistics.
+   */
+  void ResetThreadingStats() noexcept;
 
 private:
-    //==============================================================================
-    // PRIVATE MEMBERS
-    //==============================================================================
-    
-    std::unique_ptr<BaseAdc> adc_impl_;           ///< Wrapped ADC implementation
-    mutable std::shared_mutex rw_mutex_;          ///< Reader-writer mutex
-    std::atomic<bool> initialized_;               ///< Atomic initialization flag
-    std::chrono::milliseconds mutex_timeout_;     ///< Mutex acquisition timeout
-    mutable ThreadingStats stats_;                ///< Threading statistics
-    
-    //==============================================================================
-    // PRIVATE HELPER METHODS
-    //==============================================================================
-    
-    /**
-     * @brief Acquire exclusive lock with timeout and statistics.
-     */
-    bool AcquireExclusiveLock() noexcept;
-    
-    /**
-     * @brief Acquire shared lock with timeout and statistics.
-     */
-    bool AcquireSharedLock() const noexcept;
-    
-    /**
-     * @brief Update lock timing statistics.
-     */
-    void UpdateLockStats(const std::chrono::steady_clock::time_point& start_time) const noexcept;
-    
-    /**
-     * @brief Default mutex timeout (5 seconds).
-     */
-    static constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{5000};
+  //==============================================================================
+  // PRIVATE MEMBERS
+  //==============================================================================
+
+  std::unique_ptr<BaseAdc> adc_impl_;       ///< Wrapped ADC implementation
+  mutable std::shared_mutex rw_mutex_;      ///< Reader-writer mutex
+  std::atomic<bool> initialized_;           ///< Atomic initialization flag
+  std::chrono::milliseconds mutex_timeout_; ///< Mutex acquisition timeout
+  mutable ThreadingStats stats_;            ///< Threading statistics
+
+  //==============================================================================
+  // PRIVATE HELPER METHODS
+  //==============================================================================
+
+  /**
+   * @brief Acquire exclusive lock with timeout and statistics.
+   */
+  bool AcquireExclusiveLock() noexcept;
+
+  /**
+   * @brief Acquire shared lock with timeout and statistics.
+   */
+  bool AcquireSharedLock() const noexcept;
+
+  /**
+   * @brief Update lock timing statistics.
+   */
+  void UpdateLockStats(const std::chrono::steady_clock::time_point &start_time) const noexcept;
+
+  /**
+   * @brief Default mutex timeout (5 seconds).
+   */
+  static constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{5000};
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_SFADC_H_

--- a/inc/thread_safe/SfCan.h
+++ b/inc/thread_safe/SfCan.h
@@ -24,12 +24,12 @@
 
 #include "BaseCan.h"
 #include "McuTypes.h"
-#include <memory>
-#include <shared_mutex>
 #include <atomic>
 #include <chrono>
-#include <vector>
 #include <cstdint>
+#include <memory>
+#include <shared_mutex>
+#include <vector>
 
 /**
  * @class SfCan
@@ -46,22 +46,22 @@
  * config.baud_rate = 500000;
  * config.tx_pin = GPIO_CAN_TX;
  * config.rx_pin = GPIO_CAN_RX;
- * 
+ *
  * SfCan sf_can(std::make_unique<McuCan>(config));
  * if (sf_can.Initialize()) {
  *     sf_can.Start();
- *     
+ *
  *     hf_can_message_t msg{};
  *     msg.id = 0x123;
  *     msg.dlc = 8;
  *     // ... fill msg.data
- *     
+ *
  *     // Blocking send
  *     sf_can.SendMessageBlocking(msg);
- *     
+ *
  *     // Non-blocking send
  *     sf_can.SendMessageNonBlocking(msg);
- *     
+ *
  *     // Batch send multiple messages
  *     std::vector<hf_can_message_t> messages = { msg1, msg2, msg3 };
  *     sf_can.SendMultipleMessages(messages);
@@ -70,282 +70,285 @@
  */
 class SfCan {
 public:
-    /**
-     * @brief Threading statistics structure.
-     */
-    struct ThreadingStats {
-        uint64_t lock_contentions = 0;         ///< Number of lock timeouts/contentions
-        uint64_t total_operations = 0;         ///< Total number of operations
-        uint64_t total_lock_time_us = 0;       ///< Total time spent acquiring locks (microseconds)
-        uint64_t average_lock_time_us = 0;     ///< Average lock acquisition time (microseconds)
-        uint64_t max_lock_time_us = 0;         ///< Maximum lock acquisition time (microseconds)
-    };
+  /**
+   * @brief Threading statistics structure.
+   */
+  struct ThreadingStats {
+    uint64_t lock_contentions = 0;     ///< Number of lock timeouts/contentions
+    uint64_t total_operations = 0;     ///< Total number of operations
+    uint64_t total_lock_time_us = 0;   ///< Total time spent acquiring locks (microseconds)
+    uint64_t average_lock_time_us = 0; ///< Average lock acquisition time (microseconds)
+    uint64_t max_lock_time_us = 0;     ///< Maximum lock acquisition time (microseconds)
+  };
 
-    /**
-     * @brief Construct a new SfCan object with BaseCan implementation.
-     * 
-     * @param can_impl Unique pointer to BaseCan implementation (McuCan, etc.)
-     */
-    explicit SfCan(std::unique_ptr<BaseCan> can_impl) noexcept;
-    
-    /**
-     * @brief Destroy the SfCan object.
-     * 
-     * Ensures proper cleanup of CAN interface and releases locks.
-     */
-    ~SfCan() noexcept;
-    
-    // Non-copyable and non-movable for thread safety
-    SfCan(const SfCan&) = delete;
-    SfCan& operator=(const SfCan&) = delete;
-    SfCan(SfCan&&) = delete;
-    SfCan& operator=(SfCan&&) = delete;
-    
-    //==============================================================================
-    // CONFIGURATION AND CONTROL
-    //==============================================================================
-    
-    /**
-     * @brief Set the mutex timeout for lock acquisition.
-     * 
-     * @param timeout Timeout duration for mutex operations
-     */
-    void SetMutexTimeout(std::chrono::milliseconds timeout) noexcept;
-    
-    /**
-     * @brief Get the current mutex timeout.
-     * 
-     * @return Current mutex timeout duration
-     */
-    std::chrono::milliseconds GetMutexTimeout() const noexcept;
-    
-    //==============================================================================
-    // INITIALIZATION AND CONTROL
-    //==============================================================================
-    
-    /**
-     * @brief Initialize the CAN interface.
-     * 
-     * @return True if initialization successful, false otherwise
-     */
-    bool Initialize() noexcept;
-    
-    /**
-     * @brief Deinitialize the CAN interface.
-     * 
-     * @return True if deinitialization successful, false otherwise
-     */
-    bool Deinitialize() noexcept;
-    
-    /**
-     * @brief Start CAN communication.
-     * 
-     * @return True if start successful, false otherwise
-     */
-    bool Start() noexcept;
-    
-    /**
-     * @brief Stop CAN communication.
-     * 
-     * @return True if stop successful, false otherwise
-     */
-    bool Stop() noexcept;
-    
-    //==============================================================================
-    // MESSAGE TRANSMISSION AND RECEPTION
-    //==============================================================================
-    
-    /**
-     * @brief Send a CAN message with specified timeout.
-     * 
-     * @param message CAN message to send
-     * @param timeout_ms Timeout in milliseconds
-     * @return True if message sent successfully, false otherwise
-     */
-    bool SendMessage(const hf_can_message_t& message, uint32_t timeout_ms = 1000) noexcept;
-    
-    /**
-     * @brief Receive a CAN message with specified timeout.
-     * 
-     * @param message Reference to store received message
-     * @param timeout_ms Timeout in milliseconds
-     * @return True if message received successfully, false otherwise
-     */
-    bool ReceiveMessage(hf_can_message_t& message, uint32_t timeout_ms = 1000) noexcept;
-    
-    //==============================================================================
-    // CONVENIENCE METHODS
-    //==============================================================================
-    
-    /**
-     * @brief Send a message with no blocking (timeout = 0).
-     * 
-     * @param message CAN message to send
-     * @return True if message sent immediately, false if queue full
-     */
-    bool SendMessageNonBlocking(const hf_can_message_t& message) noexcept;
-    
-    /**
-     * @brief Send a message with infinite blocking (timeout = MAX).
-     * 
-     * @param message CAN message to send
-     * @return True if message sent successfully, false on error
-     */
-    bool SendMessageBlocking(const hf_can_message_t& message) noexcept;
-    
-    /**
-     * @brief Receive a message with no blocking (timeout = 0).
-     * 
-     * @param message Reference to store received message
-     * @return True if message received immediately, false if queue empty
-     */
-    bool ReceiveMessageNonBlocking(hf_can_message_t& message) noexcept;
-    
-    /**
-     * @brief Receive a message with infinite blocking (timeout = MAX).
-     * 
-     * @param message Reference to store received message
-     * @return True if message received successfully, false on error
-     */
-    bool ReceiveMessageBlocking(hf_can_message_t& message) noexcept;
-    
-    //==============================================================================
-    // BATCH OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Send multiple messages with single lock acquisition.
-     * 
-     * @param messages Vector of messages to send
-     * @param timeout_ms Timeout per message in milliseconds
-     * @return True if all messages sent successfully, false on first failure
-     */
-    bool SendMultipleMessages(const std::vector<hf_can_message_t>& messages, uint32_t timeout_ms = 1000) noexcept;
-    
-    /**
-     * @brief Send multiple messages with partial success allowed.
-     * 
-     * @param messages Vector of messages to send
-     * @param timeout_ms Timeout per message in milliseconds
-     * @return Number of messages successfully sent
-     */
-    size_t SendMultipleMessagesPartial(const std::vector<hf_can_message_t>& messages, uint32_t timeout_ms = 1000) noexcept;
-    
-    //==============================================================================
-    // CALLBACK MANAGEMENT
-    //==============================================================================
-    
-    /**
-     * @brief Set receive callback function.
-     * 
-     * @param callback Callback function to call on message reception
-     * @return True if callback set successfully, false otherwise
-     */
-    bool SetReceiveCallback(CanReceiveCallback callback) noexcept;
-    
-    /**
-     * @brief Clear the receive callback.
-     */
-    void ClearReceiveCallback() noexcept;
-    
-    //==============================================================================
-    // STATUS AND DIAGNOSTICS
-    //==============================================================================
-    
-    /**
-     * @brief Get current CAN bus status.
-     * 
-     * @param status Reference to store status information
-     * @return True if status retrieved successfully, false otherwise
-     */
-    bool GetStatus(CanBusStatus& status) noexcept;
-    
-    /**
-     * @brief Reset the CAN interface.
-     * 
-     * @return True if reset successful, false otherwise
-     */
-    bool Reset() noexcept;
-    
-    //==============================================================================
-    // LOCK-FREE READ OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Check if CAN interface is initialized (lock-free).
-     * 
-     * @return True if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept;
-    
-    /**
-     * @brief Check if transmit queue is full.
-     * 
-     * @return True if queue full, false otherwise
-     */
-    bool IsTransmitQueueFull() const noexcept;
-    
-    /**
-     * @brief Check if receive queue is empty.
-     * 
-     * @return True if queue empty, false otherwise
-     */
-    bool IsReceiveQueueEmpty() const noexcept;
-    
-    //==============================================================================
-    // ADVANCED THREADING FEATURES
-    //==============================================================================
-    
-    /**
-     * @brief Try to acquire exclusive lock without blocking.
-     * 
-     * @return True if lock acquired, false if already locked
-     */
-    bool TryLock() noexcept;
-    
-    /**
-     * @brief Acquire exclusive lock (blocking).
-     */
-    void Lock() noexcept;
-    
-    /**
-     * @brief Release exclusive lock.
-     */
-    void Unlock() noexcept;
-    
-    /**
-     * @brief Get threading performance statistics.
-     * 
-     * @return Current threading statistics
-     */
-    ThreadingStats GetThreadingStats() const noexcept;
-    
-    /**
-     * @brief Reset threading statistics to zero.
-     */
-    void ResetThreadingStats() noexcept;
-    
-    /**
-     * @brief Get the underlying BaseCan implementation.
-     * 
-     * @return Pointer to underlying implementation
-     */
-    const BaseCan* GetImplementation() const noexcept;
+  /**
+   * @brief Construct a new SfCan object with BaseCan implementation.
+   *
+   * @param can_impl Unique pointer to BaseCan implementation (McuCan, etc.)
+   */
+  explicit SfCan(std::unique_ptr<BaseCan> can_impl) noexcept;
+
+  /**
+   * @brief Destroy the SfCan object.
+   *
+   * Ensures proper cleanup of CAN interface and releases locks.
+   */
+  ~SfCan() noexcept;
+
+  // Non-copyable and non-movable for thread safety
+  SfCan(const SfCan &) = delete;
+  SfCan &operator=(const SfCan &) = delete;
+  SfCan(SfCan &&) = delete;
+  SfCan &operator=(SfCan &&) = delete;
+
+  //==============================================================================
+  // CONFIGURATION AND CONTROL
+  //==============================================================================
+
+  /**
+   * @brief Set the mutex timeout for lock acquisition.
+   *
+   * @param timeout Timeout duration for mutex operations
+   */
+  void SetMutexTimeout(std::chrono::milliseconds timeout) noexcept;
+
+  /**
+   * @brief Get the current mutex timeout.
+   *
+   * @return Current mutex timeout duration
+   */
+  std::chrono::milliseconds GetMutexTimeout() const noexcept;
+
+  //==============================================================================
+  // INITIALIZATION AND CONTROL
+  //==============================================================================
+
+  /**
+   * @brief Initialize the CAN interface.
+   *
+   * @return True if initialization successful, false otherwise
+   */
+  bool Initialize() noexcept;
+
+  /**
+   * @brief Deinitialize the CAN interface.
+   *
+   * @return True if deinitialization successful, false otherwise
+   */
+  bool Deinitialize() noexcept;
+
+  /**
+   * @brief Start CAN communication.
+   *
+   * @return True if start successful, false otherwise
+   */
+  bool Start() noexcept;
+
+  /**
+   * @brief Stop CAN communication.
+   *
+   * @return True if stop successful, false otherwise
+   */
+  bool Stop() noexcept;
+
+  //==============================================================================
+  // MESSAGE TRANSMISSION AND RECEPTION
+  //==============================================================================
+
+  /**
+   * @brief Send a CAN message with specified timeout.
+   *
+   * @param message CAN message to send
+   * @param timeout_ms Timeout in milliseconds
+   * @return True if message sent successfully, false otherwise
+   */
+  bool SendMessage(const hf_can_message_t &message, uint32_t timeout_ms = 1000) noexcept;
+
+  /**
+   * @brief Receive a CAN message with specified timeout.
+   *
+   * @param message Reference to store received message
+   * @param timeout_ms Timeout in milliseconds
+   * @return True if message received successfully, false otherwise
+   */
+  bool ReceiveMessage(hf_can_message_t &message, uint32_t timeout_ms = 1000) noexcept;
+
+  //==============================================================================
+  // CONVENIENCE METHODS
+  //==============================================================================
+
+  /**
+   * @brief Send a message with no blocking (timeout = 0).
+   *
+   * @param message CAN message to send
+   * @return True if message sent immediately, false if queue full
+   */
+  bool SendMessageNonBlocking(const hf_can_message_t &message) noexcept;
+
+  /**
+   * @brief Send a message with infinite blocking (timeout = MAX).
+   *
+   * @param message CAN message to send
+   * @return True if message sent successfully, false on error
+   */
+  bool SendMessageBlocking(const hf_can_message_t &message) noexcept;
+
+  /**
+   * @brief Receive a message with no blocking (timeout = 0).
+   *
+   * @param message Reference to store received message
+   * @return True if message received immediately, false if queue empty
+   */
+  bool ReceiveMessageNonBlocking(hf_can_message_t &message) noexcept;
+
+  /**
+   * @brief Receive a message with infinite blocking (timeout = MAX).
+   *
+   * @param message Reference to store received message
+   * @return True if message received successfully, false on error
+   */
+  bool ReceiveMessageBlocking(hf_can_message_t &message) noexcept;
+
+  //==============================================================================
+  // BATCH OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Send multiple messages with single lock acquisition.
+   *
+   * @param messages Vector of messages to send
+   * @param timeout_ms Timeout per message in milliseconds
+   * @return True if all messages sent successfully, false on first failure
+   */
+  bool SendMultipleMessages(const std::vector<hf_can_message_t> &messages,
+                            uint32_t timeout_ms = 1000) noexcept;
+
+  /**
+   * @brief Send multiple messages with partial success allowed.
+   *
+   * @param messages Vector of messages to send
+   * @param timeout_ms Timeout per message in milliseconds
+   * @return Number of messages successfully sent
+   */
+  size_t SendMultipleMessagesPartial(const std::vector<hf_can_message_t> &messages,
+                                     uint32_t timeout_ms = 1000) noexcept;
+
+  //==============================================================================
+  // CALLBACK MANAGEMENT
+  //==============================================================================
+
+  /**
+   * @brief Set receive callback function.
+   *
+   * @param callback Callback function to call on message reception
+   * @return True if callback set successfully, false otherwise
+   */
+  bool SetReceiveCallback(CanReceiveCallback callback) noexcept;
+
+  /**
+   * @brief Clear the receive callback.
+   */
+  void ClearReceiveCallback() noexcept;
+
+  //==============================================================================
+  // STATUS AND DIAGNOSTICS
+  //==============================================================================
+
+  /**
+   * @brief Get current CAN bus status.
+   *
+   * @param status Reference to store status information
+   * @return True if status retrieved successfully, false otherwise
+   */
+  bool GetStatus(CanBusStatus &status) noexcept;
+
+  /**
+   * @brief Reset the CAN interface.
+   *
+   * @return True if reset successful, false otherwise
+   */
+  bool Reset() noexcept;
+
+  //==============================================================================
+  // LOCK-FREE READ OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Check if CAN interface is initialized (lock-free).
+   *
+   * @return True if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept;
+
+  /**
+   * @brief Check if transmit queue is full.
+   *
+   * @return True if queue full, false otherwise
+   */
+  bool IsTransmitQueueFull() const noexcept;
+
+  /**
+   * @brief Check if receive queue is empty.
+   *
+   * @return True if queue empty, false otherwise
+   */
+  bool IsReceiveQueueEmpty() const noexcept;
+
+  //==============================================================================
+  // ADVANCED THREADING FEATURES
+  //==============================================================================
+
+  /**
+   * @brief Try to acquire exclusive lock without blocking.
+   *
+   * @return True if lock acquired, false if already locked
+   */
+  bool TryLock() noexcept;
+
+  /**
+   * @brief Acquire exclusive lock (blocking).
+   */
+  void Lock() noexcept;
+
+  /**
+   * @brief Release exclusive lock.
+   */
+  void Unlock() noexcept;
+
+  /**
+   * @brief Get threading performance statistics.
+   *
+   * @return Current threading statistics
+   */
+  ThreadingStats GetThreadingStats() const noexcept;
+
+  /**
+   * @brief Reset threading statistics to zero.
+   */
+  void ResetThreadingStats() noexcept;
+
+  /**
+   * @brief Get the underlying BaseCan implementation.
+   *
+   * @return Pointer to underlying implementation
+   */
+  const BaseCan *GetImplementation() const noexcept;
 
 private:
-    std::unique_ptr<BaseCan> can_impl_;             ///< Underlying CAN implementation
-    std::atomic<bool> initialized_;                 ///< Lock-free initialization flag
-    mutable std::shared_mutex rw_mutex_;            ///< Reader-writer mutex for thread safety
-    std::chrono::milliseconds mutex_timeout_;       ///< Timeout for mutex operations
-    mutable ThreadingStats stats_;                  ///< Threading performance statistics
-    
-    /**
-     * @brief Update threading statistics.
-     * 
-     * @param start_time Start time of the operation
-     * @param was_timeout Whether the operation timed out
-     */
-    void UpdateStats(const std::chrono::steady_clock::time_point& start_time, bool was_timeout) noexcept;
+  std::unique_ptr<BaseCan> can_impl_;       ///< Underlying CAN implementation
+  std::atomic<bool> initialized_;           ///< Lock-free initialization flag
+  mutable std::shared_mutex rw_mutex_;      ///< Reader-writer mutex for thread safety
+  std::chrono::milliseconds mutex_timeout_; ///< Timeout for mutex operations
+  mutable ThreadingStats stats_;            ///< Threading performance statistics
+
+  /**
+   * @brief Update threading statistics.
+   *
+   * @param start_time Start time of the operation
+   * @param was_timeout Whether the operation timed out
+   */
+  void UpdateStats(const std::chrono::steady_clock::time_point &start_time,
+                   bool was_timeout) noexcept;
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_SFCAN_H_

--- a/inc/thread_safe/SfGpio.h
+++ b/inc/thread_safe/SfGpio.h
@@ -1,7 +1,7 @@
 /**
  * @file SfGpio.h
  * @brief Thread-safe GPIO interface wrapper.
- * 
+ *
  * This header provides a thread-safe wrapper around the base GPIO interface,
  * ensuring atomic operations and thread safety for multi-threaded applications.
  * Uses composition pattern with mutex protection.
@@ -21,192 +21,191 @@ namespace ThreadSafe {
 
 /**
  * @brief Thread-safe GPIO interface wrapper.
- * 
+ *
  * This class wraps any BaseGpio implementation with thread-safe operations
  * using mutex protection. All GPIO operations are atomic and safe for
  * concurrent access from multiple tasks/threads.
  */
 class SfGpio {
 public:
-    /**
-     * @brief Constructor with GPIO implementation.
-     * 
-     * @param gpio_impl Pointer to the base GPIO implementation to wrap
-     */
-    explicit SfGpio(std::shared_ptr<BaseGpio> gpio_impl);
-    
-    /**
-     * @brief Destructor.
-     */
-    virtual ~SfGpio();
-    
-    // Disable copy constructor and assignment operator
-    SfGpio(const SfGpio&) = delete;
-    SfGpio& operator=(const SfGpio&) = delete;
-    
-    // Enable move constructor and assignment operator
-    SfGpio(SfGpio&&) = default;
-    SfGpio& operator=(SfGpio&&) = default;
+  /**
+   * @brief Constructor with GPIO implementation.
+   *
+   * @param gpio_impl Pointer to the base GPIO implementation to wrap
+   */
+  explicit SfGpio(std::shared_ptr<BaseGpio> gpio_impl);
 
-    //==============================================================================
-    // THREAD-SAFE DIGITAL GPIO OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Set pin mode (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param mode Pin mode (input/output/etc)
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t setPinMode(hf_gpio_num_t pin, hf_gpio_mode_t mode);
-    
-    /**
-     * @brief Set pin pull mode (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param pull Pull mode (none/pullup/pulldown)
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t setPinPull(hf_gpio_num_t pin, hf_gpio_pull_t pull);
-    
-    /**
-     * @brief Set pin drive capability (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param drive_cap Drive capability level
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t setPinDriveCapability(hf_gpio_num_t pin, hf_gpio_drive_cap_t drive_cap);
-    
-    /**
-     * @brief Set digital output level (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param level Output level (true=high, false=low)
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t digitalWrite(hf_gpio_num_t pin, bool level);
-    
-    /**
-     * @brief Read digital input level (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param level Pointer to store the read level
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t digitalRead(hf_gpio_num_t pin, bool* level);
-    
-    /**
-     * @brief Toggle digital output level (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t digitalToggle(hf_gpio_num_t pin);
-    
-    //==============================================================================
-    // THREAD-SAFE MULTI-PIN OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Set multiple pins simultaneously (thread-safe).
-     * 
-     * @param pin_mask Bitmask of pins to set
-     * @param level_mask Bitmask of levels for each pin
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t writeMultiple(hf_gpio_mask_t pin_mask, hf_gpio_mask_t level_mask);
-    
-    /**
-     * @brief Read multiple pins simultaneously (thread-safe).
-     * 
-     * @param pin_mask Bitmask of pins to read
-     * @param level_mask Pointer to store the read levels
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t readMultiple(hf_gpio_mask_t pin_mask, hf_gpio_mask_t* level_mask);
-    
-    //==============================================================================
-    // THREAD-SAFE INTERRUPT OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Enable interrupt for pin (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param intr_type Interrupt trigger type
-     * @param callback Interrupt callback function
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t enableInterrupt(hf_gpio_num_t pin, 
-                                    hf_gpio_intr_type_t intr_type,
-                                    BaseGpio::InterruptCallback callback);
-    
-    /**
-     * @brief Disable interrupt for pin (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t disableInterrupt(hf_gpio_num_t pin);
-    
-    //==============================================================================
-    // THREAD-SAFE STATUS OPERATIONS
-    //==============================================================================
-    
-    /**
-     * @brief Check if pin is valid (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @return bool true if pin is valid, false otherwise
-     */
-    bool isPinValid(hf_gpio_num_t pin);
-    
-    /**
-     * @brief Get pin mode (thread-safe).
-     * 
-     * @param pin GPIO pin number
-     * @param mode Pointer to store the current mode
-     * @return hf_return_code_t HF_OK on success, error code on failure
-     */
-    hf_return_code_t getPinMode(hf_gpio_num_t pin, hf_gpio_mode_t* mode);
-    
-    /**
-     * @brief Check if GPIO system is initialized (thread-safe).
-     * 
-     * @return bool true if initialized, false otherwise
-     */
-    bool isInitialized();
+  /**
+   * @brief Destructor.
+   */
+  virtual ~SfGpio();
+
+  // Disable copy constructor and assignment operator
+  SfGpio(const SfGpio &) = delete;
+  SfGpio &operator=(const SfGpio &) = delete;
+
+  // Enable move constructor and assignment operator
+  SfGpio(SfGpio &&) = default;
+  SfGpio &operator=(SfGpio &&) = default;
+
+  //==============================================================================
+  // THREAD-SAFE DIGITAL GPIO OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Set pin mode (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param mode Pin mode (input/output/etc)
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t setPinMode(hf_gpio_num_t pin, hf_gpio_mode_t mode);
+
+  /**
+   * @brief Set pin pull mode (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param pull Pull mode (none/pullup/pulldown)
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t setPinPull(hf_gpio_num_t pin, hf_gpio_pull_t pull);
+
+  /**
+   * @brief Set pin drive capability (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param drive_cap Drive capability level
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t setPinDriveCapability(hf_gpio_num_t pin, hf_gpio_drive_cap_t drive_cap);
+
+  /**
+   * @brief Set digital output level (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param level Output level (true=high, false=low)
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t digitalWrite(hf_gpio_num_t pin, bool level);
+
+  /**
+   * @brief Read digital input level (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param level Pointer to store the read level
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t digitalRead(hf_gpio_num_t pin, bool *level);
+
+  /**
+   * @brief Toggle digital output level (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t digitalToggle(hf_gpio_num_t pin);
+
+  //==============================================================================
+  // THREAD-SAFE MULTI-PIN OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Set multiple pins simultaneously (thread-safe).
+   *
+   * @param pin_mask Bitmask of pins to set
+   * @param level_mask Bitmask of levels for each pin
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t writeMultiple(hf_gpio_mask_t pin_mask, hf_gpio_mask_t level_mask);
+
+  /**
+   * @brief Read multiple pins simultaneously (thread-safe).
+   *
+   * @param pin_mask Bitmask of pins to read
+   * @param level_mask Pointer to store the read levels
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t readMultiple(hf_gpio_mask_t pin_mask, hf_gpio_mask_t *level_mask);
+
+  //==============================================================================
+  // THREAD-SAFE INTERRUPT OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Enable interrupt for pin (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param intr_type Interrupt trigger type
+   * @param callback Interrupt callback function
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t enableInterrupt(hf_gpio_num_t pin, hf_gpio_intr_type_t intr_type,
+                                   BaseGpio::InterruptCallback callback);
+
+  /**
+   * @brief Disable interrupt for pin (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t disableInterrupt(hf_gpio_num_t pin);
+
+  //==============================================================================
+  // THREAD-SAFE STATUS OPERATIONS
+  //==============================================================================
+
+  /**
+   * @brief Check if pin is valid (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @return bool true if pin is valid, false otherwise
+   */
+  bool isPinValid(hf_gpio_num_t pin);
+
+  /**
+   * @brief Get pin mode (thread-safe).
+   *
+   * @param pin GPIO pin number
+   * @param mode Pointer to store the current mode
+   * @return hf_return_code_t HF_OK on success, error code on failure
+   */
+  hf_return_code_t getPinMode(hf_gpio_num_t pin, hf_gpio_mode_t *mode);
+
+  /**
+   * @brief Check if GPIO system is initialized (thread-safe).
+   *
+   * @return bool true if initialized, false otherwise
+   */
+  bool isInitialized();
 
 private:
-    std::shared_ptr<BaseGpio> gpio_impl_;  ///< Wrapped GPIO implementation
-    SemaphoreHandle_t mutex_;              ///< Mutex for thread safety
-    
-    /**
-     * @brief Initialize mutex.
-     * 
-     * @return bool true on success, false on failure
-     */
-    bool initializeMutex();
-    
-    /**
-     * @brief Cleanup mutex.
-     */
-    void cleanupMutex();
-    
-    /**
-     * @brief Lock mutex with timeout.
-     * 
-     * @param timeout_ms Timeout in milliseconds
-     * @return bool true if locked, false on timeout
-     */
-    bool lockMutex(hf_timeout_ms_t timeout_ms = HF_TIMEOUT_DEFAULT);
-    
-    /**
-     * @brief Unlock mutex.
-     */
-    void unlockMutex();
+  std::shared_ptr<BaseGpio> gpio_impl_; ///< Wrapped GPIO implementation
+  SemaphoreHandle_t mutex_;             ///< Mutex for thread safety
+
+  /**
+   * @brief Initialize mutex.
+   *
+   * @return bool true on success, false on failure
+   */
+  bool initializeMutex();
+
+  /**
+   * @brief Cleanup mutex.
+   */
+  void cleanupMutex();
+
+  /**
+   * @brief Lock mutex with timeout.
+   *
+   * @param timeout_ms Timeout in milliseconds
+   * @return bool true if locked, false on timeout
+   */
+  bool lockMutex(hf_timeout_ms_t timeout_ms = HF_TIMEOUT_DEFAULT);
+
+  /**
+   * @brief Unlock mutex.
+   */
+  void unlockMutex();
 };
 
 } // namespace ThreadSafe

--- a/inc/thread_safe/SfI2cBus.h
+++ b/inc/thread_safe/SfI2cBus.h
@@ -25,12 +25,12 @@ public:
    * @brief Constructor for thread-safe I2C bus.
    * @param config I2C configuration
    */
-  explicit SfI2cBus(const I2cBusConfig& config) noexcept;
-  
+  explicit SfI2cBus(const I2cBusConfig &config) noexcept;
+
   ~SfI2cBus() noexcept;
-  
-  SfI2cBus(const SfI2cBus&) = delete;
-  SfI2cBus& operator=(const SfI2cBus&) = delete;
+
+  SfI2cBus(const SfI2cBus &) = delete;
+  SfI2cBus &operator=(const SfI2cBus &) = delete;
 
   /**
    * @brief Open and initialize the I2C port.
@@ -41,7 +41,7 @@ public:
    * @brief Close and de-initialize the I2C port.
    */
   bool Close() noexcept;
-  
+
   /**
    * @brief Write to a device in a thread-safe manner.
    */
@@ -51,14 +51,13 @@ public:
   /**
    * @brief Read from a device in a thread-safe manner.
    */
-  bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes,
-            uint32_t timeoutMsec = 1000) noexcept;
+  bool Read(uint8_t addr, uint8_t *data, uint16_t sizeBytes, uint32_t timeoutMsec = 1000) noexcept;
 
   /**
    * @brief Combined write then read operation.
    */
-  bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes, 
-                 uint8_t *rxData, uint16_t rxSizeBytes, uint32_t timeoutMsec = 1000) noexcept;
+  bool WriteRead(uint8_t addr, const uint8_t *txData, uint16_t txSizeBytes, uint8_t *rxData,
+                 uint16_t rxSizeBytes, uint32_t timeoutMsec = 1000) noexcept;
 
   /**
    * @brief Lock the bus for exclusive access.
@@ -69,7 +68,7 @@ public:
    * @brief Unlock the bus.
    */
   bool Unlock() noexcept;
-  
+
   /**
    * @brief Get the clock speed in Hz.
    */

--- a/inc/thread_safe/SfPwm.h
+++ b/inc/thread_safe/SfPwm.h
@@ -15,9 +15,9 @@
 #include "../base/BasePwm.h"
 #include "../mcu/McuPwm.h"
 #include "../mcu/McuTypes.h"
+#include <cstdint>
 #include <memory>
 #include <mutex>
-#include <cstdint>
 
 /**
  * @class SfPwm
@@ -39,7 +39,7 @@
  * @code
  * // Create thread-safe PWM interface
  * SfPwm sf_pwm(std::make_unique<McuPwm>());
- * 
+ *
  * if (sf_pwm.Initialize() == HfPwmErr::PWM_SUCCESS) {
  *     // Configure a PWM channel
  *     PwmChannelConfig config{};
@@ -47,10 +47,10 @@
  *     config.frequency_hz = 1000;
  *     config.resolution_bits = 12;
  *     config.initial_duty_cycle = 0.5f;
- *     
+ *
  *     sf_pwm.ConfigureChannel(0, config);
  *     sf_pwm.EnableChannel(0);
- *     
+ *
  *     // Change duty cycle from multiple threads safely
  *     sf_pwm.SetDutyCycle(0, 0.75f);
  * }
@@ -58,383 +58,393 @@
  */
 class SfPwm {
 public:
-    //==============================================================================
-    // TYPES
-    //==============================================================================
-    
-    /// Configuration for thread-safe PWM wrapper
-    struct Config {
-        uint32_t mutex_timeout_ms;          ///< Mutex acquisition timeout
-        bool enable_statistics;             ///< Enable performance statistics
-        
-        Config() noexcept
-            : mutex_timeout_ms(5000)  // 5 second default timeout
-            , enable_statistics(false)
-        {}
-    };
-    
-    /// Performance statistics (optional)
-    struct Statistics {
-        uint64_t total_operations;          ///< Total operations performed
-        uint64_t mutex_timeouts;            ///< Number of mutex timeouts
-        uint64_t average_lock_time_us;      ///< Average lock acquisition time
-        uint64_t max_lock_time_us;          ///< Maximum lock acquisition time
-        
-        Statistics() noexcept 
-            : total_operations(0), mutex_timeouts(0)
-            , average_lock_time_us(0), max_lock_time_us(0) 
-        {}
-    };
-    
-    //==============================================================================
-    // CONSTRUCTOR AND DESTRUCTOR
-    //==============================================================================
-    
-    /**
-     * @brief Constructor with PWM implementation
-     * @param pwm_impl PWM implementation (McuPwm, Pca9685Pwm, etc.)
-     * @param config Thread-safe wrapper configuration
-     */
-    explicit SfPwm(std::unique_ptr<BasePwm> pwm_impl, const Config& config = Config{}) noexcept;
-    
-    /**
-     * @brief Destructor - ensures clean shutdown with proper synchronization
-     */
-    ~SfPwm() noexcept;
-    
-    // Prevent copying and moving
-    SfPwm(const SfPwm&) = delete;
-    SfPwm& operator=(const SfPwm&) = delete;
-    SfPwm(SfPwm&&) = delete;
-    SfPwm& operator=(SfPwm&&) = delete;
-    
-    //==============================================================================
-    // LIFECYCLE
-    //==============================================================================
-    
-    /**
-     * @brief Initialize the PWM system (thread-safe)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr Initialize() noexcept;
-    
-    /**
-     * @brief Deinitialize the PWM system (thread-safe)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr Deinitialize() noexcept;
-    
-    /**
-     * @brief Check if PWM system is initialized (thread-safe)
-     * @return true if initialized, false otherwise
-     */
-    bool IsInitialized() const noexcept;
-    
-    //==============================================================================
-    // CHANNEL MANAGEMENT
-    //==============================================================================
-    
-    /**
-     * @brief Configure a PWM channel (thread-safe)
-     * @param channel_id Channel identifier (0-based)
-     * @param config Channel configuration
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr ConfigureChannel(uint8_t channel_id, const PwmChannelConfig& config, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Enable a PWM channel (thread-safe)
-     * @param channel_id Channel to enable
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr EnableChannel(uint8_t channel_id, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Disable a PWM channel (thread-safe)
-     * @param channel_id Channel to disable
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr DisableChannel(uint8_t channel_id, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Check if a channel is enabled (thread-safe)
-     * @param channel_id Channel to check
-     * @return true if enabled, false otherwise
-     */
-    bool IsChannelEnabled(uint8_t channel_id) const noexcept;
-    
-    //==============================================================================
-    // PWM CONTROL
-    //==============================================================================
-    
-    /**
-     * @brief Set duty cycle for a channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @param duty_cycle Duty cycle (0.0 - 1.0)
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetDutyCycle(uint8_t channel_id, float duty_cycle, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Set raw duty value for a channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @param raw_value Raw duty register value
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetDutyCycleRaw(uint8_t channel_id, uint32_t raw_value, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Set frequency for a channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @param frequency_hz Frequency in Hz
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetFrequency(uint8_t channel_id, uint32_t frequency_hz, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Set phase shift for a channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @param phase_shift_degrees Phase shift in degrees (0-360)
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetPhaseShift(uint8_t channel_id, float phase_shift_degrees, uint32_t timeout_ms = 0) noexcept;
-    
-    //==============================================================================
-    // BULK OPERATIONS (OPTIMIZED FOR THREAD SAFETY)
-    //==============================================================================
-    
-    /**
-     * @brief Set duty cycles for multiple channels atomically
-     * @param channel_duties Array of {channel_id, duty_cycle} pairs
-     * @param count Number of pairs in the array
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    struct ChannelDuty {
-        uint8_t channel_id;
-        float duty_cycle;
-    };
-    HfPwmErr SetMultipleDutyCycles(const ChannelDuty* channel_duties, size_t count, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Enable multiple channels atomically
-     * @param channel_ids Array of channel IDs to enable
-     * @param count Number of channels in the array
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr EnableMultipleChannels(const uint8_t* channel_ids, size_t count, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Disable multiple channels atomically
-     * @param channel_ids Array of channel IDs to disable
-     * @param count Number of channels in the array
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr DisableMultipleChannels(const uint8_t* channel_ids, size_t count, uint32_t timeout_ms = 0) noexcept;
-    
-    //==============================================================================
-    // ADVANCED FEATURES
-    //==============================================================================
-    
-    /**
-     * @brief Start all enabled channels simultaneously (thread-safe)
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr StartAll(uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Stop all channels (thread-safe)
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr StopAll(uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Update all channel outputs simultaneously (thread-safe)
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr UpdateAll(uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Set complementary output configuration (thread-safe)
-     * @param primary_channel Primary channel
-     * @param complementary_channel Complementary channel
-     * @param deadtime_ns Deadtime in nanoseconds
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetComplementaryOutput(uint8_t primary_channel, 
-                                  uint8_t complementary_channel, 
-                                  uint32_t deadtime_ns,
+  //==============================================================================
+  // TYPES
+  //==============================================================================
+
+  /// Configuration for thread-safe PWM wrapper
+  struct Config {
+    uint32_t mutex_timeout_ms; ///< Mutex acquisition timeout
+    bool enable_statistics;    ///< Enable performance statistics
+
+    Config() noexcept
+        : mutex_timeout_ms(5000) // 5 second default timeout
+          ,
+          enable_statistics(false) {}
+  };
+
+  /// Performance statistics (optional)
+  struct Statistics {
+    uint64_t total_operations;     ///< Total operations performed
+    uint64_t mutex_timeouts;       ///< Number of mutex timeouts
+    uint64_t average_lock_time_us; ///< Average lock acquisition time
+    uint64_t max_lock_time_us;     ///< Maximum lock acquisition time
+
+    Statistics() noexcept
+        : total_operations(0), mutex_timeouts(0), average_lock_time_us(0), max_lock_time_us(0) {}
+  };
+
+  //==============================================================================
+  // CONSTRUCTOR AND DESTRUCTOR
+  //==============================================================================
+
+  /**
+   * @brief Constructor with PWM implementation
+   * @param pwm_impl PWM implementation (McuPwm, Pca9685Pwm, etc.)
+   * @param config Thread-safe wrapper configuration
+   */
+  explicit SfPwm(std::unique_ptr<BasePwm> pwm_impl, const Config &config = Config{}) noexcept;
+
+  /**
+   * @brief Destructor - ensures clean shutdown with proper synchronization
+   */
+  ~SfPwm() noexcept;
+
+  // Prevent copying and moving
+  SfPwm(const SfPwm &) = delete;
+  SfPwm &operator=(const SfPwm &) = delete;
+  SfPwm(SfPwm &&) = delete;
+  SfPwm &operator=(SfPwm &&) = delete;
+
+  //==============================================================================
+  // LIFECYCLE
+  //==============================================================================
+
+  /**
+   * @brief Initialize the PWM system (thread-safe)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr Initialize() noexcept;
+
+  /**
+   * @brief Deinitialize the PWM system (thread-safe)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr Deinitialize() noexcept;
+
+  /**
+   * @brief Check if PWM system is initialized (thread-safe)
+   * @return true if initialized, false otherwise
+   */
+  bool IsInitialized() const noexcept;
+
+  //==============================================================================
+  // CHANNEL MANAGEMENT
+  //==============================================================================
+
+  /**
+   * @brief Configure a PWM channel (thread-safe)
+   * @param channel_id Channel identifier (0-based)
+   * @param config Channel configuration
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr ConfigureChannel(uint8_t channel_id, const PwmChannelConfig &config,
+                            uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Enable a PWM channel (thread-safe)
+   * @param channel_id Channel to enable
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr EnableChannel(uint8_t channel_id, uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Disable a PWM channel (thread-safe)
+   * @param channel_id Channel to disable
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr DisableChannel(uint8_t channel_id, uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Check if a channel is enabled (thread-safe)
+   * @param channel_id Channel to check
+   * @return true if enabled, false otherwise
+   */
+  bool IsChannelEnabled(uint8_t channel_id) const noexcept;
+
+  //==============================================================================
+  // PWM CONTROL
+  //==============================================================================
+
+  /**
+   * @brief Set duty cycle for a channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @param duty_cycle Duty cycle (0.0 - 1.0)
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetDutyCycle(uint8_t channel_id, float duty_cycle, uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Set raw duty value for a channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @param raw_value Raw duty register value
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetDutyCycleRaw(uint8_t channel_id, uint32_t raw_value,
+                           uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Set frequency for a channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @param frequency_hz Frequency in Hz
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetFrequency(uint8_t channel_id, uint32_t frequency_hz,
+                        uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Set phase shift for a channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @param phase_shift_degrees Phase shift in degrees (0-360)
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetPhaseShift(uint8_t channel_id, float phase_shift_degrees,
+                         uint32_t timeout_ms = 0) noexcept;
+
+  //==============================================================================
+  // BULK OPERATIONS (OPTIMIZED FOR THREAD SAFETY)
+  //==============================================================================
+
+  /**
+   * @brief Set duty cycles for multiple channels atomically
+   * @param channel_duties Array of {channel_id, duty_cycle} pairs
+   * @param count Number of pairs in the array
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  struct ChannelDuty {
+    uint8_t channel_id;
+    float duty_cycle;
+  };
+  HfPwmErr SetMultipleDutyCycles(const ChannelDuty *channel_duties, size_t count,
+                                 uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Enable multiple channels atomically
+   * @param channel_ids Array of channel IDs to enable
+   * @param count Number of channels in the array
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr EnableMultipleChannels(const uint8_t *channel_ids, size_t count,
                                   uint32_t timeout_ms = 0) noexcept;
-    
-    //==============================================================================
-    // STATUS AND INFORMATION
-    //==============================================================================
-    
-    /**
-     * @brief Get current duty cycle for a channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @return Current duty cycle (0.0 - 1.0), or -1.0 on error
-     */
-    float GetDutyCycle(uint8_t channel_id) const noexcept;
-    
-    /**
-     * @brief Get current frequency for a channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @return Current frequency in Hz, or 0 on error
-     */
-    uint32_t GetFrequency(uint8_t channel_id) const noexcept;
-    
-    /**
-     * @brief Get channel status (thread-safe)
-     * @param channel_id Channel identifier
-     * @param status Status structure to fill
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr GetChannelStatus(uint8_t channel_id, PwmChannelStatus& status, uint32_t timeout_ms = 0) const noexcept;
-    
-    /**
-     * @brief Get PWM implementation capabilities (thread-safe)
-     * @param capabilities Capabilities structure to fill
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr GetCapabilities(PwmCapabilities& capabilities) const noexcept;
-    
-    /**
-     * @brief Get last error for a specific channel (thread-safe)
-     * @param channel_id Channel identifier
-     * @return Last error code for the channel
-     */
-    HfPwmErr GetLastError(uint8_t channel_id) const noexcept;
-    
-    //==============================================================================
-    // THREAD-SAFE CALLBACK MANAGEMENT
-    //==============================================================================
-    
-    /**
-     * @brief Set period complete callback (thread-safe)
-     * @param callback Callback function
-     * @param user_data User data passed to callback
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetPeriodCallback(PwmPeriodCallback callback, void* user_data = nullptr, uint32_t timeout_ms = 0) noexcept;
-    
-    /**
-     * @brief Set fault/error callback (thread-safe)
-     * @param callback Callback function
-     * @param user_data User data passed to callback
-     * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr SetFaultCallback(PwmFaultCallback callback, void* user_data = nullptr, uint32_t timeout_ms = 0) noexcept;
-    
-    //==============================================================================
-    // THREAD SAFETY AND DIAGNOSTICS
-    //==============================================================================
-    
-    /**
-     * @brief Try to acquire exclusive access (non-blocking)
-     * @return true if lock acquired, false if already locked
-     */
-    bool TryLock() noexcept;
-    
-    /**
-     * @brief Acquire exclusive access (blocking with timeout)
-     * @param timeout_ms Timeout in milliseconds
-     * @return true if lock acquired, false on timeout
-     */
-    bool Lock(uint32_t timeout_ms) noexcept;
-    
-    /**
-     * @brief Release exclusive access
-     */
-    void Unlock() noexcept;
-    
-    /**
-     * @brief Get performance statistics (if enabled)
-     * @param stats Statistics structure to fill
-     * @return PWM_SUCCESS on success, error code on failure
-     */
-    HfPwmErr GetStatistics(Statistics& stats) const noexcept;
-    
-    /**
-     * @brief Reset performance statistics
-     */
-    void ResetStatistics() noexcept;
-    
-    /**
-     * @brief Get underlying PWM implementation (thread-safe access)
-     * @note Use with extreme caution - direct access bypasses thread safety
-     * @return Pointer to underlying PWM implementation, or nullptr if locked
-     */
-    BasePwm* GetUnsafeDirectAccess() const noexcept;
+
+  /**
+   * @brief Disable multiple channels atomically
+   * @param channel_ids Array of channel IDs to disable
+   * @param count Number of channels in the array
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr DisableMultipleChannels(const uint8_t *channel_ids, size_t count,
+                                   uint32_t timeout_ms = 0) noexcept;
+
+  //==============================================================================
+  // ADVANCED FEATURES
+  //==============================================================================
+
+  /**
+   * @brief Start all enabled channels simultaneously (thread-safe)
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr StartAll(uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Stop all channels (thread-safe)
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr StopAll(uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Update all channel outputs simultaneously (thread-safe)
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr UpdateAll(uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Set complementary output configuration (thread-safe)
+   * @param primary_channel Primary channel
+   * @param complementary_channel Complementary channel
+   * @param deadtime_ns Deadtime in nanoseconds
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetComplementaryOutput(uint8_t primary_channel, uint8_t complementary_channel,
+                                  uint32_t deadtime_ns, uint32_t timeout_ms = 0) noexcept;
+
+  //==============================================================================
+  // STATUS AND INFORMATION
+  //==============================================================================
+
+  /**
+   * @brief Get current duty cycle for a channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @return Current duty cycle (0.0 - 1.0), or -1.0 on error
+   */
+  float GetDutyCycle(uint8_t channel_id) const noexcept;
+
+  /**
+   * @brief Get current frequency for a channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @return Current frequency in Hz, or 0 on error
+   */
+  uint32_t GetFrequency(uint8_t channel_id) const noexcept;
+
+  /**
+   * @brief Get channel status (thread-safe)
+   * @param channel_id Channel identifier
+   * @param status Status structure to fill
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr GetChannelStatus(uint8_t channel_id, PwmChannelStatus &status,
+                            uint32_t timeout_ms = 0) const noexcept;
+
+  /**
+   * @brief Get PWM implementation capabilities (thread-safe)
+   * @param capabilities Capabilities structure to fill
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr GetCapabilities(PwmCapabilities &capabilities) const noexcept;
+
+  /**
+   * @brief Get last error for a specific channel (thread-safe)
+   * @param channel_id Channel identifier
+   * @return Last error code for the channel
+   */
+  HfPwmErr GetLastError(uint8_t channel_id) const noexcept;
+
+  //==============================================================================
+  // THREAD-SAFE CALLBACK MANAGEMENT
+  //==============================================================================
+
+  /**
+   * @brief Set period complete callback (thread-safe)
+   * @param callback Callback function
+   * @param user_data User data passed to callback
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetPeriodCallback(PwmPeriodCallback callback, void *user_data = nullptr,
+                             uint32_t timeout_ms = 0) noexcept;
+
+  /**
+   * @brief Set fault/error callback (thread-safe)
+   * @param callback Callback function
+   * @param user_data User data passed to callback
+   * @param timeout_ms Mutex timeout in milliseconds (0 = use default)
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr SetFaultCallback(PwmFaultCallback callback, void *user_data = nullptr,
+                            uint32_t timeout_ms = 0) noexcept;
+
+  //==============================================================================
+  // THREAD SAFETY AND DIAGNOSTICS
+  //==============================================================================
+
+  /**
+   * @brief Try to acquire exclusive access (non-blocking)
+   * @return true if lock acquired, false if already locked
+   */
+  bool TryLock() noexcept;
+
+  /**
+   * @brief Acquire exclusive access (blocking with timeout)
+   * @param timeout_ms Timeout in milliseconds
+   * @return true if lock acquired, false on timeout
+   */
+  bool Lock(uint32_t timeout_ms) noexcept;
+
+  /**
+   * @brief Release exclusive access
+   */
+  void Unlock() noexcept;
+
+  /**
+   * @brief Get performance statistics (if enabled)
+   * @param stats Statistics structure to fill
+   * @return PWM_SUCCESS on success, error code on failure
+   */
+  HfPwmErr GetStatistics(Statistics &stats) const noexcept;
+
+  /**
+   * @brief Reset performance statistics
+   */
+  void ResetStatistics() noexcept;
+
+  /**
+   * @brief Get underlying PWM implementation (thread-safe access)
+   * @note Use with extreme caution - direct access bypasses thread safety
+   * @return Pointer to underlying PWM implementation, or nullptr if locked
+   */
+  BasePwm *GetUnsafeDirectAccess() const noexcept;
 
 private:
-    //==============================================================================
-    // INTERNAL METHODS
-    //==============================================================================
-    
-    /**
-     * @brief Get effective timeout (use default if 0 specified)
-     * @param timeout_ms Requested timeout
-     * @return Effective timeout to use
-     */
-    uint32_t GetEffectiveTimeout(uint32_t timeout_ms) const noexcept;
-    
-    /**
-     * @brief Record operation statistics
-     * @param operation_time_us Time taken for operation
-     * @param lock_time_us Time taken to acquire lock
-     * @param timed_out Whether operation timed out
-     */
-    void RecordStatistics(uint64_t operation_time_us, uint64_t lock_time_us, bool timed_out) noexcept;
-    
-    /**
-     * @brief Scoped lock helper with timeout and statistics
-     */
-    class ScopedLock {
-    public:
-        ScopedLock(SfPwm* parent, uint32_t timeout_ms) noexcept;
-        ~ScopedLock() noexcept;
-        
-        bool IsLocked() const noexcept { return locked_; }
-        HfPwmErr GetError() const noexcept { return error_; }
-        
-    private:
-        SfPwm* parent_;
-        bool locked_;
-        HfPwmErr error_;
-        uint64_t start_time_us_;
-        uint64_t lock_acquired_time_us_;
-    };
-    
-    //==============================================================================
-    // MEMBER VARIABLES
-    //==============================================================================
-    
-    std::unique_ptr<BasePwm> pwm_impl_;         ///< Underlying PWM implementation
-    mutable std::timed_mutex mutex_;            ///< Thread safety mutex
-    Config config_;                             ///< Configuration
-    bool initialized_;                          ///< Initialization state
-    
-    // Statistics (protected by mutex)
-    mutable Statistics statistics_;             ///< Performance statistics
-    
-    static constexpr uint32_t DEFAULT_TIMEOUT_MS = 5000;  ///< Default mutex timeout
+  //==============================================================================
+  // INTERNAL METHODS
+  //==============================================================================
+
+  /**
+   * @brief Get effective timeout (use default if 0 specified)
+   * @param timeout_ms Requested timeout
+   * @return Effective timeout to use
+   */
+  uint32_t GetEffectiveTimeout(uint32_t timeout_ms) const noexcept;
+
+  /**
+   * @brief Record operation statistics
+   * @param operation_time_us Time taken for operation
+   * @param lock_time_us Time taken to acquire lock
+   * @param timed_out Whether operation timed out
+   */
+  void RecordStatistics(uint64_t operation_time_us, uint64_t lock_time_us, bool timed_out) noexcept;
+
+  /**
+   * @brief Scoped lock helper with timeout and statistics
+   */
+  class ScopedLock {
+  public:
+    ScopedLock(SfPwm *parent, uint32_t timeout_ms) noexcept;
+    ~ScopedLock() noexcept;
+
+    bool IsLocked() const noexcept {
+      return locked_;
+    }
+    HfPwmErr GetError() const noexcept {
+      return error_;
+    }
+
+  private:
+    SfPwm *parent_;
+    bool locked_;
+    HfPwmErr error_;
+    uint64_t start_time_us_;
+    uint64_t lock_acquired_time_us_;
+  };
+
+  //==============================================================================
+  // MEMBER VARIABLES
+  //==============================================================================
+
+  std::unique_ptr<BasePwm> pwm_impl_; ///< Underlying PWM implementation
+  mutable std::timed_mutex mutex_;    ///< Thread safety mutex
+  Config config_;                     ///< Configuration
+  bool initialized_;                  ///< Initialization state
+
+  // Statistics (protected by mutex)
+  mutable Statistics statistics_; ///< Performance statistics
+
+  static constexpr uint32_t DEFAULT_TIMEOUT_MS = 5000; ///< Default mutex timeout
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_SFPWM_H_

--- a/inc/thread_safe/SfSpiBus.h
+++ b/inc/thread_safe/SfSpiBus.h
@@ -120,9 +120,9 @@ public:
   }
 
 private:
-  std::unique_ptr<SpiBus> spi_bus_;        ///< Underlying SPI bus implementation
-  mutable std::mutex mutex_;              ///< Mutex for thread safety
-  bool initialized_;                      ///< Initialization state
+  std::unique_ptr<SpiBus> spi_bus_; ///< Underlying SPI bus implementation
+  mutable std::mutex mutex_;        ///< Mutex for thread safety
+  bool initialized_;                ///< Initialization state
 };
 
 #endif // SFSPIBUS_H_

--- a/inc/thread_safe/SfUartDriver.h
+++ b/inc/thread_safe/SfUartDriver.h
@@ -9,8 +9,8 @@
 #ifndef SFUARTDRIVER_H
 #define SFUARTDRIVER_H
 
-#include "../mcu/McuUartDriver.h"
 #include "../mcu/McuTypes.h"
+#include "../mcu/McuUartDriver.h"
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -36,10 +36,8 @@ public:
   bool Open() noexcept;
   bool Close() noexcept;
 
-  bool Write(const uint8_t *data, uint16_t length,
-             uint32_t timeoutMsec = 1000) noexcept;
-  bool Read(uint8_t *data, uint16_t length,
-            uint32_t timeoutMsec = UINT32_MAX) noexcept;
+  bool Write(const uint8_t *data, uint16_t length, uint32_t timeoutMsec = 1000) noexcept;
+  bool Read(uint8_t *data, uint16_t length, uint32_t timeoutMsec = UINT32_MAX) noexcept;
 
   bool Lock(uint32_t timeoutMsec = UINT32_MAX) noexcept;
   bool Unlock() noexcept;

--- a/inc/utils/DigitalOutputGuard.h
+++ b/inc/utils/DigitalOutputGuard.h
@@ -19,12 +19,13 @@
 #include "../base/BaseGpio.h"
 
 /**
- * @class DigitalOutputGuard * @brief RAII guard class for managing the state of a BaseGpio instance as output.
+ * @class DigitalOutputGuard * @brief RAII guard class for managing the state of a BaseGpio instance
+ * as output.
  *
  * The DigitalOutputGuard ensures that a BaseGpio instance is configured as output
- * and set active in its constructor, and set inactive in its destructor. This ensures 
+ * and set active in its constructor, and set inactive in its destructor. This ensures
  * proper resource management and consistent behavior using RAII principles.
- * 
+ *
  * Features:
  * - Automatic output mode configuration
  * - Safe state management with error handling
@@ -57,12 +58,12 @@ public:
   ~DigitalOutputGuard() noexcept;
 
   // Disable copy operations for safety
-  DigitalOutputGuard(const DigitalOutputGuard&) = delete;
-  DigitalOutputGuard& operator=(const DigitalOutputGuard&) = delete;
+  DigitalOutputGuard(const DigitalOutputGuard &) = delete;
+  DigitalOutputGuard &operator=(const DigitalOutputGuard &) = delete;
 
   // Allow move operations
-  DigitalOutputGuard(DigitalOutputGuard&&) noexcept = default;
-  DigitalOutputGuard& operator=(DigitalOutputGuard&&) noexcept = default;
+  DigitalOutputGuard(DigitalOutputGuard &&) noexcept = default;
+  DigitalOutputGuard &operator=(DigitalOutputGuard &&) noexcept = default;
 
   /**
    * @brief Check if the guard was successfully initialized.
@@ -70,13 +71,17 @@ public:
    * @details Returns false if there were errors during construction or if the GPIO
    *          pointer is invalid.
    */
-  [[nodiscard]] bool IsValid() const noexcept { return is_valid_; }
+  [[nodiscard]] bool IsValid() const noexcept {
+    return is_valid_;
+  }
 
   /**
    * @brief Get the last error that occurred during guard operations.
    * @return HfGpioErr error code from the last operation
    */
-  [[nodiscard]] HfGpioErr GetLastError() const noexcept { return last_error_; }
+  [[nodiscard]] HfGpioErr GetLastError() const noexcept {
+    return last_error_;
+  }
 
   /**
    * @brief Manually set the GPIO to active state.
@@ -101,11 +106,11 @@ public:
   [[nodiscard]] BaseGpio::State GetCurrentState() const noexcept;
 
 private:
-  BaseGpio* gpio_;                    ///< Pointer to the managed BaseGpio instance
-  bool was_output_mode_;                 ///< Whether the GPIO was already in output mode
-  bool is_valid_;                        ///< Whether the guard is in a valid state
-  HfGpioErr last_error_;                 ///< Last error code from operations
-  
+  BaseGpio *gpio_;       ///< Pointer to the managed BaseGpio instance
+  bool was_output_mode_; ///< Whether the GPIO was already in output mode
+  bool is_valid_;        ///< Whether the guard is in a valid state
+  HfGpioErr last_error_; ///< Last error code from operations
+
   /**
    * @brief Internal helper to initialize the guard state.
    * @param ensure_output_mode Whether to ensure output mode

--- a/src/mcu/McuAdc.cpp
+++ b/src/mcu/McuAdc.cpp
@@ -11,11 +11,11 @@
 
 // Platform-specific includes via McuSelect.h (no need for manual detection)
 #ifdef HF_MCU_ESP32C6
-    #include "esp_adc/adc_cali.h"
-    #include "esp_adc/adc_cali_scheme.h"
-    #include "esp_adc/adc_oneshot.h"
-    #include "esp_adc/adc_continuous.h"
-    #include <unistd.h>
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+#include "esp_adc/adc_continuous.h"
+#include "esp_adc/adc_oneshot.h"
+#include <unistd.h>
 #endif
 
 //==============================================================================
@@ -24,28 +24,26 @@
 
 #ifdef HF_MCU_ESP32C6
 McuAdc::McuAdc(hf_adc_unit_t adc_unit, uint32_t attenuation, hf_adc_resolution_t width)
-    : BaseAdc(), unit_(adc_unit), attenuation_(attenuation), bitwidth_(width),
-      adc_handle_(nullptr), cali_handle_(nullptr), cali_enable_(false), initialized_(false),
-      dma_buffer_(nullptr), adc_continuous_handle_(nullptr), dma_task_handle_(nullptr),
-      dma_mode_active_(false), active_callback_(nullptr), callback_user_data_(nullptr)
-{
-    // ESP32-C6 only supports ADC_UNIT_1, map generic unit to platform-specific
-    if (adc_unit != 1) {
-        unit_ = 1;  // Force to ADC1 for ESP32-C6
-    }
+    : BaseAdc(), unit_(adc_unit), attenuation_(attenuation), bitwidth_(width), adc_handle_(nullptr),
+      cali_handle_(nullptr), cali_enable_(false), initialized_(false), dma_buffer_(nullptr),
+      adc_continuous_handle_(nullptr), dma_task_handle_(nullptr), dma_mode_active_(false),
+      active_callback_(nullptr), callback_user_data_(nullptr) {
+  // ESP32-C6 only supports ADC_UNIT_1, map generic unit to platform-specific
+  if (adc_unit != 1) {
+    unit_ = 1; // Force to ADC1 for ESP32-C6
+  }
 }
 #else
 McuAdc::McuAdc(hf_adc_unit_t adc_unit, uint32_t attenuation, hf_adc_resolution_t width)
-    : BaseAdc(), unit_(adc_unit), attenuation_(attenuation), bitwidth_(width), initialized_(false)
-{
+    : BaseAdc(), unit_(adc_unit), attenuation_(attenuation), bitwidth_(width), initialized_(false) {
 }
 #endif
 
 McuAdc::~McuAdc() noexcept {
-    Deinitialize();
+  Deinitialize();
 #ifdef HF_MCU_FAMILY_ESP32
-    // Clean up DMA resources if still allocated
-    DeinitializeContinuousMode();
+  // Clean up DMA resources if still allocated
+  DeinitializeContinuousMode();
 #endif
 }
 
@@ -54,57 +52,57 @@ McuAdc::~McuAdc() noexcept {
 //==============================================================================
 
 bool McuAdc::Initialize() noexcept {
-    if (initialized_) {
-        return true;
-    }
+  if (initialized_) {
+    return true;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure ADC oneshot unit
-    adc_oneshot_unit_init_cfg_t init_config = {
-        .unit_id = static_cast<adc_unit_t>(unit_),  // Map hf_adc_unit_t to adc_unit_t
-        .clk_src = ADC_DIGI_CLK_SRC_DEFAULT,
-        .ulp_mode = ADC_ULP_MODE_DISABLE
-    };
-    
-    esp_err_t ret = adc_oneshot_new_unit(&init_config, reinterpret_cast<adc_oneshot_unit_handle_t*>(&adc_handle_));
-    if (ret != ESP_OK) {
-        return false;
-    }
+  // Configure ADC oneshot unit
+  adc_oneshot_unit_init_cfg_t init_config = {
+      .unit_id = static_cast<adc_unit_t>(unit_), // Map hf_adc_unit_t to adc_unit_t
+      .clk_src = ADC_DIGI_CLK_SRC_DEFAULT,
+      .ulp_mode = ADC_ULP_MODE_DISABLE};
 
-    // Initialize calibration
-    if (!InitializeCalibration()) {
-        adc_oneshot_del_unit(static_cast<adc_oneshot_unit_handle_t>(adc_handle_));
-        adc_handle_ = nullptr;
-        return false;
-    }
+  esp_err_t ret = adc_oneshot_new_unit(&init_config,
+                                       reinterpret_cast<adc_oneshot_unit_handle_t *>(&adc_handle_));
+  if (ret != ESP_OK) {
+    return false;
+  }
 
-    initialized_ = true;
-    return true;
+  // Initialize calibration
+  if (!InitializeCalibration()) {
+    adc_oneshot_del_unit(static_cast<adc_oneshot_unit_handle_t>(adc_handle_));
+    adc_handle_ = nullptr;
+    return false;
+  }
+
+  initialized_ = true;
+  return true;
 #else
-    // Add other MCU initialization here
-    initialized_ = true;
-    return true;
+  // Add other MCU initialization here
+  initialized_ = true;
+  return true;
 #endif
 }
 
 bool McuAdc::Deinitialize() noexcept {
-    if (!initialized_) {
-        return true;
-    }
+  if (!initialized_) {
+    return true;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    DeinitializeCalibration();
-    
-    if (adc_handle_) {
-        adc_oneshot_del_unit(adc_handle_);
-        adc_handle_ = nullptr;
-    }
-    
-    DeinitializeContinuousMode();
+  DeinitializeCalibration();
+
+  if (adc_handle_) {
+    adc_oneshot_del_unit(adc_handle_);
+    adc_handle_ = nullptr;
+  }
+
+  DeinitializeContinuousMode();
 #endif
 
-    initialized_ = false;
-    return true;
+  initialized_ = false;
+  return true;
 }
 
 //==============================================================================
@@ -113,30 +111,30 @@ bool McuAdc::Deinitialize() noexcept {
 
 uint8_t McuAdc::GetMaxChannels() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    return 7;  // ESP32-C6 ADC1 has channels 0-6
+  return 7; // ESP32-C6 ADC1 has channels 0-6
 #else
-    return 0;  // Unknown for other MCUs
+  return 0; // Unknown for other MCUs
 #endif
 }
 
 bool McuAdc::IsChannelAvailable(uint8_t channel_num) const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    return channel_num < GetMaxChannels();
+  return channel_num < GetMaxChannels();
 #else
-    return false;
+  return false;
 #endif
 }
 
 HfAdcErr McuAdc::ValidateChannel(uint8_t channel_num) const noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_INVALID_CHANNEL;
-    }
-    
-    if (!initialized_) {
-        return HfAdcErr::ADC_NOT_INITIALIZED;
-    }
-    
-    return HfAdcErr::ADC_OK;
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_INVALID_CHANNEL;
+  }
+
+  if (!initialized_) {
+    return HfAdcErr::ADC_NOT_INITIALIZED;
+  }
+
+  return HfAdcErr::ADC_OK;
 }
 
 //==============================================================================
@@ -144,93 +142,95 @@ HfAdcErr McuAdc::ValidateChannel(uint8_t channel_num) const noexcept {
 //==============================================================================
 
 HfAdcErr McuAdc::ReadChannelCount(uint8_t channel_num, uint32_t &channel_reading_count,
-                                 uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!initialized_) {
-        return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
-    }
+                                  uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
+  if (!initialized_) {
+    return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure the specific channel
-    adc_oneshot_chan_cfg_t config = {
-        .atten = static_cast<adc_atten_t>(attenuation_),
-        .bitwidth = static_cast<adc_bitwidth_t>(bitwidth_)
-    };
-    
-    adc_channel_t mcu_channel = GetMcuChannel(channel_num);
-    esp_err_t ret = adc_oneshot_config_channel(static_cast<adc_oneshot_unit_handle_t>(adc_handle_), mcu_channel, &config);
+  // Configure the specific channel
+  adc_oneshot_chan_cfg_t config = {.atten = static_cast<adc_atten_t>(attenuation_),
+                                   .bitwidth = static_cast<adc_bitwidth_t>(bitwidth_)};
+
+  adc_channel_t mcu_channel = GetMcuChannel(channel_num);
+  esp_err_t ret = adc_oneshot_config_channel(static_cast<adc_oneshot_unit_handle_t>(adc_handle_),
+                                             mcu_channel, &config);
+  if (ret != ESP_OK) {
+    return HfAdcErr::ADC_ERR_CHANNEL_READ_ERR;
+  }
+
+  // Perform averaged reading
+  uint64_t sum = 0;
+  for (uint8_t i = 0; i < numOfSamplesToAvg; ++i) {
+    int raw_value;
+    ret = adc_oneshot_read(static_cast<adc_oneshot_unit_handle_t>(adc_handle_), mcu_channel,
+                           &raw_value);
     if (ret != ESP_OK) {
-        return HfAdcErr::ADC_ERR_CHANNEL_READ_ERR;
+      return HfAdcErr::ADC_ERR_CHANNEL_READ_ERR;
     }
 
-    // Perform averaged reading
-    uint64_t sum = 0;
-    for (uint8_t i = 0; i < numOfSamplesToAvg; ++i) {
-        int raw_value;
-        ret = adc_oneshot_read(static_cast<adc_oneshot_unit_handle_t>(adc_handle_), mcu_channel, &raw_value);
-        if (ret != ESP_OK) {
-            return HfAdcErr::ADC_ERR_CHANNEL_READ_ERR;
-        }
-        
-        sum += static_cast<uint32_t>(raw_value);
-        
-        if (i < (numOfSamplesToAvg - 1) && timeBetweenSamples > 0) {
-            usleep(timeBetweenSamples);
-        }
-    }
+    sum += static_cast<uint32_t>(raw_value);
 
-    channel_reading_count = static_cast<uint32_t>(sum / numOfSamplesToAvg);
-    return HfAdcErr::ADC_SUCCESS;
+    if (i < (numOfSamplesToAvg - 1) && timeBetweenSamples > 0) {
+      usleep(timeBetweenSamples);
+    }
+  }
+
+  channel_reading_count = static_cast<uint32_t>(sum / numOfSamplesToAvg);
+  return HfAdcErr::ADC_SUCCESS;
 #else
-    // Add other MCU implementations here
-    (void)channel_reading_count;
-    (void)numOfSamplesToAvg;
-    (void)timeBetweenSamples;
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  // Add other MCU implementations here
+  (void)channel_reading_count;
+  (void)numOfSamplesToAvg;
+  (void)timeBetweenSamples;
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfAdcErr McuAdc::ReadChannelV(uint8_t channel_num, float &channel_reading_v,
-                             uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
-    uint32_t raw_count;
-    HfAdcErr result = ReadChannelCount(channel_num, raw_count, numOfSamplesToAvg, timeBetweenSamples);
-    if (result != HfAdcErr::ADC_SUCCESS) {
-        return result;
-    }
+                              uint8_t numOfSamplesToAvg, uint32_t timeBetweenSamples) noexcept {
+  uint32_t raw_count;
+  HfAdcErr result = ReadChannelCount(channel_num, raw_count, numOfSamplesToAvg, timeBetweenSamples);
+  if (result != HfAdcErr::ADC_SUCCESS) {
+    return result;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    if (cali_enable_) {
-        int voltage_mv;
-        esp_err_t ret = adc_cali_raw_to_voltage(static_cast<adc_cali_handle_t>(cali_handle_), static_cast<int>(raw_count), &voltage_mv);
-        if (ret == ESP_OK) {
-            channel_reading_v = static_cast<float>(voltage_mv) / 1000.0f;  // Convert mV to V
-            return HfAdcErr::ADC_SUCCESS;
-        }
+  if (cali_enable_) {
+    int voltage_mv;
+    esp_err_t ret = adc_cali_raw_to_voltage(static_cast<adc_cali_handle_t>(cali_handle_),
+                                            static_cast<int>(raw_count), &voltage_mv);
+    if (ret == ESP_OK) {
+      channel_reading_v = static_cast<float>(voltage_mv) / 1000.0f; // Convert mV to V
+      return HfAdcErr::ADC_SUCCESS;
     }
-    
-    // Fallback to basic calculation if calibration not available
-    // ESP32-C6 with 12-bit ADC and 3.3V reference
-    channel_reading_v = (static_cast<float>(raw_count) / 4095.0f) * 3.3f;
-    return HfAdcErr::ADC_SUCCESS;
+  }
+
+  // Fallback to basic calculation if calibration not available
+  // ESP32-C6 with 12-bit ADC and 3.3V reference
+  channel_reading_v = (static_cast<float>(raw_count) / 4095.0f) * 3.3f;
+  return HfAdcErr::ADC_SUCCESS;
 #else
-    // Add other MCU implementations here
-    (void)channel_reading_v;
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  // Add other MCU implementations here
+  (void)channel_reading_v;
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfAdcErr McuAdc::ReadChannel(uint8_t channel_num, uint32_t &channel_reading_count,
-                            float &channel_reading_v, uint8_t numOfSamplesToAvg,
-                            uint32_t timeBetweenSamples) noexcept {
-    HfAdcErr result = ReadChannelCount(channel_num, channel_reading_count, numOfSamplesToAvg, timeBetweenSamples);
-    if (result != HfAdcErr::ADC_SUCCESS) {
-        return result;
-    }
+                             float &channel_reading_v, uint8_t numOfSamplesToAvg,
+                             uint32_t timeBetweenSamples) noexcept {
+  HfAdcErr result =
+      ReadChannelCount(channel_num, channel_reading_count, numOfSamplesToAvg, timeBetweenSamples);
+  if (result != HfAdcErr::ADC_SUCCESS) {
+    return result;
+  }
 
-    return ReadChannelV(channel_num, channel_reading_v, 1, 0);  // Use cached raw value
+  return ReadChannelV(channel_num, channel_reading_v, 1, 0); // Use cached raw value
 }
 
 //==============================================================================
@@ -239,73 +239,75 @@ HfAdcErr McuAdc::ReadChannel(uint8_t channel_num, uint32_t &channel_reading_coun
 
 bool McuAdc::InitializeCalibration() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    cali_enable_ = false;
+  cali_enable_ = false;
 
 #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
-    adc_cali_curve_fitting_config_t cali_config = {
-        .unit_id = unit_,
-        .atten = attenuation_,
-        .bitwidth = bitwidth_
-    };
-    
-    esp_err_t ret = adc_cali_create_scheme_curve_fitting(&cali_config, &cali_handle_);
-    if (ret == ESP_OK) {
-        cali_enable_ = true;
-        return true;
-    }
+  adc_cali_curve_fitting_config_t cali_config = {
+      .unit_id = unit_, .atten = attenuation_, .bitwidth = bitwidth_};
+
+  esp_err_t ret = adc_cali_create_scheme_curve_fitting(&cali_config, &cali_handle_);
+  if (ret == ESP_OK) {
+    cali_enable_ = true;
+    return true;
+  }
 #endif
 
 #if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
-    adc_cali_line_fitting_config_t cali_config = {
-        .unit_id = unit_,
-        .atten = attenuation_,
-        .bitwidth = bitwidth_
-    };
-    
-    esp_err_t ret = adc_cali_create_scheme_line_fitting(&cali_config, &cali_handle_);
-    if (ret == ESP_OK) {
-        cali_enable_ = true;
-        return true;
-    }
+  adc_cali_line_fitting_config_t cali_config = {
+      .unit_id = unit_, .atten = attenuation_, .bitwidth = bitwidth_};
+
+  esp_err_t ret = adc_cali_create_scheme_line_fitting(&cali_config, &cali_handle_);
+  if (ret == ESP_OK) {
+    cali_enable_ = true;
+    return true;
+  }
 #endif
 
-    return true;  // OK to continue without calibration
+  return true; // OK to continue without calibration
 #else
-    return true;
+  return true;
 #endif
 }
 
 void McuAdc::DeinitializeCalibration() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    if (cali_enable_ && cali_handle_) {
+  if (cali_enable_ && cali_handle_) {
 #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
-        adc_cali_delete_scheme_curve_fitting(cali_handle_);
+    adc_cali_delete_scheme_curve_fitting(cali_handle_);
 #elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
-        adc_cali_delete_scheme_line_fitting(cali_handle_);
+    adc_cali_delete_scheme_line_fitting(cali_handle_);
 #endif
-        cali_handle_ = nullptr;
-        cali_enable_ = false;
-    }
+    cali_handle_ = nullptr;
+    cali_enable_ = false;
+  }
 #endif
 }
 
 #ifdef HF_MCU_FAMILY_ESP32
 adc_channel_t McuAdc::GetMcuChannel(uint8_t channel_num) const noexcept {
-    // Map generic channel numbers to ESP32-C6 ADC1 channels
-    switch (channel_num) {
-        case 0: return ADC_CHANNEL_0;  // GPIO0
-        case 1: return ADC_CHANNEL_1;  // GPIO1
-        case 2: return ADC_CHANNEL_2;  // GPIO2
-        case 3: return ADC_CHANNEL_3;  // GPIO3
-        case 4: return ADC_CHANNEL_4;  // GPIO4
-        case 5: return ADC_CHANNEL_5;  // GPIO5
-        case 6: return ADC_CHANNEL_6;  // GPIO6
-        default: return ADC_CHANNEL_0; // Default fallback
-    }
+  // Map generic channel numbers to ESP32-C6 ADC1 channels
+  switch (channel_num) {
+  case 0:
+    return ADC_CHANNEL_0; // GPIO0
+  case 1:
+    return ADC_CHANNEL_1; // GPIO1
+  case 2:
+    return ADC_CHANNEL_2; // GPIO2
+  case 3:
+    return ADC_CHANNEL_3; // GPIO3
+  case 4:
+    return ADC_CHANNEL_4; // GPIO4
+  case 5:
+    return ADC_CHANNEL_5; // GPIO5
+  case 6:
+    return ADC_CHANNEL_6; // GPIO6
+  default:
+    return ADC_CHANNEL_0; // Default fallback
+  }
 }
 #else
 hf_adc_channel_t McuAdc::GetMcuChannel(uint8_t channel_num) const noexcept {
-    return static_cast<hf_adc_channel_t>(channel_num);
+  return static_cast<hf_adc_channel_t>(channel_num);
 }
 #endif
 
@@ -315,43 +317,48 @@ hf_adc_channel_t McuAdc::GetMcuChannel(uint8_t channel_num) const noexcept {
 
 float McuAdc::CountToVoltage(uint32_t raw_count) const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    if (cali_enable_) {
-        int voltage_mv;
-        esp_err_t ret = adc_cali_raw_to_voltage(static_cast<adc_cali_handle_t>(cali_handle_), 
-                                                static_cast<int>(raw_count), &voltage_mv);
-        if (ret == ESP_OK) {
-            return static_cast<float>(voltage_mv) / 1000.0f;
-        }
+  if (cali_enable_) {
+    int voltage_mv;
+    esp_err_t ret = adc_cali_raw_to_voltage(static_cast<adc_cali_handle_t>(cali_handle_),
+                                            static_cast<int>(raw_count), &voltage_mv);
+    if (ret == ESP_OK) {
+      return static_cast<float>(voltage_mv) / 1000.0f;
     }
-    
-    // Fallback calculation
-    return (static_cast<float>(raw_count) / 4095.0f) * 3.3f;
+  }
+
+  // Fallback calculation
+  return (static_cast<float>(raw_count) / 4095.0f) * 3.3f;
 #else
-    return static_cast<float>(raw_count) / 4095.0f * 3.3f;
+  return static_cast<float>(raw_count) / 4095.0f * 3.3f;
 #endif
 }
 
 uint8_t McuAdc::GetResolutionBits() const noexcept {
-    return static_cast<uint8_t>(bitwidth_);
+  return static_cast<uint8_t>(bitwidth_);
 }
 
 uint32_t McuAdc::GetMaxCount() const noexcept {
-    uint8_t bits = GetResolutionBits();
-    return (1U << bits) - 1;
+  uint8_t bits = GetResolutionBits();
+  return (1U << bits) - 1;
 }
 
 float McuAdc::GetReferenceVoltage() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // ESP32-C6 reference voltage depends on attenuation
-    switch (attenuation_) {
-        case 0: return 1.1f;   // 0dB
-        case 1: return 1.5f;   // 2.5dB  
-        case 2: return 2.2f;   // 6dB
-        case 3: return 3.9f;   // 11dB
-        default: return 3.3f;
-    }
+  // ESP32-C6 reference voltage depends on attenuation
+  switch (attenuation_) {
+  case 0:
+    return 1.1f; // 0dB
+  case 1:
+    return 1.5f; // 2.5dB
+  case 2:
+    return 2.2f; // 6dB
+  case 3:
+    return 3.9f; // 11dB
+  default:
+    return 3.3f;
+  }
 #else
-    return 3.3f;  // Default reference voltage
+  return 3.3f; // Default reference voltage
 #endif
 }
 
@@ -359,77 +366,76 @@ float McuAdc::GetReferenceVoltage() const noexcept {
 // ADVANCED ADC FEATURES IMPLEMENTATION
 //==============================================================================
 
-HfAdcErr McuAdc::ConfigureAdvanced(uint8_t channel_num, 
-                                   const AdcAdvancedConfig& config) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
+HfAdcErr McuAdc::ConfigureAdvanced(uint8_t channel_num, const AdcAdvancedConfig &config) noexcept {
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    // ESP32-C6 supports DMA mode for continuous conversion
-    if (config.sampling_mode == SamplingMode::DMA || 
-        config.sampling_mode == SamplingMode::Continuous) {
-        return InitializeContinuousMode(channel_num, config.sample_rate_hz);
-    }
+  // ESP32-C6 supports DMA mode for continuous conversion
+  if (config.sampling_mode == SamplingMode::DMA ||
+      config.sampling_mode == SamplingMode::Continuous) {
+    return InitializeContinuousMode(channel_num, config.sample_rate_hz);
+  }
 #endif
-    
-    // Other advanced features not supported on ESP32-C6 oneshot ADC
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+
+  // Other advanced features not supported on ESP32-C6 oneshot ADC
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 }
 
-HfAdcErr McuAdc::StartContinuousSampling(uint8_t channel_num,
-                                         AdcCallback callback,
-                                         void* user_data) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
+HfAdcErr McuAdc::StartContinuousSampling(uint8_t channel_num, AdcCallback callback,
+                                         void *user_data) noexcept {
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    if (!adc_continuous_handle_) {
-        return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
-    }
-    
-    // Store callback and user data
-    active_callback_ = callback;
-    callback_user_data_ = user_data;
-    current_dma_channel_ = channel_num;
-    
-    // Start continuous conversion
-    esp_err_t ret = adc_continuous_start(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
-    if (ret != ESP_OK) {
-        return HfAdcErr::ADC_ERR_HARDWARE_FAULT;
-    }
-    
-    dma_mode_active_ = true;
-    return HfAdcErr::ADC_SUCCESS;
+  if (!adc_continuous_handle_) {
+    return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
+  }
+
+  // Store callback and user data
+  active_callback_ = callback;
+  callback_user_data_ = user_data;
+  current_dma_channel_ = channel_num;
+
+  // Start continuous conversion
+  esp_err_t ret =
+      adc_continuous_start(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
+  if (ret != ESP_OK) {
+    return HfAdcErr::ADC_ERR_HARDWARE_FAULT;
+  }
+
+  dma_mode_active_ = true;
+  return HfAdcErr::ADC_SUCCESS;
 #else
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfAdcErr McuAdc::StopContinuousSampling(uint8_t channel_num) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    if (!adc_continuous_handle_ || !dma_mode_active_) {
-        return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
-    }
-    
-    // Stop continuous conversion
-    esp_err_t ret = adc_continuous_stop(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
-    if (ret != ESP_OK) {
-        return HfAdcErr::ADC_ERR_HARDWARE_FAULT;
-    }
-    
-    dma_mode_active_ = false;
-    active_callback_ = nullptr;
-    callback_user_data_ = nullptr;
-    
-    return HfAdcErr::ADC_SUCCESS;
+  if (!adc_continuous_handle_ || !dma_mode_active_) {
+    return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
+  }
+
+  // Stop continuous conversion
+  esp_err_t ret = adc_continuous_stop(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
+  if (ret != ESP_OK) {
+    return HfAdcErr::ADC_ERR_HARDWARE_FAULT;
+  }
+
+  dma_mode_active_ = false;
+  active_callback_ = nullptr;
+  callback_user_data_ = nullptr;
+
+  return HfAdcErr::ADC_SUCCESS;
 #else
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
@@ -441,144 +447,145 @@ HfAdcErr McuAdc::StopContinuousSampling(uint8_t channel_num) noexcept {
 #include "freertos/task.h"
 
 HfAdcErr McuAdc::InitializeContinuousMode(uint8_t channel_num, uint32_t sample_rate_hz) noexcept {
-    if (adc_continuous_handle_) {
-        return HfAdcErr::ADC_ERR_ALREADY_INITIALIZED;
-    }
-    
-    // Allocate DMA buffer
-    dma_buffer_ = static_cast<uint8_t*>(malloc(DMA_BUFFER_SIZE));
-    if (!dma_buffer_) {
-        return HfAdcErr::ADC_ERR_OUT_OF_MEMORY;
-    }
-    
-    // Configure continuous conversion
-    adc_continuous_handle_cfg_t adc_config = {};
-    adc_config.max_store_buf_size = DMA_BUFFER_SIZE;
-    adc_config.conv_frame_size = DMA_BUFFER_SIZE / 4;  // Smaller frame for responsiveness
-    
-    esp_err_t ret = adc_continuous_new_handle(&adc_config, 
-                                              reinterpret_cast<adc_continuous_handle_t*>(&adc_continuous_handle_));
-    if (ret != ESP_OK) {
-        free(dma_buffer_);
-        dma_buffer_ = nullptr;
-        return HfAdcErr::ADC_ERR_HARDWARE_FAULT;
-    }
-    
-    // Configure channel
-    adc_digi_pattern_config_t adc_pattern = {};
-    adc_pattern.atten = static_cast<adc_atten_t>(attenuation_);
-    adc_pattern.channel = GetMcuChannel(channel_num);
-    adc_pattern.unit = static_cast<adc_unit_t>(unit_);
-    adc_pattern.bit_width = static_cast<adc_bitwidth_t>(bitwidth_);
-    
-    adc_continuous_config_t dig_cfg = {};
-    dig_cfg.sample_freq_hz = sample_rate_hz;
-    dig_cfg.conv_mode = ADC_CONV_SINGLE_UNIT_1;  // Single unit mode
-    dig_cfg.format = ADC_DIGI_OUTPUT_FORMAT_TYPE1;
-    dig_cfg.pattern_num = 1;
-    dig_cfg.adc_pattern = &adc_pattern;
-    
-    ret = adc_continuous_config(static_cast<adc_continuous_handle_t>(adc_continuous_handle_), &dig_cfg);
-    if (ret != ESP_OK) {
-        adc_continuous_del_handle(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
-        free(dma_buffer_);
-        dma_buffer_ = nullptr;
-        adc_continuous_handle_ = nullptr;
-        return HfAdcErr::ADC_ERR_INVALID_CONFIGURATION;
-    }
-    
-    // Create DMA processing task
-    BaseType_t task_ret = xTaskCreate(DmaProcessingTask, "adc_dma_task", 
-                                      4096, this, 5, 
-                                      reinterpret_cast<TaskHandle_t*>(&dma_task_handle_));
-    if (task_ret != pdPASS) {
-        DeinitializeContinuousMode();
-        return HfAdcErr::ADC_ERR_SYSTEM_ERROR;
-    }
-    
-    return HfAdcErr::ADC_SUCCESS;
+  if (adc_continuous_handle_) {
+    return HfAdcErr::ADC_ERR_ALREADY_INITIALIZED;
+  }
+
+  // Allocate DMA buffer
+  dma_buffer_ = static_cast<uint8_t *>(malloc(DMA_BUFFER_SIZE));
+  if (!dma_buffer_) {
+    return HfAdcErr::ADC_ERR_OUT_OF_MEMORY;
+  }
+
+  // Configure continuous conversion
+  adc_continuous_handle_cfg_t adc_config = {};
+  adc_config.max_store_buf_size = DMA_BUFFER_SIZE;
+  adc_config.conv_frame_size = DMA_BUFFER_SIZE / 4; // Smaller frame for responsiveness
+
+  esp_err_t ret = adc_continuous_new_handle(
+      &adc_config, reinterpret_cast<adc_continuous_handle_t *>(&adc_continuous_handle_));
+  if (ret != ESP_OK) {
+    free(dma_buffer_);
+    dma_buffer_ = nullptr;
+    return HfAdcErr::ADC_ERR_HARDWARE_FAULT;
+  }
+
+  // Configure channel
+  adc_digi_pattern_config_t adc_pattern = {};
+  adc_pattern.atten = static_cast<adc_atten_t>(attenuation_);
+  adc_pattern.channel = GetMcuChannel(channel_num);
+  adc_pattern.unit = static_cast<adc_unit_t>(unit_);
+  adc_pattern.bit_width = static_cast<adc_bitwidth_t>(bitwidth_);
+
+  adc_continuous_config_t dig_cfg = {};
+  dig_cfg.sample_freq_hz = sample_rate_hz;
+  dig_cfg.conv_mode = ADC_CONV_SINGLE_UNIT_1; // Single unit mode
+  dig_cfg.format = ADC_DIGI_OUTPUT_FORMAT_TYPE1;
+  dig_cfg.pattern_num = 1;
+  dig_cfg.adc_pattern = &adc_pattern;
+
+  ret =
+      adc_continuous_config(static_cast<adc_continuous_handle_t>(adc_continuous_handle_), &dig_cfg);
+  if (ret != ESP_OK) {
+    adc_continuous_del_handle(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
+    free(dma_buffer_);
+    dma_buffer_ = nullptr;
+    adc_continuous_handle_ = nullptr;
+    return HfAdcErr::ADC_ERR_INVALID_CONFIGURATION;
+  }
+
+  // Create DMA processing task
+  BaseType_t task_ret = xTaskCreate(DmaProcessingTask, "adc_dma_task", 4096, this, 5,
+                                    reinterpret_cast<TaskHandle_t *>(&dma_task_handle_));
+  if (task_ret != pdPASS) {
+    DeinitializeContinuousMode();
+    return HfAdcErr::ADC_ERR_SYSTEM_ERROR;
+  }
+
+  return HfAdcErr::ADC_SUCCESS;
 }
 
 HfAdcErr McuAdc::DeinitializeContinuousMode() noexcept {
-    if (dma_mode_active_) {
-        StopContinuousSampling(current_dma_channel_);
-    }
-    
-    // Delete task
-    if (dma_task_handle_) {
-        vTaskDelete(static_cast<TaskHandle_t>(dma_task_handle_));
-        dma_task_handle_ = nullptr;
-    }
-    
-    // Clean up continuous ADC
-    if (adc_continuous_handle_) {
-        adc_continuous_del_handle(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
-        adc_continuous_handle_ = nullptr;
-    }
-    
-    // Free DMA buffer
-    if (dma_buffer_) {
-        free(dma_buffer_);
-        dma_buffer_ = nullptr;
-    }
-    
-    return HfAdcErr::ADC_SUCCESS;
+  if (dma_mode_active_) {
+    StopContinuousSampling(current_dma_channel_);
+  }
+
+  // Delete task
+  if (dma_task_handle_) {
+    vTaskDelete(static_cast<TaskHandle_t>(dma_task_handle_));
+    dma_task_handle_ = nullptr;
+  }
+
+  // Clean up continuous ADC
+  if (adc_continuous_handle_) {
+    adc_continuous_del_handle(static_cast<adc_continuous_handle_t>(adc_continuous_handle_));
+    adc_continuous_handle_ = nullptr;
+  }
+
+  // Free DMA buffer
+  if (dma_buffer_) {
+    free(dma_buffer_);
+    dma_buffer_ = nullptr;
+  }
+
+  return HfAdcErr::ADC_SUCCESS;
 }
 
-void McuAdc::DmaProcessingTask(void* pvParameters) {
-    McuAdc* adc = static_cast<McuAdc*>(pvParameters);
-    uint8_t* data_buffer = static_cast<uint8_t*>(malloc(adc->DMA_BUFFER_SIZE));
-    
-    if (!data_buffer) {
-        vTaskDelete(nullptr);
-        return;
-    }
-    
-    while (adc->adc_continuous_handle_) {
-        uint32_t bytes_read = 0;
-        esp_err_t ret = adc_continuous_read(static_cast<adc_continuous_handle_t>(adc->adc_continuous_handle_),
-                                            data_buffer, adc->DMA_BUFFER_SIZE, &bytes_read, 1000);
-        
-        if (ret == ESP_OK && bytes_read > 0 && adc->dma_mode_active_) {
-            adc->ProcessDmaData(data_buffer, bytes_read);
-        } else if (ret == ESP_ERR_TIMEOUT) {
-            // Normal timeout, continue
-            continue;
-        } else if (ret != ESP_OK) {
-            // Error occurred, stop processing
-            break;
-        }
-        
-        // Small delay to prevent watchdog issues
-        vTaskDelay(pdMS_TO_TICKS(1));
-    }
-    
-    free(data_buffer);
+void McuAdc::DmaProcessingTask(void *pvParameters) {
+  McuAdc *adc = static_cast<McuAdc *>(pvParameters);
+  uint8_t *data_buffer = static_cast<uint8_t *>(malloc(adc->DMA_BUFFER_SIZE));
+
+  if (!data_buffer) {
     vTaskDelete(nullptr);
+    return;
+  }
+
+  while (adc->adc_continuous_handle_) {
+    uint32_t bytes_read = 0;
+    esp_err_t ret =
+        adc_continuous_read(static_cast<adc_continuous_handle_t>(adc->adc_continuous_handle_),
+                            data_buffer, adc->DMA_BUFFER_SIZE, &bytes_read, 1000);
+
+    if (ret == ESP_OK && bytes_read > 0 && adc->dma_mode_active_) {
+      adc->ProcessDmaData(data_buffer, bytes_read);
+    } else if (ret == ESP_ERR_TIMEOUT) {
+      // Normal timeout, continue
+      continue;
+    } else if (ret != ESP_OK) {
+      // Error occurred, stop processing
+      break;
+    }
+
+    // Small delay to prevent watchdog issues
+    vTaskDelay(pdMS_TO_TICKS(1));
+  }
+
+  free(data_buffer);
+  vTaskDelete(nullptr);
 }
 
-void McuAdc::ProcessDmaData(uint8_t* buffer, size_t length) noexcept {
-    if (!active_callback_ || !dma_mode_active_) {
-        return;
-    }
-    
-    // Convert raw DMA data to samples
-    size_t num_samples = length / sizeof(adc_digi_output_data_t);
-    auto* samples = reinterpret_cast<uint16_t*>(malloc(num_samples * sizeof(uint16_t)));
-    
-    if (!samples) {
-        return;
-    }
-    
-    auto* adc_data = reinterpret_cast<adc_digi_output_data_t*>(buffer);
-    for (size_t i = 0; i < num_samples; i++) {
-        samples[i] = adc_data[i].type1.data;  // Extract 12-bit ADC data
-    }
-    
-    // Invoke user callback
-    active_callback_(current_dma_channel_, samples, num_samples, callback_user_data_);
-    
-    free(samples);
+void McuAdc::ProcessDmaData(uint8_t *buffer, size_t length) noexcept {
+  if (!active_callback_ || !dma_mode_active_) {
+    return;
+  }
+
+  // Convert raw DMA data to samples
+  size_t num_samples = length / sizeof(adc_digi_output_data_t);
+  auto *samples = reinterpret_cast<uint16_t *>(malloc(num_samples * sizeof(uint16_t)));
+
+  if (!samples) {
+    return;
+  }
+
+  auto *adc_data = reinterpret_cast<adc_digi_output_data_t *>(buffer);
+  for (size_t i = 0; i < num_samples; i++) {
+    samples[i] = adc_data[i].type1.data; // Extract 12-bit ADC data
+  }
+
+  // Invoke user callback
+  active_callback_(current_dma_channel_, samples, num_samples, callback_user_data_);
+
+  free(samples);
 }
 
 #endif // ESP_PLATFORM
@@ -586,53 +593,52 @@ void McuAdc::ProcessDmaData(uint8_t* buffer, size_t length) noexcept {
 // CALIBRATION SUPPORT IMPLEMENTATION
 //==============================================================================
 
-HfAdcErr McuAdc::CalibrateChannel(uint8_t channel_num,
-                                  const CalibrationConfig& config,
+HfAdcErr McuAdc::CalibrateChannel(uint8_t channel_num, const CalibrationConfig &config,
                                   CalibrationProgressCallback progress_callback,
-                                  void* user_data) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
-    // For ESP32-C6, we rely on hardware calibration via eFuse
-    // Custom calibration would require additional implementation
-    (void)config;
-    (void)progress_callback;
-    (void)user_data;
-    
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+                                  void *user_data) noexcept {
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
+  // For ESP32-C6, we rely on hardware calibration via eFuse
+  // Custom calibration would require additional implementation
+  (void)config;
+  (void)progress_callback;
+  (void)user_data;
+
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 }
 
-HfAdcErr McuAdc::VerifyCalibration(uint8_t channel_num, float reference_voltage, 
-                                   float& measured_voltage, float& error_percent) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
-    HfAdcErr result = ReadChannelV(channel_num, measured_voltage, 10);  // Average 10 samples
-    if (result != HfAdcErr::ADC_SUCCESS) {
-        return result;
-    }
-    
-    error_percent = std::abs((measured_voltage - reference_voltage) / reference_voltage) * 100.0f;
-    
-    return HfAdcErr::ADC_SUCCESS;
+HfAdcErr McuAdc::VerifyCalibration(uint8_t channel_num, float reference_voltage,
+                                   float &measured_voltage, float &error_percent) noexcept {
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
+  HfAdcErr result = ReadChannelV(channel_num, measured_voltage, 10); // Average 10 samples
+  if (result != HfAdcErr::ADC_SUCCESS) {
+    return result;
+  }
+
+  error_percent = std::abs((measured_voltage - reference_voltage) / reference_voltage) * 100.0f;
+
+  return HfAdcErr::ADC_SUCCESS;
 }
 
 HfAdcErr McuAdc::SaveCalibration(uint8_t channel_num) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
-    // ESP32-C6 calibration is stored in eFuse, not NVS
-    return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
+  // ESP32-C6 calibration is stored in eFuse, not NVS
+  return HfAdcErr::ADC_ERR_UNSUPPORTED_OPERATION;
 }
 
 HfAdcErr McuAdc::LoadCalibration(uint8_t channel_num) noexcept {
-    if (!IsChannelAvailable(channel_num)) {
-        return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
-    }
-    
-    // ESP32-C6 calibration is loaded from eFuse automatically
-    return HfAdcErr::ADC_SUCCESS;
+  if (!IsChannelAvailable(channel_num)) {
+    return HfAdcErr::ADC_ERR_INVALID_CHANNEL;
+  }
+
+  // ESP32-C6 calibration is loaded from eFuse automatically
+  return HfAdcErr::ADC_SUCCESS;
 }

--- a/src/mcu/McuCan.cpp
+++ b/src/mcu/McuCan.cpp
@@ -3,8 +3,8 @@
  * @brief Implementation of MCU-integrated CAN controller.
  *
  * This file provides the implementation for CAN bus communication using the
- * microcontroller's built-in CAN peripheral. For ESP32, it wraps TWAI 
- * (Two-Wire Automotive Interface). All platform-specific types and 
+ * microcontroller's built-in CAN peripheral. For ESP32, it wraps TWAI
+ * (Two-Wire Automotive Interface). All platform-specific types and
  * implementations are isolated through McuTypes.h.
  */
 #include "McuCan.h"
@@ -15,13 +15,10 @@
 // CONSTRUCTOR AND DESTRUCTOR
 //==============================================================================
 
-McuCan::McuCan(const CanBusConfig& config) noexcept
-    : config_(config), receive_callback_(nullptr)
-{
-}
+McuCan::McuCan(const CanBusConfig &config) noexcept : config_(config), receive_callback_(nullptr) {}
 
 McuCan::~McuCan() noexcept {
-    Deinitialize();
+  Deinitialize();
 }
 
 //==============================================================================
@@ -29,67 +26,67 @@ McuCan::~McuCan() noexcept {
 //==============================================================================
 
 bool McuCan::Initialize() noexcept {
-    if (initialized_) {
-        return true;
-    }
-
-    if (!PlatformInitialize()) {
-        return false;
-    }
-
-    initialized_ = true;
+  if (initialized_) {
     return true;
+  }
+
+  if (!PlatformInitialize()) {
+    return false;
+  }
+
+  initialized_ = true;
+  return true;
 }
 
 bool McuCan::Deinitialize() noexcept {
-    if (!initialized_) {
-        return true;
-    }
-
-    PlatformDeinitialize();
-    initialized_ = false;
-    receive_callback_ = nullptr;
+  if (!initialized_) {
     return true;
+  }
+
+  PlatformDeinitialize();
+  initialized_ = false;
+  receive_callback_ = nullptr;
+  return true;
 }
 
 bool McuCan::Start() noexcept {
-    if (!initialized_) {
-        return false;
-    }
+  if (!initialized_) {
+    return false;
+  }
 
-    return PlatformStart();
+  return PlatformStart();
 }
 
 bool McuCan::Stop() noexcept {
-    if (!initialized_) {
-        return false;
-    }
+  if (!initialized_) {
+    return false;
+  }
 
-    return PlatformStop();
+  return PlatformStop();
 }
 
 //==============================================================================
 // MESSAGE TRANSMISSION AND RECEPTION
 //==============================================================================
 
-bool McuCan::SendMessage(const CanMessage& message, uint32_t timeout_ms) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+bool McuCan::SendMessage(const CanMessage &message, uint32_t timeout_ms) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformSendMessage(message, timeout_ms);
+  if (!initialized_) {
+    return false;
+  }
+
+  return PlatformSendMessage(message, timeout_ms);
 }
 
-bool McuCan::ReceiveMessage(CanMessage& message, uint32_t timeout_ms) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+bool McuCan::ReceiveMessage(CanMessage &message, uint32_t timeout_ms) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformReceiveMessage(message, timeout_ms);
+  if (!initialized_) {
+    return false;
+  }
+
+  return PlatformReceiveMessage(message, timeout_ms);
 }
 
 //==============================================================================
@@ -97,83 +94,83 @@ bool McuCan::ReceiveMessage(CanMessage& message, uint32_t timeout_ms) noexcept {
 //==============================================================================
 
 bool McuCan::SetReceiveCallback(CanReceiveCallback callback) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    receive_callback_ = callback;
-    return true;
+  if (!initialized_) {
+    return false;
+  }
+
+  receive_callback_ = callback;
+  return true;
 }
 
 void McuCan::ClearReceiveCallback() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    receive_callback_ = nullptr;
+  std::lock_guard<std::mutex> lock(mutex_);
+  receive_callback_ = nullptr;
 }
 
 //==============================================================================
 // STATUS AND DIAGNOSTICS
 //==============================================================================
 
-bool McuCan::GetStatus(CanBusStatus& status) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+bool McuCan::GetStatus(CanBusStatus &status) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformGetStatus(status);
+  if (!initialized_) {
+    return false;
+  }
+
+  return PlatformGetStatus(status);
 }
 
 bool McuCan::Reset() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformReset();
+  if (!initialized_) {
+    return false;
+  }
+
+  return PlatformReset();
 }
 
 bool McuCan::IsTransmitQueueFull() const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return true;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformIsTransmitQueueFull();
+  if (!initialized_) {
+    return true;
+  }
+
+  return PlatformIsTransmitQueueFull();
 }
 
 bool McuCan::IsReceiveQueueEmpty() const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return true;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformIsReceiveQueueEmpty();
+  if (!initialized_) {
+    return true;
+  }
+
+  return PlatformIsReceiveQueueEmpty();
 }
 
 uint32_t McuCan::GetTransmitErrorCount() const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return 0;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformGetTransmitErrorCount();
+  if (!initialized_) {
+    return 0;
+  }
+
+  return PlatformGetTransmitErrorCount();
 }
 
 uint32_t McuCan::GetReceiveErrorCount() const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return 0;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformGetReceiveErrorCount();
+  if (!initialized_) {
+    return 0;
+  }
+
+  return PlatformGetReceiveErrorCount();
 }
 
 //==============================================================================
@@ -181,23 +178,23 @@ uint32_t McuCan::GetReceiveErrorCount() const noexcept {
 //==============================================================================
 
 bool McuCan::SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformSetAcceptanceFilter(id, mask, extended);
+  if (!initialized_) {
+    return false;
+  }
+
+  return PlatformSetAcceptanceFilter(id, mask, extended);
 }
 
 bool McuCan::ClearAcceptanceFilter() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return false;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    return PlatformClearAcceptanceFilter();
+  if (!initialized_) {
+    return false;
+  }
+
+  return PlatformClearAcceptanceFilter();
 }
 
 //==============================================================================
@@ -205,266 +202,263 @@ bool McuCan::ClearAcceptanceFilter() noexcept {
 //==============================================================================
 
 bool McuCan::PlatformInitialize() noexcept {
-    // Configure TWAI driver (ESP32's CAN implementation)
-    hf_can_general_config_t general_config = {
-        .mode = config_.silent_mode ? HF_CAN_MODE_LISTEN_ONLY : 
-                (config_.loopback_mode ? HF_CAN_MODE_LOOPBACK : HF_CAN_MODE_NORMAL),
-        .tx_io = config_.tx_pin,
-        .rx_io = config_.rx_pin,
-        .clkout_io = HF_CAN_IO_UNUSED,
-        .bus_off_io = HF_CAN_IO_UNUSED,
-        .tx_queue_len = static_cast<uint32_t>(config_.tx_queue_size),
-        .rx_queue_len = static_cast<uint32_t>(config_.rx_queue_size),
-        .alerts_enabled = HF_CAN_ALERT_ALL,
-        .clkout_divider = 0
-    };
+  // Configure TWAI driver (ESP32's CAN implementation)
+  hf_can_general_config_t general_config = {
+      .mode = config_.silent_mode
+                  ? HF_CAN_MODE_LISTEN_ONLY
+                  : (config_.loopback_mode ? HF_CAN_MODE_LOOPBACK : HF_CAN_MODE_NORMAL),
+      .tx_io = config_.tx_pin,
+      .rx_io = config_.rx_pin,
+      .clkout_io = HF_CAN_IO_UNUSED,
+      .bus_off_io = HF_CAN_IO_UNUSED,
+      .tx_queue_len = static_cast<uint32_t>(config_.tx_queue_size),
+      .rx_queue_len = static_cast<uint32_t>(config_.rx_queue_size),
+      .alerts_enabled = HF_CAN_ALERT_ALL,
+      .clkout_divider = 0};
 
-    // Configure timing parameters based on baud rate
-    hf_can_timing_config_t timing_config;
-    if (!GetTimingConfig(config_.baudrate, &timing_config)) {
-        return false;
-    }
+  // Configure timing parameters based on baud rate
+  hf_can_timing_config_t timing_config;
+  if (!GetTimingConfig(config_.baudrate, &timing_config)) {
+    return false;
+  }
 
-    // Configure filter (accept all by default)
-    hf_can_filter_config_t filter_config = {
-        .acceptance_code = 0,
-        .acceptance_mask = 0xFFFFFFFF,
-        .single_filter = true
-    };
+  // Configure filter (accept all by default)
+  hf_can_filter_config_t filter_config = {
+      .acceptance_code = 0, .acceptance_mask = 0xFFFFFFFF, .single_filter = true};
 
-    // Install TWAI driver
-    if (HF_CAN_DRIVER_INSTALL(&general_config, &timing_config, &filter_config) != HF_CAN_OK) {
-        return false;
-    }
+  // Install TWAI driver
+  if (HF_CAN_DRIVER_INSTALL(&general_config, &timing_config, &filter_config) != HF_CAN_OK) {
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 bool McuCan::PlatformDeinitialize() noexcept {
-    // Uninstall TWAI driver
-    HF_CAN_DRIVER_UNINSTALL();
-    return true;
+  // Uninstall TWAI driver
+  HF_CAN_DRIVER_UNINSTALL();
+  return true;
 }
 
 bool McuCan::PlatformStart() noexcept {
-    return HF_CAN_START() == HF_CAN_OK;
+  return HF_CAN_START() == HF_CAN_OK;
 }
 
 bool McuCan::PlatformStop() noexcept {
-    return HF_CAN_STOP() == HF_CAN_OK;
+  return HF_CAN_STOP() == HF_CAN_OK;
 }
 
-bool McuCan::PlatformSendMessage(const CanMessage& message, uint32_t timeout_ms) noexcept {
-    // Convert CanMessage to platform-specific hf_can_message_t
-    hf_can_message_t platform_msg;
-    platform_msg.id = message.id;
-    platform_msg.is_extended = message.extended_id;
-    platform_msg.is_rtr = message.remote_frame;
-    platform_msg.dlc = message.data_length > 8 ? 8 : message.data_length; // Classic CAN limit
-    
-    // Copy data (limit to 8 bytes for classic CAN)
-    for (uint8_t i = 0; i < platform_msg.dlc && i < sizeof(platform_msg.data); ++i) {
-        platform_msg.data[i] = message.data[i];
-    }
-    
-    hf_can_err_t result = HF_CAN_TRANSMIT(&platform_msg, HF_TICKS_FROM_MS(timeout_ms));
-    return result == HF_CAN_OK;
+bool McuCan::PlatformSendMessage(const CanMessage &message, uint32_t timeout_ms) noexcept {
+  // Convert CanMessage to platform-specific hf_can_message_t
+  hf_can_message_t platform_msg;
+  platform_msg.id = message.id;
+  platform_msg.is_extended = message.extended_id;
+  platform_msg.is_rtr = message.remote_frame;
+  platform_msg.dlc = message.data_length > 8 ? 8 : message.data_length; // Classic CAN limit
+
+  // Copy data (limit to 8 bytes for classic CAN)
+  for (uint8_t i = 0; i < platform_msg.dlc && i < sizeof(platform_msg.data); ++i) {
+    platform_msg.data[i] = message.data[i];
+  }
+
+  hf_can_err_t result = HF_CAN_TRANSMIT(&platform_msg, HF_TICKS_FROM_MS(timeout_ms));
+  return result == HF_CAN_OK;
 }
 
-bool McuCan::PlatformReceiveMessage(CanMessage& message, uint32_t timeout_ms) noexcept {
-    hf_can_message_t platform_msg;
-    hf_can_err_t result = HF_CAN_RECEIVE(&platform_msg, HF_TICKS_FROM_MS(timeout_ms));
-    
-    if (result == HF_CAN_OK) {
-        // Convert platform message to CanMessage
-        message.id = platform_msg.id;
-        message.extended_id = platform_msg.is_extended;
-        message.remote_frame = platform_msg.is_rtr;
-        message.format = CanFrameFormat::Classic; // ESP32 TWAI only supports classic CAN
-        message.dlc = platform_msg.dlc;
-        message.data_length = platform_msg.dlc;
-        message.error_state_indicator = false;
-        message.bit_rate_switch = false;
-        
-        // Copy data
-        for (uint8_t i = 0; i < platform_msg.dlc && i < sizeof(message.data); ++i) {
-            message.data[i] = platform_msg.data[i];
-        }
-        
-        // Clear remaining data
-        for (uint8_t i = platform_msg.dlc; i < sizeof(message.data); ++i) {
-            message.data[i] = 0;
-        }
-        
-        return true;
-    }
-    
-    return false;
-}
+bool McuCan::PlatformReceiveMessage(CanMessage &message, uint32_t timeout_ms) noexcept {
+  hf_can_message_t platform_msg;
+  hf_can_err_t result = HF_CAN_RECEIVE(&platform_msg, HF_TICKS_FROM_MS(timeout_ms));
 
-bool McuCan::PlatformGetStatus(CanBusStatus& status) noexcept {
-    hf_can_status_info_t status_info;
-    
-    if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
-        return false;
+  if (result == HF_CAN_OK) {
+    // Convert platform message to CanMessage
+    message.id = platform_msg.id;
+    message.extended_id = platform_msg.is_extended;
+    message.remote_frame = platform_msg.is_rtr;
+    message.format = CanFrameFormat::Classic; // ESP32 TWAI only supports classic CAN
+    message.dlc = platform_msg.dlc;
+    message.data_length = platform_msg.dlc;
+    message.error_state_indicator = false;
+    message.bit_rate_switch = false;
+
+    // Copy data
+    for (uint8_t i = 0; i < platform_msg.dlc && i < sizeof(message.data); ++i) {
+      message.data[i] = platform_msg.data[i];
     }
 
-    status.tx_error_count = status_info.tx_error_counter;
-    status.rx_error_count = status_info.rx_error_counter;
-    status.tx_failed_count = status_info.tx_failed_count;
-    status.rx_missed_count = status_info.rx_missed_count;
-    status.bus_off = (status_info.state == HF_CAN_STATE_BUS_OFF);
-    status.error_warning = (status_info.tx_error_counter > 96 || status_info.rx_error_counter > 96);
-    status.error_passive = (status_info.tx_error_counter > 127 || status_info.rx_error_counter > 127);
+    // Clear remaining data
+    for (uint8_t i = platform_msg.dlc; i < sizeof(message.data); ++i) {
+      message.data[i] = 0;
+    }
 
     return true;
+  }
+
+  return false;
+}
+
+bool McuCan::PlatformGetStatus(CanBusStatus &status) noexcept {
+  hf_can_status_info_t status_info;
+
+  if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
+    return false;
+  }
+
+  status.tx_error_count = status_info.tx_error_counter;
+  status.rx_error_count = status_info.rx_error_counter;
+  status.tx_failed_count = status_info.tx_failed_count;
+  status.rx_missed_count = status_info.rx_missed_count;
+  status.bus_off = (status_info.state == HF_CAN_STATE_BUS_OFF);
+  status.error_warning = (status_info.tx_error_counter > 96 || status_info.rx_error_counter > 96);
+  status.error_passive = (status_info.tx_error_counter > 127 || status_info.rx_error_counter > 127);
+
+  return true;
 }
 
 bool McuCan::PlatformReset() noexcept {
-    // Stop the driver
-    if (HF_CAN_STOP() != HF_CAN_OK) {
-        return false;
-    }
-    
-    // Start the driver again
-    return HF_CAN_START() == HF_CAN_OK;
+  // Stop the driver
+  if (HF_CAN_STOP() != HF_CAN_OK) {
+    return false;
+  }
+
+  // Start the driver again
+  return HF_CAN_START() == HF_CAN_OK;
 }
 
 bool McuCan::PlatformSetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended) noexcept {
-    // For ESP32 TWAI, filters need to be set during initialization
-    // This would require stopping and restarting the driver
-    // For now, return false to indicate filter changes are not supported at runtime
-    (void)id;
-    (void)mask;
-    (void)extended;
-    return false;
+  // For ESP32 TWAI, filters need to be set during initialization
+  // This would require stopping and restarting the driver
+  // For now, return false to indicate filter changes are not supported at runtime
+  (void)id;
+  (void)mask;
+  (void)extended;
+  return false;
 }
 
 bool McuCan::PlatformClearAcceptanceFilter() noexcept {
-    // Same limitation as above
-    return false;
+  // Same limitation as above
+  return false;
 }
 
 bool McuCan::PlatformIsTransmitQueueFull() const noexcept {
-    hf_can_status_info_t status_info;
-    
-    if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
-        return true;
-    }
+  hf_can_status_info_t status_info;
 
-    return status_info.tx_queue_len >= config_.tx_queue_size;
+  if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
+    return true;
+  }
+
+  return status_info.tx_queue_len >= config_.tx_queue_size;
 }
 
 bool McuCan::PlatformIsReceiveQueueEmpty() const noexcept {
-    hf_can_status_info_t status_info;
-    
-    if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
-        return true;
-    }
+  hf_can_status_info_t status_info;
 
-    return status_info.rx_queue_len == 0;
+  if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
+    return true;
+  }
+
+  return status_info.rx_queue_len == 0;
 }
 
 uint32_t McuCan::PlatformGetTransmitErrorCount() const noexcept {
-    hf_can_status_info_t status_info;
-    
-    if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
-        return 0;
-    }
+  hf_can_status_info_t status_info;
 
-    return status_info.tx_error_counter;
+  if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
+    return 0;
+  }
+
+  return status_info.tx_error_counter;
 }
 
 uint32_t McuCan::PlatformGetReceiveErrorCount() const noexcept {
-    hf_can_status_info_t status_info;
-    
-    if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
-        return 0;
-    }
+  hf_can_status_info_t status_info;
 
-    return status_info.rx_error_counter;
+  if (HF_CAN_GET_STATUS_INFO(&status_info) != HF_CAN_OK) {
+    return 0;
+  }
+
+  return status_info.rx_error_counter;
 }
 
-bool McuCan::GetTimingConfig(uint32_t baud_rate, void* timing_config_ptr) noexcept {
-    hf_can_timing_config_t* timing_config = static_cast<hf_can_timing_config_t*>(timing_config_ptr);
-    
-    // ESP32-C6 CAN timing configuration for different baud rates
-    // These values are calculated for 40MHz APB clock
-    
-    switch (baud_rate) {
-        case 1000000: // 1 Mbps
-            timing_config->brp = 4;
-            timing_config->tseg_1 = 15;
-            timing_config->tseg_2 = 4;
-            timing_config->sjw = 3;
-            timing_config->triple_sampling = false;
-            break;
-            
-        case 800000: // 800 kbps
-            timing_config->brp = 4;
-            timing_config->tseg_1 = 16;
-            timing_config->tseg_2 = 8;
-            timing_config->sjw = 3;
-            timing_config->triple_sampling = false;
-            break;
-            
-        case 500000: // 500 kbps
-            timing_config->brp = 8;
-            timing_config->tseg_1 = 15;
-            timing_config->tseg_2 = 4;
-            timing_config->sjw = 3;
-            timing_config->triple_sampling = false;
-            break;
-            
-        case 250000: // 250 kbps
-            timing_config->brp = 16;
-            timing_config->tseg_1 = 15;
-            timing_config->tseg_2 = 4;
-            timing_config->sjw = 3;
-            timing_config->triple_sampling = false;
-            break;
-            
-        case 125000: // 125 kbps
-            timing_config->brp = 32;
-            timing_config->tseg_1 = 15;
-            timing_config->tseg_2 = 4;
-            timing_config->sjw = 3;
-            timing_config->triple_sampling = false;
-            break;
-            
-        case 100000: // 100 kbps
-            timing_config->brp = 40;
-            timing_config->tseg_1 = 15;
-            timing_config->tseg_2 = 4;
-            timing_config->sjw = 3;
-            timing_config->triple_sampling = false;
-            break;
-            
-        default:
-            return false; // Unsupported baud rate
-    }
-    
-    return true;
+bool McuCan::GetTimingConfig(uint32_t baud_rate, void *timing_config_ptr) noexcept {
+  hf_can_timing_config_t *timing_config = static_cast<hf_can_timing_config_t *>(timing_config_ptr);
+
+  // ESP32-C6 CAN timing configuration for different baud rates
+  // These values are calculated for 40MHz APB clock
+
+  switch (baud_rate) {
+  case 1000000: // 1 Mbps
+    timing_config->brp = 4;
+    timing_config->tseg_1 = 15;
+    timing_config->tseg_2 = 4;
+    timing_config->sjw = 3;
+    timing_config->triple_sampling = false;
+    break;
+
+  case 800000: // 800 kbps
+    timing_config->brp = 4;
+    timing_config->tseg_1 = 16;
+    timing_config->tseg_2 = 8;
+    timing_config->sjw = 3;
+    timing_config->triple_sampling = false;
+    break;
+
+  case 500000: // 500 kbps
+    timing_config->brp = 8;
+    timing_config->tseg_1 = 15;
+    timing_config->tseg_2 = 4;
+    timing_config->sjw = 3;
+    timing_config->triple_sampling = false;
+    break;
+
+  case 250000: // 250 kbps
+    timing_config->brp = 16;
+    timing_config->tseg_1 = 15;
+    timing_config->tseg_2 = 4;
+    timing_config->sjw = 3;
+    timing_config->triple_sampling = false;
+    break;
+
+  case 125000: // 125 kbps
+    timing_config->brp = 32;
+    timing_config->tseg_1 = 15;
+    timing_config->tseg_2 = 4;
+    timing_config->sjw = 3;
+    timing_config->triple_sampling = false;
+    break;
+
+  case 100000: // 100 kbps
+    timing_config->brp = 40;
+    timing_config->tseg_1 = 15;
+    timing_config->tseg_2 = 4;
+    timing_config->sjw = 3;
+    timing_config->triple_sampling = false;
+    break;
+
+  default:
+    return false; // Unsupported baud rate
+  }
+
+  return true;
 }
 
 //==============================================================================
 // INTERRUPT HANDLING
 //==============================================================================
 
-void McuCan::StaticReceiveHandler(void* arg) {
-    McuCan* instance = static_cast<McuCan*>(arg);
-    if (instance) {
-        instance->HandleReceiveInterrupt();
-    }
+void McuCan::StaticReceiveHandler(void *arg) {
+  McuCan *instance = static_cast<McuCan *>(arg);
+  if (instance) {
+    instance->HandleReceiveInterrupt();
+  }
 }
 
 void McuCan::HandleReceiveInterrupt() {
-    if (receive_callback_) {
-        CanMessage message;
-        if (PlatformReceiveMessage(message, 0)) {  // Non-blocking receive
-            receive_callback_(message);
-        }
+  if (receive_callback_) {
+    CanMessage message;
+    if (PlatformReceiveMessage(message, 0)) { // Non-blocking receive
+      receive_callback_(message);
     }
+  }
 }
 
 //==============================================================================
@@ -472,42 +466,47 @@ void McuCan::HandleReceiveInterrupt() {
 //==============================================================================
 
 bool McuCan::SupportsCanFD() const noexcept {
-    // ESP32-C6 TWAI does not support CAN-FD currently
-    return false;
+  // ESP32-C6 TWAI does not support CAN-FD currently
+  return false;
 }
 
 bool McuCan::SetCanFDMode(bool enable, uint32_t data_baudrate, bool enable_brs) noexcept {
-    // ESP32-C6 TWAI does not support CAN-FD
-    (void)enable;
-    (void)data_baudrate;
-    (void)enable_brs;
-    return false;
+  // ESP32-C6 TWAI does not support CAN-FD
+  (void)enable;
+  (void)data_baudrate;
+  (void)enable_brs;
+  return false;
 }
 
-bool McuCan::ConfigureCanFDTiming(uint16_t nominal_prescaler, uint8_t nominal_tseg1, uint8_t nominal_tseg2,
-                                  uint16_t data_prescaler, uint8_t data_tseg1, uint8_t data_tseg2,
-                                  uint8_t sjw) noexcept {
-    // ESP32-C6 TWAI does not support CAN-FD
-    (void)nominal_prescaler; (void)nominal_tseg1; (void)nominal_tseg2;
-    (void)data_prescaler; (void)data_tseg1; (void)data_tseg2;
-    (void)sjw;
-    return false;
+bool McuCan::ConfigureCanFDTiming(uint16_t nominal_prescaler, uint8_t nominal_tseg1,
+                                  uint8_t nominal_tseg2, uint16_t data_prescaler,
+                                  uint8_t data_tseg1, uint8_t data_tseg2, uint8_t sjw) noexcept {
+  // ESP32-C6 TWAI does not support CAN-FD
+  (void)nominal_prescaler;
+  (void)nominal_tseg1;
+  (void)nominal_tseg2;
+  (void)data_prescaler;
+  (void)data_tseg1;
+  (void)data_tseg2;
+  (void)sjw;
+  return false;
 }
 
 bool McuCan::SetTransmitterDelayCompensation(uint8_t tdc_offset, uint8_t tdc_filter) noexcept {
-    // ESP32-C6 TWAI does not support CAN-FD
-    (void)tdc_offset;
-    (void)tdc_filter;
-    return false;
+  // ESP32-C6 TWAI does not support CAN-FD
+  (void)tdc_offset;
+  (void)tdc_filter;
+  return false;
 }
 
-bool McuCan::GetCanFDCapabilities(uint8_t& max_data_bytes, uint32_t& max_nominal_baudrate,
-                                  uint32_t& max_data_baudrate, bool& supports_brs, bool& supports_esi) noexcept {
-    // ESP32-C6 TWAI does not support CAN-FD, but we can return classic CAN limits
-    max_data_bytes = 8;                 // Classic CAN limit
-    max_nominal_baudrate = 1000000;     // 1 Mbps max for ESP32-C6
-    max_data_baudrate = 0;              // No data phase for classic CAN
-    supports_brs = false;               // No BRS support
-    supports_esi = false;               // No ESI support
-    return true;                        // Return true to indicate we can provide classic CAN capabilities
+bool McuCan::GetCanFDCapabilities(uint8_t &max_data_bytes, uint32_t &max_nominal_baudrate,
+                                  uint32_t &max_data_baudrate, bool &supports_brs,
+                                  bool &supports_esi) noexcept {
+  // ESP32-C6 TWAI does not support CAN-FD, but we can return classic CAN limits
+  max_data_bytes = 8;             // Classic CAN limit
+  max_nominal_baudrate = 1000000; // 1 Mbps max for ESP32-C6
+  max_data_baudrate = 0;          // No data phase for classic CAN
+  supports_brs = false;           // No BRS support
+  supports_esi = false;           // No ESI support
+  return true;                    // Return true to indicate we can provide classic CAN capabilities
 }

--- a/src/mcu/McuGpio.cpp
+++ b/src/mcu/McuGpio.cpp
@@ -4,7 +4,7 @@
  *
  * This file contains the implementation of MCU-specific GPIO operations
  * for the unified BaseGpio class with advanced ESP32C6/ESP-IDF v5.5+ features.
- * It handles dynamic mode switching, pull resistor configuration, platform-specific 
+ * It handles dynamic mode switching, pull resistor configuration, platform-specific
  * GPIO management, glitch filtering, power management, and RTC GPIO support.
  */
 
@@ -13,62 +13,48 @@
 
 // Platform-specific includes via centralized McuSelect.h (included in McuGpio.h)
 #ifdef HF_MCU_ESP32C6
-    // ESP32-C6 specific includes (already included via McuSelect.h)
-    static const char* TAG = "McuGpio";
+// ESP32-C6 specific includes (already included via McuSelect.h)
+static const char *TAG = "McuGpio";
 #elif defined(HF_MCU_FAMILY_ESP32)
-    // ESP32 family includes for advanced GPIO features
-    #include "driver/rtc_io.h"
-    #include "esp_sleep.h"
-    #include "soc/rtc.h"
-    static const char* TAG = "McuGpio";
+// ESP32 family includes for advanced GPIO features
+#include "driver/rtc_io.h"
+#include "esp_sleep.h"
+#include "soc/rtc.h"
+static const char *TAG = "McuGpio";
 #else
-    #error "Unsupported MCU platform. Please add support for your target MCU."
+#error "Unsupported MCU platform. Please add support for your target MCU."
 #endif
 
 //==============================================================================
 // Constructor
 //==============================================================================
 
-McuGpio::McuGpio(HfPinNumber pin_num, 
-                    Direction direction,
-                    ActiveState active_state,
-                    OutputMode output_mode,
-                    PullMode pull_mode,
-                    GpioDriveCapability drive_capability) noexcept
-    : BaseGpio(pin_num, direction, active_state, output_mode, pull_mode)
-    , interrupt_trigger_(InterruptTrigger::None)
-    , interrupt_callback_(nullptr)
-    , interrupt_user_data_(nullptr)
-    , interrupt_enabled_(false)
-    , interrupt_count_(0)
-    , platform_semaphore_(nullptr)
-    , drive_capability_(drive_capability)
-    , glitch_filter_type_(GpioGlitchFilterType::None)
-    , pin_glitch_filter_enabled_(false)
-    , flex_glitch_filter_enabled_(false)
-    , flex_filter_config_{}
-    , sleep_config_{}
-    , hold_enabled_(false)
-    , rtc_gpio_enabled_(false)
-    , wakeup_config_{}
-    , glitch_filter_handle_(nullptr)
-    , rtc_gpio_handle_(nullptr)
-{    
-    // Constructor delegates to BaseGpio base class
-    // Initialize interrupt state and advanced features
-    
-    // Initialize sleep configuration to safe defaults
-    sleep_config_.sleep_direction = Direction::Input;
-    sleep_config_.sleep_pull_mode = PullMode::Floating;
-    sleep_config_.sleep_output_enable = false;
-    sleep_config_.sleep_input_enable = true;
-    sleep_config_.hold_during_sleep = false;
-    
-    // Initialize wake-up configuration
-    wakeup_config_.wake_trigger = InterruptTrigger::None;
-    wakeup_config_.enable_rtc_wake = false;
-    wakeup_config_.enable_ext1_wake = false;
-    wakeup_config_.wake_level = 0;
+McuGpio::McuGpio(HfPinNumber pin_num, Direction direction, ActiveState active_state,
+                 OutputMode output_mode, PullMode pull_mode,
+                 GpioDriveCapability drive_capability) noexcept
+    : BaseGpio(pin_num, direction, active_state, output_mode, pull_mode),
+      interrupt_trigger_(InterruptTrigger::None), interrupt_callback_(nullptr),
+      interrupt_user_data_(nullptr), interrupt_enabled_(false), interrupt_count_(0),
+      platform_semaphore_(nullptr), drive_capability_(drive_capability),
+      glitch_filter_type_(GpioGlitchFilterType::None), pin_glitch_filter_enabled_(false),
+      flex_glitch_filter_enabled_(false), flex_filter_config_{}, sleep_config_{},
+      hold_enabled_(false), rtc_gpio_enabled_(false), wakeup_config_{},
+      glitch_filter_handle_(nullptr), rtc_gpio_handle_(nullptr) {
+  // Constructor delegates to BaseGpio base class
+  // Initialize interrupt state and advanced features
+
+  // Initialize sleep configuration to safe defaults
+  sleep_config_.sleep_direction = Direction::Input;
+  sleep_config_.sleep_pull_mode = PullMode::Floating;
+  sleep_config_.sleep_output_enable = false;
+  sleep_config_.sleep_input_enable = true;
+  sleep_config_.hold_during_sleep = false;
+
+  // Initialize wake-up configuration
+  wakeup_config_.wake_trigger = InterruptTrigger::None;
+  wakeup_config_.enable_rtc_wake = false;
+  wakeup_config_.enable_ext1_wake = false;
+  wakeup_config_.wake_level = 0;
 }
 
 //==============================================================================
@@ -76,11 +62,11 @@ McuGpio::McuGpio(HfPinNumber pin_num,
 //==============================================================================
 
 McuGpio::~McuGpio() {
-    // Disable interrupts before cleanup
-    if (interrupt_enabled_) {
-        DisableInterrupt();
-    }
-    CleanupInterruptSemaphore();
+  // Disable interrupts before cleanup
+  if (interrupt_enabled_) {
+    DisableInterrupt();
+  }
+  CleanupInterruptSemaphore();
 }
 
 //==============================================================================
@@ -88,142 +74,192 @@ McuGpio::~McuGpio() {
 //==============================================================================
 
 bool McuGpio::Initialize() noexcept {
-    if (IsInitialized()) {
-        ESP_LOGW(TAG, "Pin %d already initialized", pin_);
-        return true;
-    }
-
-    InitializeInterruptSemaphore();
-    
-    if (!ValidatePinNumber()) {
-        ESP_LOGE(TAG, "Invalid pin number %d", pin_);
-        return false;
-    }
-
-    if (!IsPinAvailable()) {
-        ESP_LOGE(TAG, "Pin %d not available for GPIO", pin_);
-        return false;
-    }
-
-    // Apply initial configuration
-    HfGpioErr result = ApplyConfiguration();
-    if (result != HfGpioErr::GPIO_SUCCESS) {        ESP_LOGE(TAG, "Failed to configure pin %d: %s", pin_, 
-                 HfGpioErrToString(result));
-        return false;
-    }
-
-    ESP_LOGI(TAG, "Initialized pin %d as %s, %s, %s", 
-             pin_,
-             ToString(current_direction_),
-             ToString(active_state_),
-             ToString(pull_mode_));
-
+  if (IsInitialized()) {
+    ESP_LOGW(TAG, "Pin %d already initialized", pin_);
     return true;
+  }
+
+  InitializeInterruptSemaphore();
+
+  if (!ValidatePinNumber()) {
+    ESP_LOGE(TAG, "Invalid pin number %d", pin_);
+    return false;
+  }
+
+  if (!IsPinAvailable()) {
+    ESP_LOGE(TAG, "Pin %d not available for GPIO", pin_);
+    return false;
+  }
+
+  // Apply initial configuration
+  HfGpioErr result = ApplyConfiguration();
+  if (result != HfGpioErr::GPIO_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure pin %d: %s", pin_, HfGpioErrToString(result));
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Initialized pin %d as %s, %s, %s", pin_, ToString(current_direction_),
+           ToString(active_state_), ToString(pull_mode_));
+
+  return true;
 }
 
 bool McuGpio::Deinitialize() noexcept {
-    if (!IsInitialized()) {
-        return true;
-    }
+  if (!IsInitialized()) {
+    return true;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Reset pin to safe default state
-    gpio_config_t io_conf = {};
-    io_conf.pin_bit_mask = (1ULL << pin_);
-    io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.intr_type = GPIO_INTR_DISABLE;
-    
-    esp_err_t result = gpio_config(&io_conf);
-    if (result != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to deinitialize pin %d: %s", pin_, esp_err_to_name(result));
-        return false;
-    }
+  // Reset pin to safe default state
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin_);
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = GPIO_INTR_DISABLE;
+
+  esp_err_t result = gpio_config(&io_conf);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to deinitialize pin %d: %s", pin_, esp_err_to_name(result));
+    return false;
+  }
 #endif
 
-    ESP_LOGI(TAG, "Deinitialized pin %d", pin_);
-    return BaseGpio::Deinitialize();
+  ESP_LOGI(TAG, "Deinitialized pin %d", pin_);
+  return BaseGpio::Deinitialize();
 }
 
 bool McuGpio::IsPinAvailable() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Check if pin is valid for GPIO operations
-    if (pin_ < 0 || pin_ >= GPIO_NUM_MAX) {
-        return false;
-    }
-    
+  // Check if pin is valid for GPIO operations
+  if (pin_ < 0 || pin_ >= GPIO_NUM_MAX) {
+    return false;
+  }
+
 #ifdef HF_MCU_ESP32C6
-    // ESP32-C6 specific pin availability (0-30 available)
-    if (pin_ > 30) {
-        return false;
-    }
-    
-    // ESP32-C6 pin restrictions
-    switch (pin_) {
-        // USB pins - reserved for USB functionality
-        case 12: case 13:
-            return false;
-            
-        // Boot strapping pins - use with caution
-        case 8: case 9:
-            ESP_LOGW(TAG, "Pin %d is a bootstrap pin - use with caution", pin_);
-            return true;
-            
-        // Valid GPIO pins for ESP32-C6
-        case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7:
-        case 10: case 11: case 14: case 15: case 16: case 17: case 18: case 19:
-        case 20: case 21: case 22: case 23: case 24: case 25: case 26: case 27:
-        case 28: case 29: case 30:
-            return true;
-            
-        default:
-            return false;
-    }
-    
+  // ESP32-C6 specific pin availability (0-30 available)
+  if (pin_ > 30) {
+    return false;
+  }
+
+  // ESP32-C6 pin restrictions
+  switch (pin_) {
+  // USB pins - reserved for USB functionality
+  case 12:
+  case 13:
+    return false;
+
+  // Boot strapping pins - use with caution
+  case 8:
+  case 9:
+    ESP_LOGW(TAG, "Pin %d is a bootstrap pin - use with caution", pin_);
+    return true;
+
+  // Valid GPIO pins for ESP32-C6
+  case 0:
+  case 1:
+  case 2:
+  case 3:
+  case 4:
+  case 5:
+  case 6:
+  case 7:
+  case 10:
+  case 11:
+  case 14:
+  case 15:
+  case 16:
+  case 17:
+  case 18:
+  case 19:
+  case 20:
+  case 21:
+  case 22:
+  case 23:
+  case 24:
+  case 25:
+  case 26:
+  case 27:
+  case 28:
+  case 29:
+  case 30:
+    return true;
+
+  default:
+    return false;
+  }
+
 #else
-    // ESP32 Classic pin availability checks
-    switch (pin_) {
-        // Input-only pins on ESP32 Classic
-        case 34: case 35: case 36: case 37: case 38: case 39:
-            return (current_direction_ == Direction::Input);
-        
-        // Flash pins - typically reserved
-        case 6: case 7: case 8: case 9: case 10: case 11:
-            return false;
-            
-        // Valid GPIO pins for ESP32 Classic
-        case 0: case 1: case 2: case 3: case 4: case 5:
-        case 12: case 13: case 14: case 15: case 16: case 17: case 18: case 19:
-        case 21: case 22: case 23: case 25: case 26: case 27:
-        case 32: case 33:
-            return true;
-            
-        default:
-            return false;
-    }
+  // ESP32 Classic pin availability checks
+  switch (pin_) {
+  // Input-only pins on ESP32 Classic
+  case 34:
+  case 35:
+  case 36:
+  case 37:
+  case 38:
+  case 39:
+    return (current_direction_ == Direction::Input);
+
+  // Flash pins - typically reserved
+  case 6:
+  case 7:
+  case 8:
+  case 9:
+  case 10:
+  case 11:
+    return false;
+
+  // Valid GPIO pins for ESP32 Classic
+  case 0:
+  case 1:
+  case 2:
+  case 3:
+  case 4:
+  case 5:
+  case 12:
+  case 13:
+  case 14:
+  case 15:
+  case 16:
+  case 17:
+  case 18:
+  case 19:
+  case 21:
+  case 22:
+  case 23:
+  case 25:
+  case 26:
+  case 27:
+  case 32:
+  case 33:
+    return true;
+
+  default:
+    return false;
+  }
 #endif
 
 #else
-    // Add other MCU platform checks here
-    return (pin_ >= 0);
+  // Add other MCU platform checks here
+  return (pin_ >= 0);
 #endif
 }
 
 uint8_t McuGpio::GetMaxPins() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    return GPIO_NUM_MAX;
+  return GPIO_NUM_MAX;
 #else
-    return 32; // Default fallback
+  return 32; // Default fallback
 #endif
 }
 
-const char* McuGpio::GetDescription() const noexcept {
-    return "McuGpio - Unified MCU GPIO with dynamic mode switching";
+const char *McuGpio::GetDescription() const noexcept {
+  return "McuGpio - Unified MCU GPIO with dynamic mode switching";
 }
 
 bool McuGpio::SupportsInterrupts() const noexcept {
-    return true; // Most MCU GPIOs support interrupts
+  return true; // Most MCU GPIOs support interrupts
 }
 
 //==============================================================================
@@ -232,301 +268,304 @@ bool McuGpio::SupportsInterrupts() const noexcept {
 
 HfGpioErr McuGpio::SetDirectionImpl(Direction direction) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    gpio_config_t io_conf = {};
-    io_conf.pin_bit_mask = (1ULL << pin);
-    
-    if (direction == Direction::Input) {
-        io_conf.mode = GPIO_MODE_INPUT;
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin);
+
+  if (direction == Direction::Input) {
+    io_conf.mode = GPIO_MODE_INPUT;
+  } else {
+    // Configure as output with current output mode
+    if (output_mode_ == OutputMode::OpenDrain) {
+      io_conf.mode = GPIO_MODE_OUTPUT_OD;
     } else {
-        // Configure as output with current output mode
-        if (output_mode_ == OutputMode::OpenDrain) {
-            io_conf.mode = GPIO_MODE_OUTPUT_OD;
-        } else {
-            io_conf.mode = GPIO_MODE_OUTPUT;
-        }
+      io_conf.mode = GPIO_MODE_OUTPUT;
     }
-    
-    // Apply current pull mode
-    switch (pull_mode_) {
-        case PullMode::PullUp:
-            io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
-            io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-            break;
-        case PullMode::PullDown:
-            io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-            io_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
-            break;
-        case PullMode::Floating:
-        default:
-            io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-            io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-            break;
-    }
-    
-    io_conf.intr_type = GPIO_INTR_DISABLE;
-    
-    esp_err_t result = gpio_config(&io_conf);
-    if (result != ESP_OK) {        ESP_LOGE(TAG, "Failed to set direction for pin %d: %s", pin_, esp_err_to_name(result));
-        return HfGpioErr::GPIO_ERR_HARDWARE_FAULT;
-    }
-    
-    ESP_LOGD(TAG, "Set pin %d direction to %s", pin_, ToString(direction));
-    return HfGpioErr::GPIO_SUCCESS;
+  }
+
+  // Apply current pull mode
+  switch (pull_mode_) {
+  case PullMode::PullUp:
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    break;
+  case PullMode::PullDown:
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
+    break;
+  case PullMode::Floating:
+  default:
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    break;
+  }
+
+  io_conf.intr_type = GPIO_INTR_DISABLE;
+
+  esp_err_t result = gpio_config(&io_conf);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set direction for pin %d: %s", pin_, esp_err_to_name(result));
+    return HfGpioErr::GPIO_ERR_HARDWARE_FAULT;
+  }
+
+  ESP_LOGD(TAG, "Set pin %d direction to %s", pin_, ToString(direction));
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfGpioErr McuGpio::SetOutputModeImpl(OutputMode mode) noexcept {
-    // For MCUs, output mode change typically requires reconfiguring the pin
-    // if it's currently an output
-    if (current_direction_ == Direction::Output) {
-        return SetDirectionImpl(Direction::Output); // Reconfigure with new mode
-    }
-      ESP_LOGD(TAG, "Set pin %d output mode to %s (will apply on next output config)", 
-             pin_, ToString(mode));
-    return HfGpioErr::GPIO_SUCCESS;
+  // For MCUs, output mode change typically requires reconfiguring the pin
+  // if it's currently an output
+  if (current_direction_ == Direction::Output) {
+    return SetDirectionImpl(Direction::Output); // Reconfigure with new mode
+  }
+  ESP_LOGD(TAG, "Set pin %d output mode to %s (will apply on next output config)", pin_,
+           ToString(mode));
+  return HfGpioErr::GPIO_SUCCESS;
 }
 
 HfGpioErr McuGpio::SetActiveImpl() noexcept {
-    if (current_direction_ != Direction::Output) {
-        return HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
-    }
+  if (current_direction_ != Direction::Output) {
+    return HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    bool level = StateToLevel(State::Active);
-    esp_err_t result = gpio_set_level(static_cast<gpio_num_t>(pin), level ? 1 : 0);
-    
-    if (result != ESP_OK) {        ESP_LOGE(TAG, "Failed to set pin %d active: %s", pin_, esp_err_to_name(result));
-        return HfGpioErr::GPIO_ERR_WRITE_FAILURE;
-    }
-    
-    ESP_LOGV(TAG, "Set pin %d to active (%s)", pin_, level ? "HIGH" : "LOW");
-    return HfGpioErr::GPIO_SUCCESS;
+  bool level = StateToLevel(State::Active);
+  esp_err_t result = gpio_set_level(static_cast<gpio_num_t>(pin), level ? 1 : 0);
+
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set pin %d active: %s", pin_, esp_err_to_name(result));
+    return HfGpioErr::GPIO_ERR_WRITE_FAILURE;
+  }
+
+  ESP_LOGV(TAG, "Set pin %d to active (%s)", pin_, level ? "HIGH" : "LOW");
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfGpioErr McuGpio::SetInactiveImpl() noexcept {
-    if (current_direction_ != Direction::Output) {
-        return HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
-    }
+  if (current_direction_ != Direction::Output) {
+    return HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    bool level = StateToLevel(State::Inactive);
-    esp_err_t result = gpio_set_level(static_cast<gpio_num_t>(pin), level ? 1 : 0);
-    
-    if (result != ESP_OK) {        ESP_LOGE(TAG, "Failed to set pin %d inactive: %s", pin_, esp_err_to_name(result));
-        return HfGpioErr::GPIO_ERR_WRITE_FAILURE;
-    }
-    
-    ESP_LOGV(TAG, "Set pin %d to inactive (%s)", pin_, level ? "HIGH" : "LOW");
-    return HfGpioErr::GPIO_SUCCESS;
+  bool level = StateToLevel(State::Inactive);
+  esp_err_t result = gpio_set_level(static_cast<gpio_num_t>(pin), level ? 1 : 0);
+
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set pin %d inactive: %s", pin_, esp_err_to_name(result));
+    return HfGpioErr::GPIO_ERR_WRITE_FAILURE;
+  }
+
+  ESP_LOGV(TAG, "Set pin %d to inactive (%s)", pin_, level ? "HIGH" : "LOW");
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfGpioErr McuGpio::IsActiveImpl(bool& is_active) noexcept {
+HfGpioErr McuGpio::IsActiveImpl(bool &is_active) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    int level = gpio_get_level(static_cast<gpio_num_t>(pin));
-    if (level < 0) {
-        ESP_LOGE(TAG, "Failed to read pin %d level", pin);
-        return HfGpioErr::GPIO_ERR_READ_FAILURE;
-    }
-    
-    State current_state = LevelToState(level != 0);
-    is_active = (current_state == State::Active);
-      ESP_LOGV(TAG, "Read pin %d: %s (%s)", pin_, 
-             is_active ? "ACTIVE" : "INACTIVE", 
-             level ? "HIGH" : "LOW");
-    
-    return HfGpioErr::GPIO_SUCCESS;
+  int level = gpio_get_level(static_cast<gpio_num_t>(pin));
+  if (level < 0) {
+    ESP_LOGE(TAG, "Failed to read pin %d level", pin);
+    return HfGpioErr::GPIO_ERR_READ_FAILURE;
+  }
+
+  State current_state = LevelToState(level != 0);
+  is_active = (current_state == State::Active);
+  ESP_LOGV(TAG, "Read pin %d: %s (%s)", pin_, is_active ? "ACTIVE" : "INACTIVE",
+           level ? "HIGH" : "LOW");
+
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfGpioErr McuGpio::ToggleImpl() noexcept {
-    if (current_direction_ != Direction::Output) {
-        return HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
-    }
+  if (current_direction_ != Direction::Output) {
+    return HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Read current level and invert it
-    int current_level = gpio_get_level(static_cast<gpio_num_t>(pin));
-    if (current_level < 0) {
-        ESP_LOGE(TAG, "Failed to read pin %d level for toggle", pin);
-        return HfGpioErr::GPIO_ERR_READ_FAILURE;
-    }
-    
-    int new_level = current_level ? 0 : 1;
-    esp_err_t result = gpio_set_level(static_cast<gpio_num_t>(pin), new_level);
-    
-    if (result != ESP_OK) {        ESP_LOGE(TAG, "Failed to toggle pin %d: %s", pin_, esp_err_to_name(result));
-        return HfGpioErr::GPIO_ERR_WRITE_FAILURE;
-    }
-    
-    ESP_LOGV(TAG, "Toggled pin %d from %s to %s", pin_, 
-             current_level ? "HIGH" : "LOW", new_level ? "HIGH" : "LOW");
-    return HfGpioErr::GPIO_SUCCESS;
+  // Read current level and invert it
+  int current_level = gpio_get_level(static_cast<gpio_num_t>(pin));
+  if (current_level < 0) {
+    ESP_LOGE(TAG, "Failed to read pin %d level for toggle", pin);
+    return HfGpioErr::GPIO_ERR_READ_FAILURE;
+  }
+
+  int new_level = current_level ? 0 : 1;
+  esp_err_t result = gpio_set_level(static_cast<gpio_num_t>(pin), new_level);
+
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to toggle pin %d: %s", pin_, esp_err_to_name(result));
+    return HfGpioErr::GPIO_ERR_WRITE_FAILURE;
+  }
+
+  ESP_LOGV(TAG, "Toggled pin %d from %s to %s", pin_, current_level ? "HIGH" : "LOW",
+           new_level ? "HIGH" : "LOW");
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfGpioErr McuGpio::SetPullModeImpl(PullMode mode) noexcept {
-    // For MCUs, changing pull mode typically requires reconfiguring the pin
-    return SetDirectionImpl(current_direction_); // Reconfigure with new pull mode
+  // For MCUs, changing pull mode typically requires reconfiguring the pin
+  return SetDirectionImpl(current_direction_); // Reconfigure with new pull mode
 }
 
 BaseGpio::PullMode McuGpio::GetPullModeImpl() const noexcept {
-    // Return cached pull mode - querying from hardware registers is complex
-    // and not always reliable across different MCU platforms
-    return pull_mode_;
+  // Return cached pull mode - querying from hardware registers is complex
+  // and not always reliable across different MCU platforms
+  return pull_mode_;
 }
 
 //==============================================================================
 // Interrupt Functionality Implementation
 //==============================================================================
 
-HfGpioErr McuGpio::ConfigureInterrupt(InterruptTrigger trigger, 
-                                             InterruptCallback callback, 
-                                             void* user_data) noexcept {
-    if (!EnsureInitialized()) {
-        return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
-    }
+HfGpioErr McuGpio::ConfigureInterrupt(InterruptTrigger trigger, InterruptCallback callback,
+                                      void *user_data) noexcept {
+  if (!EnsureInitialized()) {
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+  }
 
-    // Disable interrupt first if it's currently enabled
-    if (interrupt_enabled_) {
-        DisableInterrupt();
-    }
+  // Disable interrupt first if it's currently enabled
+  if (interrupt_enabled_) {
+    DisableInterrupt();
+  }
 
-    // Store configuration
-    interrupt_trigger_ = trigger;
-    interrupt_callback_ = callback;
-    interrupt_user_data_ = user_data;
-    interrupt_count_ = 0;
+  // Store configuration
+  interrupt_trigger_ = trigger;
+  interrupt_callback_ = callback;
+  interrupt_user_data_ = user_data;
+  interrupt_count_ = 0;
 
-    // If trigger is None, just clear configuration
-    if (trigger == InterruptTrigger::None) {
-        return HfGpioErr::GPIO_SUCCESS;
-    }
+  // If trigger is None, just clear configuration
+  if (trigger == InterruptTrigger::None) {
+    return HfGpioErr::GPIO_SUCCESS;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure interrupt type
-    uint32_t platform_trigger = ConvertInterruptTrigger(trigger);
-    if (platform_trigger == GPIO_INTR_DISABLE) {
-        return HfGpioErr::GPIO_ERR_INVALID_PARAMETER;
-    }
+  // Configure interrupt type
+  uint32_t platform_trigger = ConvertInterruptTrigger(trigger);
+  if (platform_trigger == GPIO_INTR_DISABLE) {
+    return HfGpioErr::GPIO_ERR_INVALID_PARAMETER;
+  }
 
-    // Configure GPIO for interrupt
-    gpio_config_t io_conf = {};
-    io_conf.pin_bit_mask = (1ULL << pin_);
-    io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = (pull_mode_ == PullMode::PullUp) ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
-    io_conf.pull_down_en = (pull_mode_ == PullMode::PullDown) ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;
-    io_conf.intr_type = static_cast<gpio_int_type_t>(platform_trigger);
+  // Configure GPIO for interrupt
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin_);
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pull_up_en = (pull_mode_ == PullMode::PullUp) ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
+  io_conf.pull_down_en =
+      (pull_mode_ == PullMode::PullDown) ? GPIO_PULLDOWN_ENABLE : GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = static_cast<gpio_int_type_t>(platform_trigger);
 
-    esp_err_t result = gpio_config(&io_conf);
-    if (result != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to configure interrupt for pin %d: %s", pin_, esp_err_to_name(result));
-        return HfGpioErr::GPIO_ERR_HARDWARE_FAULT;
-    }
+  esp_err_t result = gpio_config(&io_conf);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to configure interrupt for pin %d: %s", pin_, esp_err_to_name(result));
+    return HfGpioErr::GPIO_ERR_HARDWARE_FAULT;
+  }
 #endif
 
-    return HfGpioErr::GPIO_SUCCESS;
+  return HfGpioErr::GPIO_SUCCESS;
 }
 
 HfGpioErr McuGpio::EnableInterrupt() noexcept {
-    if (interrupt_enabled_) {
-        return HfGpioErr::GPIO_ERR_INTERRUPT_ALREADY_ENABLED;
-    }
+  if (interrupt_enabled_) {
+    return HfGpioErr::GPIO_ERR_INTERRUPT_ALREADY_ENABLED;
+  }
 
-    if (interrupt_trigger_ == InterruptTrigger::None) {
-        return HfGpioErr::GPIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (interrupt_trigger_ == InterruptTrigger::None) {
+    return HfGpioErr::GPIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (!EnsureInitialized()) {
-        return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
-    }
+  if (!EnsureInitialized()) {
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Install ISR service if not already installed
-    esp_err_t err = gpio_install_isr_service(0);
-    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
-        ESP_LOGE(TAG, "Failed to install ISR service: %s", esp_err_to_name(err));
-        return HfGpioErr::GPIO_ERR_INTERRUPT_HANDLER_FAILED;
-    }
+  // Install ISR service if not already installed
+  esp_err_t err = gpio_install_isr_service(0);
+  if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "Failed to install ISR service: %s", esp_err_to_name(err));
+    return HfGpioErr::GPIO_ERR_INTERRUPT_HANDLER_FAILED;
+  }
 
-    // Add ISR handler for this pin
-    err = gpio_isr_handler_add(static_cast<gpio_num_t>(pin_), InterruptHandler, this);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to add ISR handler for pin %d: %s", pin_, esp_err_to_name(err));
-        return HfGpioErr::GPIO_ERR_INTERRUPT_HANDLER_FAILED;
-    }
+  // Add ISR handler for this pin
+  err = gpio_isr_handler_add(static_cast<gpio_num_t>(pin_), InterruptHandler, this);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to add ISR handler for pin %d: %s", pin_, esp_err_to_name(err));
+    return HfGpioErr::GPIO_ERR_INTERRUPT_HANDLER_FAILED;
+  }
 #endif
 
-    interrupt_enabled_ = true;
-    ESP_LOGI(TAG, "Interrupt enabled for pin %d with trigger %s", pin_, ToString(interrupt_trigger_));
-    return HfGpioErr::GPIO_SUCCESS;
+  interrupt_enabled_ = true;
+  ESP_LOGI(TAG, "Interrupt enabled for pin %d with trigger %s", pin_, ToString(interrupt_trigger_));
+  return HfGpioErr::GPIO_SUCCESS;
 }
 
 HfGpioErr McuGpio::DisableInterrupt() noexcept {
-    if (!interrupt_enabled_) {
-        return HfGpioErr::GPIO_ERR_INTERRUPT_NOT_ENABLED;
-    }
+  if (!interrupt_enabled_) {
+    return HfGpioErr::GPIO_ERR_INTERRUPT_NOT_ENABLED;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Remove ISR handler
-    esp_err_t err = gpio_isr_handler_remove(static_cast<gpio_num_t>(pin_));
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Failed to remove ISR handler for pin %d: %s", pin_, esp_err_to_name(err));
-        // Continue anyway since we're disabling
-    }
+  // Remove ISR handler
+  esp_err_t err = gpio_isr_handler_remove(static_cast<gpio_num_t>(pin_));
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Failed to remove ISR handler for pin %d: %s", pin_, esp_err_to_name(err));
+    // Continue anyway since we're disabling
+  }
 #endif
 
-    interrupt_enabled_ = false;
-    ESP_LOGI(TAG, "Interrupt disabled for pin %d", pin_);
-    return HfGpioErr::GPIO_SUCCESS;
+  interrupt_enabled_ = false;
+  ESP_LOGI(TAG, "Interrupt disabled for pin %d", pin_);
+  return HfGpioErr::GPIO_SUCCESS;
 }
 
 HfGpioErr McuGpio::WaitForInterrupt(uint32_t timeout_ms) noexcept {
-    if (!interrupt_enabled_) {
-        return HfGpioErr::GPIO_ERR_INTERRUPT_NOT_ENABLED;
-    }
+  if (!interrupt_enabled_) {
+    return HfGpioErr::GPIO_ERR_INTERRUPT_NOT_ENABLED;
+  }
 
-    if (!platform_semaphore_) {
-        return HfGpioErr::GPIO_ERR_SYSTEM_ERROR;
-    }
+  if (!platform_semaphore_) {
+    return HfGpioErr::GPIO_ERR_SYSTEM_ERROR;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    TickType_t timeout_ticks = (timeout_ms == 0) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
-    BaseType_t result = xSemaphoreTake(platform_semaphore_, timeout_ticks);
-    
-    if (result == pdTRUE) {
-        return HfGpioErr::GPIO_SUCCESS;
-    } else {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
+  TickType_t timeout_ticks = (timeout_ms == 0) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
+  BaseType_t result = xSemaphoreTake(platform_semaphore_, timeout_ticks);
+
+  if (result == pdTRUE) {
+    return HfGpioErr::GPIO_SUCCESS;
+  } else {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfGpioErr McuGpio::GetInterruptStatus(InterruptStatus& status) noexcept {
-    status.is_enabled = interrupt_enabled_;
-    status.trigger_type = interrupt_trigger_;
-    status.interrupt_count = interrupt_count_;
-    status.has_callback = (interrupt_callback_ != nullptr);
-    
-    return HfGpioErr::GPIO_SUCCESS;
+HfGpioErr McuGpio::GetInterruptStatus(InterruptStatus &status) noexcept {
+  status.is_enabled = interrupt_enabled_;
+  status.trigger_type = interrupt_trigger_;
+  status.interrupt_count = interrupt_count_;
+  status.has_callback = (interrupt_callback_ != nullptr);
+
+  return HfGpioErr::GPIO_SUCCESS;
 }
 
 HfGpioErr McuGpio::ClearInterruptStats() noexcept {
-    interrupt_count_ = 0;
-    return HfGpioErr::GPIO_SUCCESS;
+  interrupt_count_ = 0;
+  return HfGpioErr::GPIO_SUCCESS;
 }
 
 //==============================================================================
@@ -535,65 +574,66 @@ HfGpioErr McuGpio::ClearInterruptStats() noexcept {
 
 uint32_t McuGpio::ConvertInterruptTrigger(InterruptTrigger trigger) const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    switch (trigger) {
-        case InterruptTrigger::RisingEdge:
-            return gpio_int_type_t::GPIO_INTR_POSEDGE;
-        case InterruptTrigger::FallingEdge:
-            return GPIO_INTR_NEGEDGE;
-        case InterruptTrigger::BothEdges:
-            return GPIO_INTR_ANYEDGE;
-        case InterruptTrigger::LowLevel:
-            return GPIO_INTR_LOW_LEVEL;
-        case InterruptTrigger::HighLevel:
-            return GPIO_INTR_HIGH_LEVEL;
-        case InterruptTrigger::None:
-        default:
-            return GPIO_INTR_DISABLE;
-    }
+  switch (trigger) {
+  case InterruptTrigger::RisingEdge:
+    return gpio_int_type_t::GPIO_INTR_POSEDGE;
+  case InterruptTrigger::FallingEdge:
+    return GPIO_INTR_NEGEDGE;
+  case InterruptTrigger::BothEdges:
+    return GPIO_INTR_ANYEDGE;
+  case InterruptTrigger::LowLevel:
+    return GPIO_INTR_LOW_LEVEL;
+  case InterruptTrigger::HighLevel:
+    return GPIO_INTR_HIGH_LEVEL;
+  case InterruptTrigger::None:
+  default:
+    return GPIO_INTR_DISABLE;
+  }
 #else
-    return 0;
+  return 0;
 #endif
 }
 
-void IRAM_ATTR McuGpio::InterruptHandler(void* arg) noexcept {
-    auto* self = static_cast<McuGpio*>(arg);
-    if (!self) return;
+void IRAM_ATTR McuGpio::InterruptHandler(void *arg) noexcept {
+  auto *self = static_cast<McuGpio *>(arg);
+  if (!self)
+    return;
 
-    // Increment interrupt counter
-    self->interrupt_count_++;
+  // Increment interrupt counter
+  self->interrupt_count_++;
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Signal semaphore for WaitForInterrupt
-    if (self->platform_semaphore_) {
-        BaseType_t higher_priority_task_woken = pdFALSE;
-        xSemaphoreGiveFromISR(self->platform_semaphore_, &higher_priority_task_woken);
-        if (higher_priority_task_woken) {
-            portYIELD_FROM_ISR();
-        }
+  // Signal semaphore for WaitForInterrupt
+  if (self->platform_semaphore_) {
+    BaseType_t higher_priority_task_woken = pdFALSE;
+    xSemaphoreGiveFromISR(self->platform_semaphore_, &higher_priority_task_woken);
+    if (higher_priority_task_woken) {
+      portYIELD_FROM_ISR();
     }
+  }
 #endif
 
-    // Call user callback if registered
-    if (self->interrupt_callback_) {
-        self->interrupt_callback_(self, self->interrupt_trigger_, self->interrupt_user_data_);
-    }
+  // Call user callback if registered
+  if (self->interrupt_callback_) {
+    self->interrupt_callback_(self, self->interrupt_trigger_, self->interrupt_user_data_);
+  }
 }
 
 void McuGpio::InitializeInterruptSemaphore() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    platform_semaphore_ = xSemaphoreCreateBinary();
-    if (!platform_semaphore_) {
-        ESP_LOGE(TAG, "Failed to create interrupt semaphore for pin %d", pin_);
-    }
+  platform_semaphore_ = xSemaphoreCreateBinary();
+  if (!platform_semaphore_) {
+    ESP_LOGE(TAG, "Failed to create interrupt semaphore for pin %d", pin_);
+  }
 #endif
 }
 
 void McuGpio::CleanupInterruptSemaphore() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    if (platform_semaphore_) {
-        vSemaphoreDelete(platform_semaphore_);
-        platform_semaphore_ = nullptr;
-    }
+  if (platform_semaphore_) {
+    vSemaphoreDelete(platform_semaphore_);
+    platform_semaphore_ = nullptr;
+  }
 #endif
 }
 
@@ -603,239 +643,243 @@ void McuGpio::CleanupInterruptSemaphore() noexcept {
 
 HfGpioErr McuGpio::SetDriveCapability(GpioDriveCapability capability) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    if (!IsInitialized()) {
-        drive_capability_ = capability;  // Store for later application
-        return HfGpioErr::GPIO_SUCCESS;
-    }
-    
-    gpio_drive_cap_t esp_drive_cap;
-    switch (capability) {
-        case GpioDriveCapability::Weak:
-            esp_drive_cap = GPIO_DRIVE_CAP_0;  // ~5mA
-            break;
-        case GpioDriveCapability::Stronger:
-            esp_drive_cap = GPIO_DRIVE_CAP_1;  // ~10mA
-            break;
-        case GpioDriveCapability::Medium:
-            esp_drive_cap = GPIO_DRIVE_CAP_2;  // ~20mA
-            break;
-        case GpioDriveCapability::Strongest:
-            esp_drive_cap = GPIO_DRIVE_CAP_3;  // ~40mA
-            break;
-        default:
-            return HfGpioErr::GPIO_ERR_INVALID_CONFIG;
-    }
-    
-    esp_err_t err = gpio_set_drive_capability(static_cast<gpio_num_t>(GetPinNumber()), esp_drive_cap);
-    if (err == ESP_OK) {
-        drive_capability_ = capability;
-        return HfGpioErr::GPIO_SUCCESS;
-    }
-    return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
-#else
-    // Store capability for non-ESP32 platforms
+  if (!IsInitialized()) {
+    drive_capability_ = capability; // Store for later application
+    return HfGpioErr::GPIO_SUCCESS;
+  }
+
+  gpio_drive_cap_t esp_drive_cap;
+  switch (capability) {
+  case GpioDriveCapability::Weak:
+    esp_drive_cap = GPIO_DRIVE_CAP_0; // ~5mA
+    break;
+  case GpioDriveCapability::Stronger:
+    esp_drive_cap = GPIO_DRIVE_CAP_1; // ~10mA
+    break;
+  case GpioDriveCapability::Medium:
+    esp_drive_cap = GPIO_DRIVE_CAP_2; // ~20mA
+    break;
+  case GpioDriveCapability::Strongest:
+    esp_drive_cap = GPIO_DRIVE_CAP_3; // ~40mA
+    break;
+  default:
+    return HfGpioErr::GPIO_ERR_INVALID_CONFIG;
+  }
+
+  esp_err_t err = gpio_set_drive_capability(static_cast<gpio_num_t>(GetPinNumber()), esp_drive_cap);
+  if (err == ESP_OK) {
     drive_capability_ = capability;
     return HfGpioErr::GPIO_SUCCESS;
+  }
+  return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
+#else
+  // Store capability for non-ESP32 platforms
+  drive_capability_ = capability;
+  return HfGpioErr::GPIO_SUCCESS;
 #endif
 }
 
 bool McuGpio::SupportsGlitchFilter() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    return true;  // ESP32C6 supports glitch filters
+  return true; // ESP32C6 supports glitch filters
 #else
-    return false;
+  return false;
 #endif
 }
 
 HfGpioErr McuGpio::ConfigurePinGlitchFilter(bool enable) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Note: Pin glitch filter configuration would be implemented here
-    // with ESP-IDF v5.5+ GPIO glitch filter APIs
-    pin_glitch_filter_enabled_ = enable;
-    if (enable) {
-        if (glitch_filter_type_ == GpioGlitchFilterType::None) {
-            glitch_filter_type_ = GpioGlitchFilterType::Pin;
-        } else if (glitch_filter_type_ == GpioGlitchFilterType::Flex) {
-            glitch_filter_type_ = GpioGlitchFilterType::Both;
-        }
-    } else {
-        if (glitch_filter_type_ == GpioGlitchFilterType::Pin) {
-            glitch_filter_type_ = GpioGlitchFilterType::None;
-        } else if (glitch_filter_type_ == GpioGlitchFilterType::Both) {
-            glitch_filter_type_ = GpioGlitchFilterType::Flex;
-        }
+  // Note: Pin glitch filter configuration would be implemented here
+  // with ESP-IDF v5.5+ GPIO glitch filter APIs
+  pin_glitch_filter_enabled_ = enable;
+  if (enable) {
+    if (glitch_filter_type_ == GpioGlitchFilterType::None) {
+      glitch_filter_type_ = GpioGlitchFilterType::Pin;
+    } else if (glitch_filter_type_ == GpioGlitchFilterType::Flex) {
+      glitch_filter_type_ = GpioGlitchFilterType::Both;
     }
-    return HfGpioErr::GPIO_SUCCESS;
+  } else {
+    if (glitch_filter_type_ == GpioGlitchFilterType::Pin) {
+      glitch_filter_type_ = GpioGlitchFilterType::None;
+    } else if (glitch_filter_type_ == GpioGlitchFilterType::Both) {
+      glitch_filter_type_ = GpioGlitchFilterType::Flex;
+    }
+  }
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfGpioErr McuGpio::ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig& config) noexcept {
+HfGpioErr McuGpio::ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig &config) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Store configuration for ESP-IDF v5.5+ implementation
-    flex_filter_config_ = config;
-    flex_glitch_filter_enabled_ = true;
-    
-    if (glitch_filter_type_ == GpioGlitchFilterType::None) {
-        glitch_filter_type_ = GpioGlitchFilterType::Flex;
-    } else if (glitch_filter_type_ == GpioGlitchFilterType::Pin) {
-        glitch_filter_type_ = GpioGlitchFilterType::Both;
-    }
-    
-    return HfGpioErr::GPIO_SUCCESS;
+  // Store configuration for ESP-IDF v5.5+ implementation
+  flex_filter_config_ = config;
+  flex_glitch_filter_enabled_ = true;
+
+  if (glitch_filter_type_ == GpioGlitchFilterType::None) {
+    glitch_filter_type_ = GpioGlitchFilterType::Flex;
+  } else if (glitch_filter_type_ == GpioGlitchFilterType::Pin) {
+    glitch_filter_type_ = GpioGlitchFilterType::Both;
+  }
+
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfGpioErr McuGpio::EnableGlitchFilters() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Implementation would enable all configured glitch filters
-    return HfGpioErr::GPIO_SUCCESS;
+  // Implementation would enable all configured glitch filters
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfGpioErr McuGpio::DisableGlitchFilters() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Implementation would disable all glitch filters
-    pin_glitch_filter_enabled_ = false;
-    flex_glitch_filter_enabled_ = false;
-    glitch_filter_type_ = GpioGlitchFilterType::None;
-    return HfGpioErr::GPIO_SUCCESS;
+  // Implementation would disable all glitch filters
+  pin_glitch_filter_enabled_ = false;
+  flex_glitch_filter_enabled_ = false;
+  glitch_filter_type_ = GpioGlitchFilterType::None;
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
+  return HfGpioErr::GPIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 bool McuGpio::SupportsRtcGpio() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Check if pin supports RTC GPIO functionality
-    return rtc_gpio_is_valid_gpio(static_cast<gpio_num_t>(GetPinNumber()));
+  // Check if pin supports RTC GPIO functionality
+  return rtc_gpio_is_valid_gpio(static_cast<gpio_num_t>(GetPinNumber()));
 #else
-    return false;
+  return false;
 #endif
 }
 
-HfGpioErr McuGpio::ConfigureSleep(const GpioSleepConfig& config) noexcept {
+HfGpioErr McuGpio::ConfigureSleep(const GpioSleepConfig &config) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    sleep_config_ = config;
-    
-    if (SupportsRtcGpio()) {
-        gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
-        
-        // Configure sleep direction
-        if (config.sleep_direction == Direction::Output) {
-            esp_err_t err = rtc_gpio_set_direction(pin, RTC_GPIO_MODE_OUTPUT_ONLY);
-            if (err != ESP_OK) return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
-        } else {
-            esp_err_t err = rtc_gpio_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
-            if (err != ESP_OK) return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
-        }
-        
-        // Configure pull resistors
-        rtc_gpio_pullup_dis(pin);
-        rtc_gpio_pulldown_dis(pin);
-        if (config.sleep_pull_mode == PullMode::PullUp) {
-            rtc_gpio_pullup_en(pin);
-        } else if (config.sleep_pull_mode == PullMode::PullDown) {
-            rtc_gpio_pulldown_en(pin);
-        }
-        
-        // Configure hold
-        if (config.hold_during_sleep) {
-            rtc_gpio_hold_en(pin);
-        } else {
-            rtc_gpio_hold_dis(pin);
-        }
+  sleep_config_ = config;
+
+  if (SupportsRtcGpio()) {
+    gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
+
+    // Configure sleep direction
+    if (config.sleep_direction == Direction::Output) {
+      esp_err_t err = rtc_gpio_set_direction(pin, RTC_GPIO_MODE_OUTPUT_ONLY);
+      if (err != ESP_OK)
+        return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
+    } else {
+      esp_err_t err = rtc_gpio_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
+      if (err != ESP_OK)
+        return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
     }
-    
-    return HfGpioErr::GPIO_SUCCESS;
+
+    // Configure pull resistors
+    rtc_gpio_pullup_dis(pin);
+    rtc_gpio_pulldown_dis(pin);
+    if (config.sleep_pull_mode == PullMode::PullUp) {
+      rtc_gpio_pullup_en(pin);
+    } else if (config.sleep_pull_mode == PullMode::PullDown) {
+      rtc_gpio_pulldown_en(pin);
+    }
+
+    // Configure hold
+    if (config.hold_during_sleep) {
+      rtc_gpio_hold_en(pin);
+    } else {
+      rtc_gpio_hold_dis(pin);
+    }
+  }
+
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    sleep_config_ = config;
-    return HfGpioErr::GPIO_SUCCESS;
+  sleep_config_ = config;
+  return HfGpioErr::GPIO_SUCCESS;
 #endif
 }
 
 HfGpioErr McuGpio::ConfigureHold(bool enable) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    hold_enabled_ = enable;
-    
-    if (SupportsRtcGpio()) {
-        gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
-        if (enable) {
-            rtc_gpio_hold_en(pin);
-        } else {
-            rtc_gpio_hold_dis(pin);
-        }
+  hold_enabled_ = enable;
+
+  if (SupportsRtcGpio()) {
+    gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
+    if (enable) {
+      rtc_gpio_hold_en(pin);
     } else {
-        // Use digital GPIO hold for non-RTC pins
-        gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
-        if (enable) {
-            gpio_hold_en(pin);
-        } else {
-            gpio_hold_dis(pin);
-        }
+      rtc_gpio_hold_dis(pin);
     }
-    
-    return HfGpioErr::GPIO_SUCCESS;
+  } else {
+    // Use digital GPIO hold for non-RTC pins
+    gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
+    if (enable) {
+      gpio_hold_en(pin);
+    } else {
+      gpio_hold_dis(pin);
+    }
+  }
+
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    hold_enabled_ = enable;
-    return HfGpioErr::GPIO_SUCCESS;
+  hold_enabled_ = enable;
+  return HfGpioErr::GPIO_SUCCESS;
 #endif
 }
 
-HfGpioErr McuGpio::ConfigureWakeUp(const GpioWakeUpConfig& config) noexcept {
+HfGpioErr McuGpio::ConfigureWakeUp(const GpioWakeUpConfig &config) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    wakeup_config_ = config;
-    
-    if (config.enable_rtc_wake && SupportsRtcGpio()) {
-        gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
-        
-        // Configure as RTC GPIO for wake-up
-        esp_err_t err = rtc_gpio_init(pin);
-        if (err != ESP_OK) return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
-        
-        // Set direction for wake-up
-        err = rtc_gpio_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
-        if (err != ESP_OK) return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
-        
-        // Configure wake-up trigger
-        if (config.wake_trigger == InterruptTrigger::RisingEdge || 
-            config.wake_trigger == InterruptTrigger::BothEdges) {
-            esp_sleep_enable_gpio_wakeup();
-        }
+  wakeup_config_ = config;
+
+  if (config.enable_rtc_wake && SupportsRtcGpio()) {
+    gpio_num_t pin = static_cast<gpio_num_t>(GetPinNumber());
+
+    // Configure as RTC GPIO for wake-up
+    esp_err_t err = rtc_gpio_init(pin);
+    if (err != ESP_OK)
+      return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
+
+    // Set direction for wake-up
+    err = rtc_gpio_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
+    if (err != ESP_OK)
+      return HfGpioErr::GPIO_ERR_HARDWARE_FAILURE;
+
+    // Configure wake-up trigger
+    if (config.wake_trigger == InterruptTrigger::RisingEdge ||
+        config.wake_trigger == InterruptTrigger::BothEdges) {
+      esp_sleep_enable_gpio_wakeup();
     }
-    
-    return HfGpioErr::GPIO_SUCCESS;
+  }
+
+  return HfGpioErr::GPIO_SUCCESS;
 #else
-    wakeup_config_ = config;
-    return HfGpioErr::GPIO_SUCCESS;
+  wakeup_config_ = config;
+  return HfGpioErr::GPIO_SUCCESS;
 #endif
 }
 
 GpioConfigDump McuGpio::GetConfigurationDump() const noexcept {
-    GpioConfigDump dump;
-    
-    dump.pin_number = static_cast<uint8_t>(GetPinNumber());
-    dump.direction = GetDirection();
-    dump.pull_mode = GetPullMode();
-    dump.output_mode = GetOutputMode();
-    dump.drive_capability = drive_capability_;
-    dump.input_enabled = (GetDirection() == Direction::Input);
-    dump.output_enabled = (GetDirection() == Direction::Output);
-    dump.open_drain = (GetOutputMode() == OutputMode::OpenDrain);
-    dump.sleep_sel_enabled = false;  // Would be read from hardware
-    dump.function_select = 0;        // Would be read from IOMUX
-    dump.is_rtc_gpio = SupportsRtcGpio();
-    dump.glitch_filter_enabled = (glitch_filter_type_ != GpioGlitchFilterType::None);
-    dump.filter_type = glitch_filter_type_;
-    
-    return dump;
+  GpioConfigDump dump;
+
+  dump.pin_number = static_cast<uint8_t>(GetPinNumber());
+  dump.direction = GetDirection();
+  dump.pull_mode = GetPullMode();
+  dump.output_mode = GetOutputMode();
+  dump.drive_capability = drive_capability_;
+  dump.input_enabled = (GetDirection() == Direction::Input);
+  dump.output_enabled = (GetDirection() == Direction::Output);
+  dump.open_drain = (GetOutputMode() == OutputMode::OpenDrain);
+  dump.sleep_sel_enabled = false; // Would be read from hardware
+  dump.function_select = 0;       // Would be read from IOMUX
+  dump.is_rtc_gpio = SupportsRtcGpio();
+  dump.glitch_filter_enabled = (glitch_filter_type_ != GpioGlitchFilterType::None);
+  dump.filter_type = glitch_filter_type_;
+
+  return dump;
 }
 
 bool McuGpio::IsHeld() const noexcept {
-    return hold_enabled_;
+  return hold_enabled_;
 }

--- a/src/mcu/McuI2c.cpp
+++ b/src/mcu/McuI2c.cpp
@@ -7,27 +7,23 @@
 
 // Platform-specific includes via centralized McuSelect.h
 #ifdef HF_MCU_FAMILY_ESP32
-#include "driver/i2c.h" 
+#include "driver/i2c.h"
 #include "esp_log.h"
-static const char* TAG = "McuI2c";
+static const char *TAG = "McuI2c";
 #endif
 
 //==============================================//
 // CONSTRUCTOR & DESTRUCTOR                     //
 //==============================================//
 
-McuI2c::McuI2c(const I2cBusConfig& config) noexcept
-    : BaseI2cBus(config),
-      platform_handle_(nullptr),
-      last_error_(HfI2cErr::I2C_SUCCESS),
-      transaction_count_(0),
-      bus_locked_(false) {
-}
+McuI2c::McuI2c(const I2cBusConfig &config) noexcept
+    : BaseI2cBus(config), platform_handle_(nullptr), last_error_(HfI2cErr::I2C_SUCCESS),
+      transaction_count_(0), bus_locked_(false) {}
 
 McuI2c::~McuI2c() noexcept {
-    if (initialized_) {
-        Deinitialize();
-    }
+  if (initialized_) {
+    Deinitialize();
+  }
 }
 
 //==============================================//
@@ -35,235 +31,232 @@ McuI2c::~McuI2c() noexcept {
 //==============================================//
 
 bool McuI2c::Initialize() noexcept {
-    if (initialized_) {
-        return true;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    // Validate configuration
-    if (config_.sda_pin == HF_GPIO_INVALID || config_.scl_pin == HF_GPIO_INVALID) {
-        last_error_ = HfI2cErr::I2C_ERR_INVALID_CONFIGURATION;
-        return false;
-    }
-
-    if (config_.clock_speed_hz == 0 || config_.clock_speed_hz > 1000000) {
-        last_error_ = HfI2cErr::I2C_ERR_INVALID_CLOCK_SPEED;
-        return false;
-    }
-
-    // Platform-specific initialization
-    if (!PlatformInitialize()) {
-        return false;
-    }
-
-    last_error_ = HfI2cErr::I2C_SUCCESS;
+  if (initialized_) {
     return true;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Validate configuration
+  if (config_.sda_pin == HF_GPIO_INVALID || config_.scl_pin == HF_GPIO_INVALID) {
+    last_error_ = HfI2cErr::I2C_ERR_INVALID_CONFIGURATION;
+    return false;
+  }
+
+  if (config_.clock_speed_hz == 0 || config_.clock_speed_hz > 1000000) {
+    last_error_ = HfI2cErr::I2C_ERR_INVALID_CLOCK_SPEED;
+    return false;
+  }
+
+  // Platform-specific initialization
+  if (!PlatformInitialize()) {
+    return false;
+  }
+
+  last_error_ = HfI2cErr::I2C_SUCCESS;
+  return true;
 }
 
 bool McuI2c::Deinitialize() noexcept {
-    if (!initialized_) {
-        return true;
-    }
+  if (!initialized_) {
+    return true;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    bool result = PlatformDeinitialize();
-    if (result) {
-        last_error_ = HfI2cErr::I2C_SUCCESS;
-    }
-    
-    return result;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  bool result = PlatformDeinitialize();
+  if (result) {
+    last_error_ = HfI2cErr::I2C_SUCCESS;
+  }
+
+  return result;
 }
 
-HfI2cErr McuI2c::Write(uint8_t device_addr, const uint8_t* data,
-                          uint16_t length, uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
-    }
+HfI2cErr McuI2c::Write(uint8_t device_addr, const uint8_t *data, uint16_t length,
+                       uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized()) {
+    return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
+  }
 
-    if (!data && length > 0) {
-        return HfI2cErr::I2C_ERR_NULL_POINTER;
-    }
+  if (!data && length > 0) {
+    return HfI2cErr::I2C_ERR_NULL_POINTER;
+  }
 
-    if (!IsValidDeviceAddress(device_addr)) {
-        return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
-    }
+  if (!IsValidDeviceAddress(device_addr)) {
+    return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err;
-    uint32_t timeout = GetTimeoutMs(timeout_ms);
-    
-    // Create I2C command link
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    if (!cmd) {
-        last_error_ = HfI2cErr::I2C_ERR_OUT_OF_MEMORY;
-        return last_error_;
-    }
+  esp_err_t err;
+  uint32_t timeout = GetTimeoutMs(timeout_ms);
 
+  // Create I2C command link
+  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+  if (!cmd) {
+    last_error_ = HfI2cErr::I2C_ERR_OUT_OF_MEMORY;
+    return last_error_;
+  }
+
+  // Start condition
+  i2c_master_start(cmd);
+
+  // Write device address with write bit
+  i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_WRITE, true);
+
+  // Write data if any
+  if (length > 0) {
+    i2c_master_write(cmd, data, length, true);
+  }
+
+  // Stop condition
+  i2c_master_stop(cmd);
+
+  // Execute command
+  err = i2c_master_cmd_begin(static_cast<i2c_port_t>(config_.port), cmd, pdMS_TO_TICKS(timeout));
+
+  // Clean up
+  i2c_cmd_link_delete(cmd);
+
+  last_error_ = ConvertPlatformError(err);
+  transaction_count_++;
+
+  return last_error_;
+#else
+  last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
+#endif
+}
+
+HfI2cErr McuI2c::Read(uint8_t device_addr, uint8_t *data, uint16_t length,
+                      uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized()) {
+    return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
+  }
+
+  if (!data || length == 0) {
+    return HfI2cErr::I2C_ERR_INVALID_PARAMETER;
+  }
+
+  if (!IsValidDeviceAddress(device_addr)) {
+    return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+#ifdef HF_MCU_FAMILY_ESP32
+  esp_err_t err;
+  uint32_t timeout = GetTimeoutMs(timeout_ms);
+
+  // Create I2C command link
+  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+  if (!cmd) {
+    last_error_ = HfI2cErr::I2C_ERR_OUT_OF_MEMORY;
+    return last_error_;
+  }
+
+  // Start condition
+  i2c_master_start(cmd);
+
+  // Write device address with read bit
+  i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_READ, true);
+
+  // Read data
+  if (length > 1) {
+    i2c_master_read(cmd, data, length - 1, I2C_MASTER_ACK);
+  }
+  i2c_master_read_byte(cmd, &data[length - 1], I2C_MASTER_NACK);
+
+  // Stop condition
+  i2c_master_stop(cmd);
+
+  // Execute command
+  err = i2c_master_cmd_begin(static_cast<i2c_port_t>(config_.port), cmd, pdMS_TO_TICKS(timeout));
+
+  // Clean up
+  i2c_cmd_link_delete(cmd);
+
+  last_error_ = ConvertPlatformError(err);
+  transaction_count_++;
+
+  return last_error_;
+#else
+  last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
+#endif
+}
+
+HfI2cErr McuI2c::WriteRead(uint8_t device_addr, const uint8_t *tx_data, uint16_t tx_length,
+                           uint8_t *rx_data, uint16_t rx_length, uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized()) {
+    return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
+  }
+
+  if ((!tx_data && tx_length > 0) || (!rx_data && rx_length > 0)) {
+    return HfI2cErr::I2C_ERR_NULL_POINTER;
+  }
+
+  if (!IsValidDeviceAddress(device_addr)) {
+    return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+#ifdef HF_MCU_FAMILY_ESP32
+  esp_err_t err;
+  uint32_t timeout = GetTimeoutMs(timeout_ms);
+
+  // Create I2C command link
+  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+  if (!cmd) {
+    last_error_ = HfI2cErr::I2C_ERR_OUT_OF_MEMORY;
+    return last_error_;
+  }
+
+  // Write phase
+  if (tx_length > 0) {
     // Start condition
     i2c_master_start(cmd);
-    
+
     // Write device address with write bit
     i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_WRITE, true);
-    
-    // Write data if any
-    if (length > 0) {
-        i2c_master_write(cmd, data, length, true);
-    }
-    
-    // Stop condition
-    i2c_master_stop(cmd);
-    
-    // Execute command
-    err = i2c_master_cmd_begin(static_cast<i2c_port_t>(config_.port), cmd, 
-                               pdMS_TO_TICKS(timeout));
-    
-    // Clean up
-    i2c_cmd_link_delete(cmd);
-    
-    last_error_ = ConvertPlatformError(err);
-    transaction_count_++;
-    
-    return last_error_;
-#else
-    last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
-    return last_error_;
-#endif
-}
 
-HfI2cErr McuI2c::Read(uint8_t device_addr, uint8_t* data,
-                         uint16_t length, uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
-    }
+    // Write data
+    i2c_master_write(cmd, tx_data, tx_length, true);
+  }
 
-    if (!data || length == 0) {
-        return HfI2cErr::I2C_ERR_INVALID_PARAMETER;
-    }
-
-    if (!IsValidDeviceAddress(device_addr)) {
-        return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-#ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err;
-    uint32_t timeout = GetTimeoutMs(timeout_ms);
-    
-    // Create I2C command link
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    if (!cmd) {
-        last_error_ = HfI2cErr::I2C_ERR_OUT_OF_MEMORY;
-        return last_error_;
-    }
-
-    // Start condition
+  // Read phase
+  if (rx_length > 0) {
+    // Repeated start condition
     i2c_master_start(cmd);
-    
+
     // Write device address with read bit
     i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_READ, true);
-    
+
     // Read data
-    if (length > 1) {
-        i2c_master_read(cmd, data, length - 1, I2C_MASTER_ACK);
+    if (rx_length > 1) {
+      i2c_master_read(cmd, rx_data, rx_length - 1, I2C_MASTER_ACK);
     }
-    i2c_master_read_byte(cmd, &data[length - 1], I2C_MASTER_NACK);
-    
-    // Stop condition
-    i2c_master_stop(cmd);
-    
-    // Execute command
-    err = i2c_master_cmd_begin(static_cast<i2c_port_t>(config_.port), cmd, 
-                               pdMS_TO_TICKS(timeout));
-    
-    // Clean up
-    i2c_cmd_link_delete(cmd);
-    
-    last_error_ = ConvertPlatformError(err);
-    transaction_count_++;
-    
-    return last_error_;
+    i2c_master_read_byte(cmd, &rx_data[rx_length - 1], I2C_MASTER_NACK);
+  }
+
+  // Stop condition
+  i2c_master_stop(cmd);
+
+  // Execute command
+  err = i2c_master_cmd_begin(static_cast<i2c_port_t>(config_.port), cmd, pdMS_TO_TICKS(timeout));
+
+  // Clean up
+  i2c_cmd_link_delete(cmd);
+
+  last_error_ = ConvertPlatformError(err);
+  transaction_count_++;
+
+  return last_error_;
 #else
-    last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
-    return last_error_;
-#endif
-}
-
-HfI2cErr McuI2c::WriteRead(uint8_t device_addr, const uint8_t* tx_data, uint16_t tx_length,
-                              uint8_t* rx_data, uint16_t rx_length, uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
-    }
-
-    if ((!tx_data && tx_length > 0) || (!rx_data && rx_length > 0)) {
-        return HfI2cErr::I2C_ERR_NULL_POINTER;
-    }
-
-    if (!IsValidDeviceAddress(device_addr)) {
-        return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-#ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err;
-    uint32_t timeout = GetTimeoutMs(timeout_ms);
-    
-    // Create I2C command link
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-    if (!cmd) {
-        last_error_ = HfI2cErr::I2C_ERR_OUT_OF_MEMORY;
-        return last_error_;
-    }
-
-    // Write phase
-    if (tx_length > 0) {
-        // Start condition
-        i2c_master_start(cmd);
-        
-        // Write device address with write bit
-        i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_WRITE, true);
-        
-        // Write data
-        i2c_master_write(cmd, tx_data, tx_length, true);
-    }
-    
-    // Read phase
-    if (rx_length > 0) {
-        // Repeated start condition
-        i2c_master_start(cmd);
-        
-        // Write device address with read bit
-        i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_READ, true);
-        
-        // Read data
-        if (rx_length > 1) {
-            i2c_master_read(cmd, rx_data, rx_length - 1, I2C_MASTER_ACK);
-        }
-        i2c_master_read_byte(cmd, &rx_data[rx_length - 1], I2C_MASTER_NACK);
-    }
-    
-    // Stop condition
-    i2c_master_stop(cmd);
-    
-    // Execute command
-    err = i2c_master_cmd_begin(static_cast<i2c_port_t>(config_.port), cmd, 
-                               pdMS_TO_TICKS(timeout));
-    
-    // Clean up
-    i2c_cmd_link_delete(cmd);
-    
-    last_error_ = ConvertPlatformError(err);
-    transaction_count_++;
-    
-    return last_error_;
-#else
-    last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
-    return last_error_;
+  last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
 #endif
 }
 
@@ -272,76 +265,76 @@ HfI2cErr McuI2c::WriteRead(uint8_t device_addr, const uint8_t* tx_data, uint16_t
 //==============================================//
 
 bool McuI2c::IsBusy() noexcept {
-    if (!initialized_) {
-        return false;
-    }
+  if (!initialized_) {
+    return false;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Check if I2C bus is busy (platform specific implementation)
-    // This is a simplified implementation
-    return bus_locked_;
+  // Check if I2C bus is busy (platform specific implementation)
+  // This is a simplified implementation
+  return bus_locked_;
 #else
-    return false;
+  return false;
 #endif
 }
 
 bool McuI2c::ResetBus() noexcept {
-    if (!initialized_) {
-        return false;
-    }
+  if (!initialized_) {
+    return false;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Reset I2C bus by deinitializing and reinitializing
-    if (PlatformDeinitialize() && PlatformInitialize()) {
-        last_error_ = HfI2cErr::I2C_SUCCESS;
-        return true;
-    }
-    return false;
+  // Reset I2C bus by deinitializing and reinitializing
+  if (PlatformDeinitialize() && PlatformInitialize()) {
+    last_error_ = HfI2cErr::I2C_SUCCESS;
+    return true;
+  }
+  return false;
 #else
-    return false;
+  return false;
 #endif
 }
 
 bool McuI2c::SetClockSpeed(uint32_t clock_speed_hz) noexcept {
-    if (clock_speed_hz == 0 || clock_speed_hz > 1000000) {
-        return false;
-    }
+  if (clock_speed_hz == 0 || clock_speed_hz > 1000000) {
+    return false;
+  }
 
-    config_.clock_speed_hz = clock_speed_hz;
-    
-    // Reinitialize if already initialized
-    if (initialized_) {
-        return ResetBus();
-    }
-    
-    return true;
+  config_.clock_speed_hz = clock_speed_hz;
+
+  // Reinitialize if already initialized
+  if (initialized_) {
+    return ResetBus();
+  }
+
+  return true;
 }
 
 bool McuI2c::SetPullUps(bool enable) noexcept {
-    config_.enable_pullups = enable;
-    
-    // Reinitialize if already initialized
-    if (initialized_) {
-        return ResetBus();
-    }
-    
-    return true;
+  config_.enable_pullups = enable;
+
+  // Reinitialize if already initialized
+  if (initialized_) {
+    return ResetBus();
+  }
+
+  return true;
 }
 
 uint32_t McuI2c::GetBusStatus() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Return platform-specific status information
-    return static_cast<uint32_t>(last_error_);
+  // Return platform-specific status information
+  return static_cast<uint32_t>(last_error_);
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 bool McuI2c::RecoverBus() noexcept {
-    // Implement bus recovery sequence (clock stretching, etc.)
-    return ResetBus();
+  // Implement bus recovery sequence (clock stretching, etc.)
+  return ResetBus();
 }
 
 //==============================================//
@@ -350,79 +343,76 @@ bool McuI2c::RecoverBus() noexcept {
 
 HfI2cErr McuI2c::ConvertPlatformError(int32_t platform_error) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    switch (platform_error) {
-        case ESP_OK:
-            return HfI2cErr::I2C_SUCCESS;
-        case ESP_ERR_INVALID_ARG:
-            return HfI2cErr::I2C_ERR_INVALID_PARAMETER;
-        case ESP_ERR_TIMEOUT:
-            return HfI2cErr::I2C_ERR_TIMEOUT;
-        case ESP_FAIL:
-            return HfI2cErr::I2C_ERR_FAILURE;
-        case ESP_ERR_INVALID_STATE:
-            return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
-        default:
-            return HfI2cErr::I2C_ERR_COMMUNICATION_FAILURE;
-    }
+  switch (platform_error) {
+  case ESP_OK:
+    return HfI2cErr::I2C_SUCCESS;
+  case ESP_ERR_INVALID_ARG:
+    return HfI2cErr::I2C_ERR_INVALID_PARAMETER;
+  case ESP_ERR_TIMEOUT:
+    return HfI2cErr::I2C_ERR_TIMEOUT;
+  case ESP_FAIL:
+    return HfI2cErr::I2C_ERR_FAILURE;
+  case ESP_ERR_INVALID_STATE:
+    return HfI2cErr::I2C_ERR_NOT_INITIALIZED;
+  default:
+    return HfI2cErr::I2C_ERR_COMMUNICATION_FAILURE;
+  }
 #else
-    (void)platform_error;
-    return HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
+  (void)platform_error;
+  return HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 bool McuI2c::PlatformInitialize() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure I2C parameters
-    i2c_config_t conf = {};
-    conf.mode = I2C_MODE_MASTER;
-    conf.sda_io_num = static_cast<gpio_num_t>(config_.sda_pin);
-    conf.scl_io_num = static_cast<gpio_num_t>(config_.scl_pin);
-    conf.sda_pullup_en = config_.enable_pullups ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
-    conf.scl_pullup_en = config_.enable_pullups ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
-    conf.master.clk_speed = config_.clock_speed_hz;
+  // Configure I2C parameters
+  i2c_config_t conf = {};
+  conf.mode = I2C_MODE_MASTER;
+  conf.sda_io_num = static_cast<gpio_num_t>(config_.sda_pin);
+  conf.scl_io_num = static_cast<gpio_num_t>(config_.scl_pin);
+  conf.sda_pullup_en = config_.enable_pullups ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
+  conf.scl_pullup_en = config_.enable_pullups ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE;
+  conf.master.clk_speed = config_.clock_speed_hz;
 
-    // Configure I2C
-    esp_err_t err = i2c_param_config(static_cast<i2c_port_t>(config_.port), &conf);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "i2c_param_config failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-
-    // Install I2C driver
-    err = i2c_driver_install(static_cast<i2c_port_t>(config_.port), 
-                            conf.mode, 
-                            config_.rx_buffer_size, 
-                            config_.tx_buffer_size, 
-                            0);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "i2c_driver_install failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-
-    ESP_LOGI(TAG, "I2C bus initialized on port %d, SDA=%d, SCL=%d, clock=%lu Hz",
-             config_.port, config_.sda_pin, config_.scl_pin, config_.clock_speed_hz);
-    
-    return true;
-#else
-    last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
+  // Configure I2C
+  esp_err_t err = i2c_param_config(static_cast<i2c_port_t>(config_.port), &conf);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "i2c_param_config failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
     return false;
+  }
+
+  // Install I2C driver
+  err = i2c_driver_install(static_cast<i2c_port_t>(config_.port), conf.mode, config_.rx_buffer_size,
+                           config_.tx_buffer_size, 0);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "i2c_driver_install failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "I2C bus initialized on port %d, SDA=%d, SCL=%d, clock=%lu Hz", config_.port,
+           config_.sda_pin, config_.scl_pin, config_.clock_speed_hz);
+
+  return true;
+#else
+  last_error_ = HfI2cErr::I2C_ERR_UNSUPPORTED_OPERATION;
+  return false;
 #endif
 }
 
 bool McuI2c::PlatformDeinitialize() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = i2c_driver_delete(static_cast<i2c_port_t>(config_.port));
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "i2c_driver_delete failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-    
-    ESP_LOGI(TAG, "I2C bus deinitialized on port %d", config_.port);
-    return true;
-#else
+  esp_err_t err = i2c_driver_delete(static_cast<i2c_port_t>(config_.port));
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "i2c_driver_delete failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
     return false;
+  }
+
+  ESP_LOGI(TAG, "I2C bus deinitialized on port %d", config_.port);
+  return true;
+#else
+  return false;
 #endif
 }

--- a/src/mcu/McuNvsStorage.cpp
+++ b/src/mcu/McuNvsStorage.cpp
@@ -16,7 +16,8 @@ McuNvsStorage::~McuNvsStorage() noexcept {
 
 bool McuNvsStorage::Open() noexcept {
   if (handle)
-    return true;  hf_err_t err = HF_NVS_FLASH_INIT();
+    return true;
+  hf_err_t err = HF_NVS_FLASH_INIT();
   if (err != HF_OK && err != HF_ERR_NVS_NO_FREE_PAGES && err != HF_ERR_NVS_NEW_VERSION_FOUND) {
     return false;
   }

--- a/src/mcu/McuPeriodicTimer.cpp
+++ b/src/mcu/McuPeriodicTimer.cpp
@@ -7,31 +7,27 @@
 
 // Platform-specific includes
 #ifdef HF_MCU_FAMILY_ESP32
-    #include "esp_timer.h"
-    #include "esp_log.h"
-    #include "esp_err.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_timer.h"
 #else
-    #error "Unsupported MCU platform. Please add support for your target MCU."
+#error "Unsupported MCU platform. Please add support for your target MCU."
 #endif
 
-static const char* TAG = "McuPeriodicTimer";
+static const char *TAG = "McuPeriodicTimer";
 
 //==============================================================================
 // CONSTRUCTOR AND DESTRUCTOR
 //==============================================================================
 
-McuPeriodicTimer::McuPeriodicTimer(TimerCallback callback, void* user_data) noexcept
-    : BasePeriodicTimer(callback, user_data)
-    , timer_handle_(nullptr)
-    , period_us_(0)
-    , stats_{}
-{
-    ESP_LOGD(TAG, "McuPeriodicTimer constructor");
+McuPeriodicTimer::McuPeriodicTimer(TimerCallback callback, void *user_data) noexcept
+    : BasePeriodicTimer(callback, user_data), timer_handle_(nullptr), period_us_(0), stats_{} {
+  ESP_LOGD(TAG, "McuPeriodicTimer constructor");
 }
 
 McuPeriodicTimer::~McuPeriodicTimer() noexcept {
-    Deinitialize();
-    ESP_LOGD(TAG, "McuPeriodicTimer destructor");
+  Deinitialize();
+  ESP_LOGD(TAG, "McuPeriodicTimer destructor");
 }
 
 //==============================================================================
@@ -39,185 +35,186 @@ McuPeriodicTimer::~McuPeriodicTimer() noexcept {
 //==============================================================================
 
 HfTimerErr McuPeriodicTimer::Initialize() noexcept {
-    if (IsInitialized()) {
-        ESP_LOGW(TAG, "Timer already initialized");
-        return HfTimerErr::TIMER_ERR_ALREADY_INITIALIZED;
-    }
+  if (IsInitialized()) {
+    ESP_LOGW(TAG, "Timer already initialized");
+    return HfTimerErr::TIMER_ERR_ALREADY_INITIALIZED;
+  }
 
-    if (!HasValidCallback()) {
-        ESP_LOGE(TAG, "No callback function provided");
-        return HfTimerErr::TIMER_ERR_NULL_POINTER;
-    }
+  if (!HasValidCallback()) {
+    ESP_LOGE(TAG, "No callback function provided");
+    return HfTimerErr::TIMER_ERR_NULL_POINTER;
+  }
 
-    // Create ESP32 timer handle
-    if (!CreateTimerHandle()) {
-        ESP_LOGE(TAG, "Failed to create timer handle");
-        return HfTimerErr::TIMER_ERR_HARDWARE_FAULT;
-    }
+  // Create ESP32 timer handle
+  if (!CreateTimerHandle()) {
+    ESP_LOGE(TAG, "Failed to create timer handle");
+    return HfTimerErr::TIMER_ERR_HARDWARE_FAULT;
+  }
 
-    SetInitialized(true);
-    stats_ = {}; // Reset statistics
-    ESP_LOGI(TAG, "Timer initialized successfully");
-    return HfTimerErr::TIMER_SUCCESS;
+  SetInitialized(true);
+  stats_ = {}; // Reset statistics
+  ESP_LOGI(TAG, "Timer initialized successfully");
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
 HfTimerErr McuPeriodicTimer::Deinitialize() noexcept {
-    if (!IsInitialized()) {
-        return HfTimerErr::TIMER_SUCCESS;
-    }
-
-    // Stop timer if running
-    if (IsRunning()) {
-        Stop();
-    }
-
-    // Clean up timer handle
-    DestroyTimerHandle();
-
-    SetInitialized(false);
-    period_us_ = 0;
-    ESP_LOGI(TAG, "Timer deinitialized");
+  if (!IsInitialized()) {
     return HfTimerErr::TIMER_SUCCESS;
+  }
+
+  // Stop timer if running
+  if (IsRunning()) {
+    Stop();
+  }
+
+  // Clean up timer handle
+  DestroyTimerHandle();
+
+  SetInitialized(false);
+  period_us_ = 0;
+  ESP_LOGI(TAG, "Timer deinitialized");
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
 HfTimerErr McuPeriodicTimer::Start(uint64_t period_us) noexcept {
-    if (!IsInitialized()) {
-        ESP_LOGE(TAG, "Timer not initialized");
-        return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
-    }
+  if (!IsInitialized()) {
+    ESP_LOGE(TAG, "Timer not initialized");
+    return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  }
 
-    if (IsRunning()) {
-        ESP_LOGW(TAG, "Timer already running");
-        return HfTimerErr::TIMER_ERR_ALREADY_RUNNING;
-    }
+  if (IsRunning()) {
+    ESP_LOGW(TAG, "Timer already running");
+    return HfTimerErr::TIMER_ERR_ALREADY_RUNNING;
+  }
 
-    if (!ValidatePeriod(period_us)) {
-        ESP_LOGE(TAG, "Invalid period: %llu us", period_us);
-        return HfTimerErr::TIMER_ERR_INVALID_PERIOD;
-    }
+  if (!ValidatePeriod(period_us)) {
+    ESP_LOGE(TAG, "Invalid period: %llu us", period_us);
+    return HfTimerErr::TIMER_ERR_INVALID_PERIOD;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = esp_timer_start_periodic(static_cast<esp_timer_handle_t>(timer_handle_), period_us);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "esp_timer_start_periodic failed: %s", esp_err_to_name(ret));
-        stats_.last_error = ConvertError(ret);
-        return stats_.last_error;
-    }
+  esp_err_t ret =
+      esp_timer_start_periodic(static_cast<esp_timer_handle_t>(timer_handle_), period_us);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_timer_start_periodic failed: %s", esp_err_to_name(ret));
+    stats_.last_error = ConvertError(ret);
+    return stats_.last_error;
+  }
 #endif
 
-    period_us_ = period_us;
-    SetRunning(true);
-    stats_.start_count++;
-    ESP_LOGI(TAG, "Timer started with period %llu us", period_us);
-    return HfTimerErr::TIMER_SUCCESS;
+  period_us_ = period_us;
+  SetRunning(true);
+  stats_.start_count++;
+  ESP_LOGI(TAG, "Timer started with period %llu us", period_us);
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
 HfTimerErr McuPeriodicTimer::Stop() noexcept {
-    if (!IsInitialized()) {
-        ESP_LOGE(TAG, "Timer not initialized");
-        return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
-    }
+  if (!IsInitialized()) {
+    ESP_LOGE(TAG, "Timer not initialized");
+    return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  }
 
-    if (!IsRunning()) {
-        ESP_LOGW(TAG, "Timer not running");
-        return HfTimerErr::TIMER_ERR_NOT_RUNNING;
-    }
+  if (!IsRunning()) {
+    ESP_LOGW(TAG, "Timer not running");
+    return HfTimerErr::TIMER_ERR_NOT_RUNNING;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = esp_timer_stop(static_cast<esp_timer_handle_t>(timer_handle_));
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "esp_timer_stop failed: %s", esp_err_to_name(ret));
-        stats_.last_error = ConvertError(ret);
-        return stats_.last_error;
-    }
+  esp_err_t ret = esp_timer_stop(static_cast<esp_timer_handle_t>(timer_handle_));
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_timer_stop failed: %s", esp_err_to_name(ret));
+    stats_.last_error = ConvertError(ret);
+    return stats_.last_error;
+  }
 #endif
 
-    SetRunning(false);
-    stats_.stop_count++;
-    ESP_LOGI(TAG, "Timer stopped");
-    return HfTimerErr::TIMER_SUCCESS;
+  SetRunning(false);
+  stats_.stop_count++;
+  ESP_LOGI(TAG, "Timer stopped");
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
 HfTimerErr McuPeriodicTimer::SetPeriod(uint64_t new_period_us) noexcept {
-    if (!IsInitialized()) {
-        ESP_LOGE(TAG, "Timer not initialized");
-        return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  if (!IsInitialized()) {
+    ESP_LOGE(TAG, "Timer not initialized");
+    return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  }
+
+  if (!ValidatePeriod(new_period_us)) {
+    ESP_LOGE(TAG, "Invalid period: %llu us", new_period_us);
+    return HfTimerErr::TIMER_ERR_INVALID_PERIOD;
+  }
+
+  bool was_running = IsRunning();
+
+  // Stop timer if running
+  if (was_running) {
+    HfTimerErr stop_result = Stop();
+    if (stop_result != HfTimerErr::TIMER_SUCCESS) {
+      return stop_result;
     }
+  }
 
-    if (!ValidatePeriod(new_period_us)) {
-        ESP_LOGE(TAG, "Invalid period: %llu us", new_period_us);
-        return HfTimerErr::TIMER_ERR_INVALID_PERIOD;
-    }
+  period_us_ = new_period_us;
 
-    bool was_running = IsRunning();
-    
-    // Stop timer if running
-    if (was_running) {
-        HfTimerErr stop_result = Stop();
-        if (stop_result != HfTimerErr::TIMER_SUCCESS) {
-            return stop_result;
-        }
-    }
+  // Restart with new period if it was running
+  if (was_running) {
+    return Start(new_period_us);
+  }
 
-    period_us_ = new_period_us;
-
-    // Restart with new period if it was running
-    if (was_running) {
-        return Start(new_period_us);
-    }
-
-    ESP_LOGD(TAG, "Period set to %llu us", new_period_us);
-    return HfTimerErr::TIMER_SUCCESS;
+  ESP_LOGD(TAG, "Period set to %llu us", new_period_us);
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
-HfTimerErr McuPeriodicTimer::GetPeriod(uint64_t& period_us) noexcept {
-    if (!IsInitialized()) {
-        return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
-    }
-    period_us = period_us_;
-    return HfTimerErr::TIMER_SUCCESS;
+HfTimerErr McuPeriodicTimer::GetPeriod(uint64_t &period_us) noexcept {
+  if (!IsInitialized()) {
+    return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  }
+  period_us = period_us_;
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
-HfTimerErr McuPeriodicTimer::GetStats(uint64_t& callback_count, uint64_t& missed_callbacks,
-                                     HfTimerErr& last_error) noexcept {
-    if (!IsInitialized()) {
-        return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
-    }
-    callback_count = stats_.callback_count;
-    missed_callbacks = stats_.missed_callbacks;
-    last_error = stats_.last_error;
-    return HfTimerErr::TIMER_SUCCESS;
+HfTimerErr McuPeriodicTimer::GetStats(uint64_t &callback_count, uint64_t &missed_callbacks,
+                                      HfTimerErr &last_error) noexcept {
+  if (!IsInitialized()) {
+    return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  }
+  callback_count = stats_.callback_count;
+  missed_callbacks = stats_.missed_callbacks;
+  last_error = stats_.last_error;
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
 HfTimerErr McuPeriodicTimer::ResetStats() noexcept {
-    if (!IsInitialized()) {
-        return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
-    }
-    stats_ = {};
-    return HfTimerErr::TIMER_SUCCESS;
+  if (!IsInitialized()) {
+    return HfTimerErr::TIMER_ERR_NOT_INITIALIZED;
+  }
+  stats_ = {};
+  return HfTimerErr::TIMER_SUCCESS;
 }
 
-const char* McuPeriodicTimer::GetDescription() const noexcept {
+const char *McuPeriodicTimer::GetDescription() const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    return "ESP32 MCU Periodic Timer (ESP Timer API)";
+  return "ESP32 MCU Periodic Timer (ESP Timer API)";
 #else
-    return "MCU Periodic Timer (Unknown platform)";
+  return "MCU Periodic Timer (Unknown platform)";
 #endif
 }
 
 uint64_t McuPeriodicTimer::GetMinPeriod() const noexcept {
-    // ESP32 timer supports periods from 1us
-    return 1;
+  // ESP32 timer supports periods from 1us
+  return 1;
 }
 
 uint64_t McuPeriodicTimer::GetMaxPeriod() const noexcept {
-    // ESP32 timer supports very large periods, but we limit for safety
-    return UINT64_MAX / 2;
+  // ESP32 timer supports very large periods, but we limit for safety
+  return UINT64_MAX / 2;
 }
 
 uint64_t McuPeriodicTimer::GetResolution() const noexcept {
-    // ESP32 timer has 1us resolution
-    return 1;
+  // ESP32 timer has 1us resolution
+  return 1;
 }
 //==============================================================================
 // PRIVATE METHODS
@@ -225,71 +222,71 @@ uint64_t McuPeriodicTimer::GetResolution() const noexcept {
 
 HfTimerErr McuPeriodicTimer::ConvertError(int platform_error) const noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    switch (platform_error) {
-        case ESP_OK:
-            return HfTimerErr::TIMER_SUCCESS;
-        case ESP_ERR_INVALID_ARG:
-            return HfTimerErr::TIMER_ERR_INVALID_PARAMETER;
-        case ESP_ERR_NO_MEM:
-            return HfTimerErr::TIMER_ERR_OUT_OF_MEMORY;
-        case ESP_ERR_INVALID_STATE:
-            return HfTimerErr::TIMER_ERR_ALREADY_RUNNING;
-        default:
-            return HfTimerErr::TIMER_ERR_FAILURE;
-    }
-#else
+  switch (platform_error) {
+  case ESP_OK:
+    return HfTimerErr::TIMER_SUCCESS;
+  case ESP_ERR_INVALID_ARG:
+    return HfTimerErr::TIMER_ERR_INVALID_PARAMETER;
+  case ESP_ERR_NO_MEM:
+    return HfTimerErr::TIMER_ERR_OUT_OF_MEMORY;
+  case ESP_ERR_INVALID_STATE:
+    return HfTimerErr::TIMER_ERR_ALREADY_RUNNING;
+  default:
     return HfTimerErr::TIMER_ERR_FAILURE;
+  }
+#else
+  return HfTimerErr::TIMER_ERR_FAILURE;
 #endif
 }
 
 bool McuPeriodicTimer::ValidatePeriod(uint64_t period_us) const noexcept {
-    return (period_us >= GetMinPeriod() && period_us <= GetMaxPeriod());
+  return (period_us >= GetMinPeriod() && period_us <= GetMaxPeriod());
 }
 
 bool McuPeriodicTimer::CreateTimerHandle() noexcept {
-    if (timer_handle_) {
-        return true; // Already created
-    }
+  if (timer_handle_) {
+    return true; // Already created
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_timer_create_args_t timer_args = {};
-    timer_args.callback = [](void* arg) {
-        auto* self = static_cast<McuPeriodicTimer*>(arg);
-        if (self && self->HasValidCallback()) {
-            self->stats_.callback_count++;
-            self->ExecuteCallback();
-        }
-    };
-    timer_args.arg = this;
-    timer_args.dispatch_method = ESP_TIMER_TASK;
-    timer_args.name = "HardFOC_Timer";
-
-    esp_timer_handle_t esp_handle;
-    esp_err_t ret = esp_timer_create(&timer_args, &esp_handle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "esp_timer_create failed: %s", esp_err_to_name(ret));
-        return false;
+  esp_timer_create_args_t timer_args = {};
+  timer_args.callback = [](void *arg) {
+    auto *self = static_cast<McuPeriodicTimer *>(arg);
+    if (self && self->HasValidCallback()) {
+      self->stats_.callback_count++;
+      self->ExecuteCallback();
     }
-    
-    timer_handle_ = static_cast<hf_timer_handle_t>(esp_handle);
-    return true;
-#else
+  };
+  timer_args.arg = this;
+  timer_args.dispatch_method = ESP_TIMER_TASK;
+  timer_args.name = "HardFOC_Timer";
+
+  esp_timer_handle_t esp_handle;
+  esp_err_t ret = esp_timer_create(&timer_args, &esp_handle);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_timer_create failed: %s", esp_err_to_name(ret));
     return false;
+  }
+
+  timer_handle_ = static_cast<hf_timer_handle_t>(esp_handle);
+  return true;
+#else
+  return false;
 #endif
 }
 
 void McuPeriodicTimer::DestroyTimerHandle() noexcept {
-    if (!timer_handle_) {
-        return;
-    }
+  if (!timer_handle_) {
+    return;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_timer_handle_t esp_handle = static_cast<esp_timer_handle_t>(timer_handle_);
-    esp_err_t ret = esp_timer_delete(esp_handle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "esp_timer_delete failed: %s", esp_err_to_name(ret));
-    }
+  esp_timer_handle_t esp_handle = static_cast<esp_timer_handle_t>(timer_handle_);
+  esp_err_t ret = esp_timer_delete(esp_handle);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_timer_delete failed: %s", esp_err_to_name(ret));
+  }
 #endif
 
-    timer_handle_ = nullptr;
+  timer_handle_ = nullptr;
 }

--- a/src/mcu/McuPio.cpp
+++ b/src/mcu/McuPio.cpp
@@ -12,45 +12,40 @@
 
 // Platform-specific includes and definitions
 #ifdef HF_MCU_FAMILY_ESP32
-    #include "esp_check.h"
-    #include "esp_log.h"
-    #include "soc/soc_caps.h"
-    #include "hal/rmt_ll.h"
+#include "esp_check.h"
+#include "esp_log.h"
+#include "hal/rmt_ll.h"
+#include "soc/soc_caps.h"
 #else
-    // Stub implementations for non-ESP32 platforms
-    #define ESP_LOGE(tag, format, ...) 
-    #define ESP_LOGW(tag, format, ...)
-    #define ESP_LOGI(tag, format, ...)
-    #define ESP_LOGD(tag, format, ...)
-    #define ESP_OK 0
-    #define ESP_ERR_INVALID_ARG -1
-    #define ESP_ERR_NO_MEM -2
-    #define ESP_ERR_TIMEOUT -3
-    typedef int esp_err_t;
+// Stub implementations for non-ESP32 platforms
+#define ESP_LOGE(tag, format, ...)
+#define ESP_LOGW(tag, format, ...)
+#define ESP_LOGI(tag, format, ...)
+#define ESP_LOGD(tag, format, ...)
+#define ESP_OK 0
+#define ESP_ERR_INVALID_ARG -1
+#define ESP_ERR_NO_MEM -2
+#define ESP_ERR_TIMEOUT -3
+typedef int esp_err_t;
 #endif
 
-static const char* TAG = "McuPio";
+static const char *TAG = "McuPio";
 
 //==============================================================================
 // CONSTRUCTOR AND DESTRUCTOR
 //==============================================================================
 
 McuPio::McuPio() noexcept
-    : initialized_(false)
-    , channels_{}
-    , transmit_callback_(nullptr)
-    , receive_callback_(nullptr)
-    , error_callback_(nullptr)
-    , callback_user_data_(nullptr)
-{
-    ESP_LOGD(TAG, "McuPio constructed");
+    : initialized_(false), channels_{}, transmit_callback_(nullptr), receive_callback_(nullptr),
+      error_callback_(nullptr), callback_user_data_(nullptr) {
+  ESP_LOGD(TAG, "McuPio constructed");
 }
 
 McuPio::~McuPio() noexcept {
-    if (initialized_) {
-        Deinitialize();
-    }
-    ESP_LOGD(TAG, "McuPio destroyed");
+  if (initialized_) {
+    Deinitialize();
+  }
+  ESP_LOGD(TAG, "McuPio destroyed");
 }
 
 //==============================================================================
@@ -58,205 +53,210 @@ McuPio::~McuPio() noexcept {
 //==============================================================================
 
 HfPioErr McuPio::Initialize() noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (initialized_) {
-        ESP_LOGW(TAG, "Already initialized");
-        return HfPioErr::PIO_ERR_ALREADY_INITIALIZED;
-    }
+  std::lock_guard<std::mutex> lock(state_mutex_);
+
+  if (initialized_) {
+    ESP_LOGW(TAG, "Already initialized");
+    return HfPioErr::PIO_ERR_ALREADY_INITIALIZED;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Initialize all channels to default state
-    for (auto& channel : channels_) {
-        channel = ChannelState{};
-    }
+  // Initialize all channels to default state
+  for (auto &channel : channels_) {
+    channel = ChannelState{};
+  }
 
-    initialized_ = true;
-    ESP_LOGI(TAG, "McuPio initialized successfully");
-    return HfPioErr::PIO_SUCCESS;
+  initialized_ = true;
+  ESP_LOGI(TAG, "McuPio initialized successfully");
+  return HfPioErr::PIO_SUCCESS;
 #else
-    ESP_LOGE(TAG, "ESP32 platform not available");
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  ESP_LOGE(TAG, "ESP32 platform not available");
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfPioErr McuPio::Deinitialize() noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  std::lock_guard<std::mutex> lock(state_mutex_);
+
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
+
+  // Deinitialize all configured channels
+  for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
+    if (channels_[i].configured) {
+      DeinitializeChannel(i);
     }
+  }
 
-    // Deinitialize all configured channels
-    for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
-        if (channels_[i].configured) {
-            DeinitializeChannel(i);
-        }
-    }
+  // Clear callbacks
+  transmit_callback_ = nullptr;
+  receive_callback_ = nullptr;
+  error_callback_ = nullptr;
+  callback_user_data_ = nullptr;
 
-    // Clear callbacks
-    transmit_callback_ = nullptr;
-    receive_callback_ = nullptr;
-    error_callback_ = nullptr;
-    callback_user_data_ = nullptr;
-
-    initialized_ = false;
-    ESP_LOGI(TAG, "McuPio deinitialized");
-    return HfPioErr::PIO_SUCCESS;
+  initialized_ = false;
+  ESP_LOGI(TAG, "McuPio deinitialized");
+  return HfPioErr::PIO_SUCCESS;
 }
 
 bool McuPio::IsInitialized() const noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    return initialized_;
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  return initialized_;
 }
 
 //==============================================================================
 // CHANNEL CONFIGURATION
 //==============================================================================
 
-HfPioErr McuPio::ConfigureChannel(uint8_t channel_id, const PioChannelConfig& config) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+HfPioErr McuPio::ConfigureChannel(uint8_t channel_id, const PioChannelConfig &config) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    if (channels_[channel_id].busy) {
-        return HfPioErr::PIO_ERR_CHANNEL_BUSY;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    // Validate configuration
-    if (config.gpio_pin < 0) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (channels_[channel_id].busy) {
+    return HfPioErr::PIO_ERR_CHANNEL_BUSY;
+  }
 
-    if (config.resolution_ns == 0) {
-        return HfPioErr::PIO_ERR_INVALID_RESOLUTION;
-    }
+  // Validate configuration
+  if (config.gpio_pin < 0) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
-    // Store configuration
-    channels_[channel_id].config = config;
-    
-    // Initialize the channel hardware
-    HfPioErr result = InitializeChannel(channel_id);
-    if (result != HfPioErr::PIO_SUCCESS) {
-        return result;
-    }
+  if (config.resolution_ns == 0) {
+    return HfPioErr::PIO_ERR_INVALID_RESOLUTION;
+  }
 
-    channels_[channel_id].configured = true;
-    ESP_LOGI(TAG, "Channel %d configured on GPIO %d", channel_id, config.gpio_pin);
-    
-    return HfPioErr::PIO_SUCCESS;
+  // Store configuration
+  channels_[channel_id].config = config;
+
+  // Initialize the channel hardware
+  HfPioErr result = InitializeChannel(channel_id);
+  if (result != HfPioErr::PIO_SUCCESS) {
+    return result;
+  }
+
+  channels_[channel_id].configured = true;
+  ESP_LOGI(TAG, "Channel %d configured on GPIO %d", channel_id, config.gpio_pin);
+
+  return HfPioErr::PIO_SUCCESS;
 }
 
 //==============================================================================
 // TRANSMISSION OPERATIONS
 //==============================================================================
 
-HfPioErr McuPio::Transmit(uint8_t channel_id, const PioSymbol* symbols, size_t symbol_count, bool wait_completion) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+HfPioErr McuPio::Transmit(uint8_t channel_id, const PioSymbol *symbols, size_t symbol_count,
+                          bool wait_completion) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    if (channels_[channel_id].config.direction == PioDirection::Receive) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (channels_[channel_id].busy) {
-        return HfPioErr::PIO_ERR_CHANNEL_BUSY;
-    }
+  if (channels_[channel_id].config.direction == PioDirection::Receive) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (symbols == nullptr || symbol_count == 0) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (channels_[channel_id].busy) {
+    return HfPioErr::PIO_ERR_CHANNEL_BUSY;
+  }
 
-    if (symbol_count > MAX_SYMBOLS_PER_TRANSMISSION) {
-        return HfPioErr::PIO_ERR_BUFFER_TOO_LARGE;
-    }
+  if (symbols == nullptr || symbol_count == 0) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
-    // Validate symbols
-    HfPioErr validation_result = ValidateSymbols(symbols, symbol_count);
-    if (validation_result != HfPioErr::PIO_SUCCESS) {
-        return validation_result;
-    }
+  if (symbol_count > MAX_SYMBOLS_PER_TRANSMISSION) {
+    return HfPioErr::PIO_ERR_BUFFER_TOO_LARGE;
+  }
+
+  // Validate symbols
+  HfPioErr validation_result = ValidateSymbols(symbols, symbol_count);
+  if (validation_result != HfPioErr::PIO_SUCCESS) {
+    return validation_result;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    
-    if (channel.tx_channel == nullptr) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  auto &channel = channels_[channel_id];
 
-    // Convert PioSymbols to RMT format
-    rmt_symbol_word_t rmt_symbols[MAX_SYMBOLS_PER_TRANSMISSION];
-    size_t rmt_symbol_count = 0;
-    
-    HfPioErr convert_result = ConvertToRmtSymbols(symbols, symbol_count, rmt_symbols, rmt_symbol_count);
-    if (convert_result != HfPioErr::PIO_SUCCESS) {
-        return convert_result;
-    }
+  if (channel.tx_channel == nullptr) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    // Create transmit configuration
-    rmt_transmit_config_t tx_config = {};
-    tx_config.loop_count = 0; // No loop
-    
-    // Start transmission
-    channel.busy = true;
-    channel.status.is_transmitting = true;
-    channel.status.symbols_queued = symbol_count;
-    channel.status.timestamp_us = esp_timer_get_time();
-    
-    // Register TX callbacks
-    rmt_tx_event_callbacks_t tx_callbacks = {};
-    tx_callbacks.on_trans_done = OnTransmitComplete;
-    
-    esp_err_t ret = rmt_tx_register_event_callbacks(channel.tx_channel, &tx_callbacks, this);
+  // Convert PioSymbols to RMT format
+  rmt_symbol_word_t rmt_symbols[MAX_SYMBOLS_PER_TRANSMISSION];
+  size_t rmt_symbol_count = 0;
+
+  HfPioErr convert_result =
+      ConvertToRmtSymbols(symbols, symbol_count, rmt_symbols, rmt_symbol_count);
+  if (convert_result != HfPioErr::PIO_SUCCESS) {
+    return convert_result;
+  }
+
+  // Create transmit configuration
+  rmt_transmit_config_t tx_config = {};
+  tx_config.loop_count = 0; // No loop
+
+  // Start transmission
+  channel.busy = true;
+  channel.status.is_transmitting = true;
+  channel.status.symbols_queued = symbol_count;
+  channel.status.timestamp_us = esp_timer_get_time();
+
+  // Register TX callbacks
+  rmt_tx_event_callbacks_t tx_callbacks = {};
+  tx_callbacks.on_trans_done = OnTransmitComplete;
+
+  esp_err_t ret = rmt_tx_register_event_callbacks(channel.tx_channel, &tx_callbacks, this);
+  if (ret != ESP_OK) {
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    ESP_LOGE(TAG, "Failed to register TX callbacks for channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  ret = rmt_transmit(channel.tx_channel, channel.encoder, rmt_symbols,
+                     rmt_symbol_count * sizeof(rmt_symbol_word_t), &tx_config);
+
+  if (ret != ESP_OK) {
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    ESP_LOGE(TAG, "Failed to start transmission on channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+  if (wait_completion) {
+    // Wait for transmission to complete using ESP-IDF API
+    uint32_t timeout_us = channel.config.timeout_us;
+    ret = rmt_tx_wait_all_done(channel.tx_channel,
+                               timeout_us == 0 ? portMAX_DELAY : pdMS_TO_TICKS(timeout_us / 1000));
     if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        ESP_LOGE(TAG, "Failed to register TX callbacks for channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+      ESP_LOGE(TAG, "Transmission timeout on channel %d", channel_id);
+      return HfPioErr::PIO_ERR_COMMUNICATION_TIMEOUT;
     }
-    
-    ret = rmt_transmit(channel.tx_channel, channel.encoder, rmt_symbols, rmt_symbol_count * sizeof(rmt_symbol_word_t), &tx_config);
-    
-    if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        ESP_LOGE(TAG, "Failed to start transmission on channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-    }    if (wait_completion) {
-        // Wait for transmission to complete using ESP-IDF API  
-        uint32_t timeout_us = channel.config.timeout_us;
-        ret = rmt_tx_wait_all_done(channel.tx_channel, timeout_us == 0 ? portMAX_DELAY : pdMS_TO_TICKS(timeout_us / 1000));
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Transmission timeout on channel %d", channel_id);
-            return HfPioErr::PIO_ERR_COMMUNICATION_TIMEOUT;
-        }
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        channel.status.symbols_processed = symbol_count;
-    }
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    channel.status.symbols_processed = symbol_count;
+  }
 
-    ESP_LOGD(TAG, "Started transmission of %d symbols on channel %d", symbol_count, channel_id);
-    return HfPioErr::PIO_SUCCESS;
+  ESP_LOGD(TAG, "Started transmission of %d symbols on channel %d", symbol_count, channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    ESP_LOGE(TAG, "ESP32 platform not available");
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  ESP_LOGE(TAG, "ESP32 platform not available");
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
@@ -264,114 +264,119 @@ HfPioErr McuPio::Transmit(uint8_t channel_id, const PioSymbol* symbols, size_t s
 // RECEPTION OPERATIONS
 //==============================================================================
 
-HfPioErr McuPio::StartReceive(uint8_t channel_id, PioSymbol* buffer, size_t buffer_size, uint32_t timeout_us) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+HfPioErr McuPio::StartReceive(uint8_t channel_id, PioSymbol *buffer, size_t buffer_size,
+                              uint32_t timeout_us) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    if (channels_[channel_id].config.direction == PioDirection::Transmit) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (channels_[channel_id].busy) {
-        return HfPioErr::PIO_ERR_CHANNEL_BUSY;
-    }
+  if (channels_[channel_id].config.direction == PioDirection::Transmit) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (buffer == nullptr || buffer_size == 0) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (channels_[channel_id].busy) {
+    return HfPioErr::PIO_ERR_CHANNEL_BUSY;
+  }
+
+  if (buffer == nullptr || buffer_size == 0) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    
-    if (channel.rx_channel == nullptr) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  auto &channel = channels_[channel_id];
 
-    // Store buffer information
-    channel.rx_buffer = buffer;
-    channel.rx_buffer_size = buffer_size;
-    channel.rx_symbols_received = 0;
+  if (channel.rx_channel == nullptr) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    // Create receive configuration
-    rmt_receive_config_t rx_config = {};
-    rx_config.signal_range_min_ns = channel.config.resolution_ns;
-    rx_config.signal_range_max_ns = channel.config.resolution_ns * 32767; // Max duration    // Allocate RMT symbol buffer for reception
-    size_t rmt_buffer_size = std::min(buffer_size, static_cast<size_t>(64)); // RMT buffer limit
-    
-    // Start reception
-    channel.busy = true;
-    channel.status.is_receiving = true;
-    channel.status.timestamp_us = esp_timer_get_time();
+  // Store buffer information
+  channel.rx_buffer = buffer;
+  channel.rx_buffer_size = buffer_size;
+  channel.rx_symbols_received = 0;
 
-    // Register RX callbacks
-    rmt_rx_event_callbacks_t rx_callbacks = {};
-    rx_callbacks.on_recv_done = OnReceiveComplete;
-    
-    esp_err_t ret = rmt_rx_register_event_callbacks(channel.rx_channel, &rx_callbacks, this);
-    if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_receiving = false;
-        ESP_LOGE(TAG, "Failed to register RX callbacks for channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-    }
+  // Create receive configuration
+  rmt_receive_config_t rx_config = {};
+  rx_config.signal_range_min_ns = channel.config.resolution_ns;
+  rx_config.signal_range_max_ns =
+      channel.config.resolution_ns *
+      32767; // Max duration    // Allocate RMT symbol buffer for reception
+  size_t rmt_buffer_size = std::min(buffer_size, static_cast<size_t>(64)); // RMT buffer limit
 
-    // Start reception with allocated buffer
-    ret = rmt_receive(channel.rx_channel, nullptr, rmt_buffer_size * sizeof(rmt_symbol_word_t), &rx_config);
-    if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_receiving = false;
-        ESP_LOGE(TAG, "Failed to start reception on channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-    }
+  // Start reception
+  channel.busy = true;
+  channel.status.is_receiving = true;
+  channel.status.timestamp_us = esp_timer_get_time();
 
-    ESP_LOGI(TAG, "Started reception on channel %d", channel_id);
-    return HfPioErr::PIO_SUCCESS;
+  // Register RX callbacks
+  rmt_rx_event_callbacks_t rx_callbacks = {};
+  rx_callbacks.on_recv_done = OnReceiveComplete;
+
+  esp_err_t ret = rmt_rx_register_event_callbacks(channel.rx_channel, &rx_callbacks, this);
+  if (ret != ESP_OK) {
+    channel.busy = false;
+    channel.status.is_receiving = false;
+    ESP_LOGE(TAG, "Failed to register RX callbacks for channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  // Start reception with allocated buffer
+  ret = rmt_receive(channel.rx_channel, nullptr, rmt_buffer_size * sizeof(rmt_symbol_word_t),
+                    &rx_config);
+  if (ret != ESP_OK) {
+    channel.busy = false;
+    channel.status.is_receiving = false;
+    ESP_LOGE(TAG, "Failed to start reception on channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  ESP_LOGI(TAG, "Started reception on channel %d", channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    ESP_LOGE(TAG, "ESP32 platform not available");
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  ESP_LOGE(TAG, "ESP32 platform not available");
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfPioErr McuPio::StopReceive(uint8_t channel_id, size_t& symbols_received) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+HfPioErr McuPio::StopReceive(uint8_t channel_id, size_t &symbols_received) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    auto& channel = channels_[channel_id];
-    
-    if (!channel.status.is_receiving) {
-        symbols_received = 0;
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
+
+  auto &channel = channels_[channel_id];
+
+  if (!channel.status.is_receiving) {
+    symbols_received = 0;
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Stop reception
-    channel.busy = false;
-    channel.status.is_receiving = false;
-    symbols_received = channel.rx_symbols_received;
+  // Stop reception
+  channel.busy = false;
+  channel.status.is_receiving = false;
+  symbols_received = channel.rx_symbols_received;
 
-    ESP_LOGI(TAG, "Stopped reception on channel %d, received %d symbols", channel_id, symbols_received);
-    return HfPioErr::PIO_SUCCESS;
+  ESP_LOGI(TAG, "Stopped reception on channel %d, received %d symbols", channel_id,
+           symbols_received);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    symbols_received = 0;
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  symbols_received = 0;
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
@@ -380,406 +385,406 @@ HfPioErr McuPio::StopReceive(uint8_t channel_id, size_t& symbols_received) noexc
 //==============================================================================
 
 bool McuPio::IsChannelBusy(uint8_t channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return false;
-    }
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    return channels_[channel_id].busy;
+  if (!IsValidChannelId(channel_id)) {
+    return false;
+  }
+
+  return channels_[channel_id].busy;
 }
 
-HfPioErr McuPio::GetChannelStatus(uint8_t channel_id, PioChannelStatus& status) const noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+HfPioErr McuPio::GetChannelStatus(uint8_t channel_id, PioChannelStatus &status) const noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    status = channels_[channel_id].status;
-    status.is_initialized = channels_[channel_id].configured;
-    status.is_busy = channels_[channel_id].busy;
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    return HfPioErr::PIO_SUCCESS;
+  status = channels_[channel_id].status;
+  status.is_initialized = channels_[channel_id].configured;
+  status.is_busy = channels_[channel_id].busy;
+
+  return HfPioErr::PIO_SUCCESS;
 }
 
-HfPioErr McuPio::GetCapabilities(PioCapabilities& capabilities) const noexcept {
-    capabilities.max_channels = MAX_CHANNELS;
-    capabilities.min_resolution_ns = 12.5; // Based on 80MHz RMT clock
-    capabilities.max_resolution_ns = 3355443; // Max with divider
-    capabilities.max_duration = 32767; // 15-bit duration field
-    capabilities.max_buffer_size = MAX_SYMBOLS_PER_TRANSMISSION;
-    capabilities.supports_bidirectional = false; // RMT is unidirectional per channel
-    capabilities.supports_loopback = true;
-    capabilities.supports_carrier = true;
+HfPioErr McuPio::GetCapabilities(PioCapabilities &capabilities) const noexcept {
+  capabilities.max_channels = MAX_CHANNELS;
+  capabilities.min_resolution_ns = 12.5;    // Based on 80MHz RMT clock
+  capabilities.max_resolution_ns = 3355443; // Max with divider
+  capabilities.max_duration = 32767;        // 15-bit duration field
+  capabilities.max_buffer_size = MAX_SYMBOLS_PER_TRANSMISSION;
+  capabilities.supports_bidirectional = false; // RMT is unidirectional per channel
+  capabilities.supports_loopback = true;
+  capabilities.supports_carrier = true;
 
-    return HfPioErr::PIO_SUCCESS;
+  return HfPioErr::PIO_SUCCESS;
 }
 
 //==============================================================================
 // CALLBACK MANAGEMENT
 //==============================================================================
 
-void McuPio::SetTransmitCallback(PioTransmitCallback callback, void* user_data) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    transmit_callback_ = callback;
-    callback_user_data_ = user_data;
+void McuPio::SetTransmitCallback(PioTransmitCallback callback, void *user_data) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  transmit_callback_ = callback;
+  callback_user_data_ = user_data;
 }
 
-void McuPio::SetReceiveCallback(PioReceiveCallback callback, void* user_data) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    receive_callback_ = callback;
-    callback_user_data_ = user_data;
+void McuPio::SetReceiveCallback(PioReceiveCallback callback, void *user_data) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  receive_callback_ = callback;
+  callback_user_data_ = user_data;
 }
 
-void McuPio::SetErrorCallback(PioErrorCallback callback, void* user_data) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    error_callback_ = callback;
-    callback_user_data_ = user_data;
+void McuPio::SetErrorCallback(PioErrorCallback callback, void *user_data) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  error_callback_ = callback;
+  callback_user_data_ = user_data;
 }
 
 void McuPio::ClearCallbacks() noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    transmit_callback_ = nullptr;
-    receive_callback_ = nullptr;
-    error_callback_ = nullptr;
-    callback_user_data_ = nullptr;
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  transmit_callback_ = nullptr;
+  receive_callback_ = nullptr;
+  error_callback_ = nullptr;
+  callback_user_data_ = nullptr;
 }
 
 //==============================================================================
 // ESP32-SPECIFIC METHODS
 //==============================================================================
 
-HfPioErr McuPio::ConfigureCarrier(uint8_t channel_id, uint32_t carrier_freq_hz, float duty_cycle) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+HfPioErr McuPio::ConfigureCarrier(uint8_t channel_id, uint32_t carrier_freq_hz,
+                                  float duty_cycle) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    if (duty_cycle < 0.0f || duty_cycle > 1.0f) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
+
+  if (duty_cycle < 0.0f || duty_cycle > 1.0f) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure carrier modulation using RMT carrier configuration
-    auto& channel = channels_[channel_id];
-    
-    if (!channel.tx_channel) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
-    
-    rmt_carrier_config_t carrier_config = {};
-    carrier_config.frequency_hz = carrier_freq_hz;
-    carrier_config.duty_cycle = duty_cycle;
-    carrier_config.polarity_active_low = false;
-    carrier_config.always_on = (carrier_freq_hz > 0);
-    
-    esp_err_t ret = rmt_apply_carrier(channel.tx_channel, &carrier_config);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to configure carrier on channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-    }
-    
-    ESP_LOGI(TAG, "Configured carrier on channel %d: %d Hz, %.2f%% duty", 
-             channel_id, carrier_freq_hz, duty_cycle * 100.0f);
-    return HfPioErr::PIO_SUCCESS;
+  // Configure carrier modulation using RMT carrier configuration
+  auto &channel = channels_[channel_id];
+
+  if (!channel.tx_channel) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
+
+  rmt_carrier_config_t carrier_config = {};
+  carrier_config.frequency_hz = carrier_freq_hz;
+  carrier_config.duty_cycle = duty_cycle;
+  carrier_config.polarity_active_low = false;
+  carrier_config.always_on = (carrier_freq_hz > 0);
+
+  esp_err_t ret = rmt_apply_carrier(channel.tx_channel, &carrier_config);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to configure carrier on channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  ESP_LOGI(TAG, "Configured carrier on channel %d: %d Hz, %.2f%% duty", channel_id, carrier_freq_hz,
+           duty_cycle * 100.0f);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfPioErr McuPio::EnableLoopback(uint8_t channel_id, bool enable) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  std::lock_guard<std::mutex> lock(state_mutex_);
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure loopback mode
-    ESP_LOGI(TAG, "Loopback %s for channel %d", enable ? "enabled" : "disabled", channel_id);
-    return HfPioErr::PIO_SUCCESS;
+  // Configure loopback mode
+  ESP_LOGI(TAG, "Loopback %s for channel %d", enable ? "enabled" : "disabled", channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 size_t McuPio::GetMaxSymbolCount() const noexcept {
-    return MAX_SYMBOLS_PER_TRANSMISSION;
+  return MAX_SYMBOLS_PER_TRANSMISSION;
 }
 
 //==============================================================================
 // ADVANCED LOW-LEVEL RMT CONTROL METHODS
 //==============================================================================
 
-HfPioErr McuPio::TransmitRawRmtSymbols(uint8_t channel_id, const rmt_symbol_word_t* rmt_symbols, 
+HfPioErr McuPio::TransmitRawRmtSymbols(uint8_t channel_id, const rmt_symbol_word_t *rmt_symbols,
                                        size_t symbol_count, bool wait_completion) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    if (channels_[channel_id].busy) {
-        return HfPioErr::PIO_ERR_CHANNEL_BUSY;
-    }
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (rmt_symbols == nullptr || symbol_count == 0) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (channels_[channel_id].busy) {
+    return HfPioErr::PIO_ERR_CHANNEL_BUSY;
+  }
+
+  if (rmt_symbols == nullptr || symbol_count == 0) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    
-    if (channel.tx_channel == nullptr) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  auto &channel = channels_[channel_id];
 
-    // Create transmit configuration
-    rmt_transmit_config_t tx_config = {};
-    tx_config.loop_count = 0; // No loop
-    
-    // Start transmission
-    channel.busy = true;
-    channel.status.is_transmitting = true;
-    channel.status.symbols_queued = symbol_count;
-    channel.status.timestamp_us = esp_timer_get_time();
-    
-    esp_err_t ret = rmt_transmit(channel.tx_channel, channel.encoder, 
-                                rmt_symbols, symbol_count * sizeof(rmt_symbol_word_t), &tx_config);
-    
+  if (channel.tx_channel == nullptr) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
+
+  // Create transmit configuration
+  rmt_transmit_config_t tx_config = {};
+  tx_config.loop_count = 0; // No loop
+
+  // Start transmission
+  channel.busy = true;
+  channel.status.is_transmitting = true;
+  channel.status.symbols_queued = symbol_count;
+  channel.status.timestamp_us = esp_timer_get_time();
+
+  esp_err_t ret = rmt_transmit(channel.tx_channel, channel.encoder, rmt_symbols,
+                               symbol_count * sizeof(rmt_symbol_word_t), &tx_config);
+
+  if (ret != ESP_OK) {
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    ESP_LOGE(TAG, "Failed to start raw RMT transmission on channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  if (wait_completion) {
+    uint32_t timeout_us = channel.config.timeout_us;
+    ret = rmt_tx_wait_all_done(channel.tx_channel,
+                               timeout_us == 0 ? portMAX_DELAY : pdMS_TO_TICKS(timeout_us / 1000));
     if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        ESP_LOGE(TAG, "Failed to start raw RMT transmission on channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+      ESP_LOGE(TAG, "Raw RMT transmission timeout on channel %d", channel_id);
+      return HfPioErr::PIO_ERR_COMMUNICATION_TIMEOUT;
     }
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    channel.status.symbols_processed = symbol_count;
+  }
 
-    if (wait_completion) {
-        uint32_t timeout_us = channel.config.timeout_us;
-        ret = rmt_tx_wait_all_done(channel.tx_channel, timeout_us == 0 ? portMAX_DELAY : pdMS_TO_TICKS(timeout_us / 1000));
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Raw RMT transmission timeout on channel %d", channel_id);
-            return HfPioErr::PIO_ERR_COMMUNICATION_TIMEOUT;
-        }
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        channel.status.symbols_processed = symbol_count;
-    }
-
-    ESP_LOGD(TAG, "Started raw RMT transmission of %d symbols on channel %d", symbol_count, channel_id);
-    return HfPioErr::PIO_SUCCESS;
+  ESP_LOGD(TAG, "Started raw RMT transmission of %d symbols on channel %d", symbol_count,
+           channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    ESP_LOGE(TAG, "ESP32 platform not available");
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  ESP_LOGE(TAG, "ESP32 platform not available");
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfPioErr McuPio::ReceiveRawRmtSymbols(uint8_t channel_id, rmt_symbol_word_t* rmt_buffer, 
-                                      size_t buffer_size, size_t& symbols_received, 
+HfPioErr McuPio::ReceiveRawRmtSymbols(uint8_t channel_id, rmt_symbol_word_t *rmt_buffer,
+                                      size_t buffer_size, size_t &symbols_received,
                                       uint32_t timeout_us) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    if (channels_[channel_id].busy) {
-        return HfPioErr::PIO_ERR_CHANNEL_BUSY;
-    }
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (rmt_buffer == nullptr || buffer_size == 0) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (channels_[channel_id].busy) {
+    return HfPioErr::PIO_ERR_CHANNEL_BUSY;
+  }
+
+  if (rmt_buffer == nullptr || buffer_size == 0) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    
-    if (channel.rx_channel == nullptr) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  auto &channel = channels_[channel_id];
 
-    // Create receive configuration
-    rmt_receive_config_t rx_config = {};
-    rx_config.signal_range_min_ns = channel.config.resolution_ns;
-    rx_config.signal_range_max_ns = timeout_us * 1000; // Convert to ns
-    
-    // Start reception
-    channel.busy = true;
-    channel.status.is_receiving = true;
-    channel.status.timestamp_us = esp_timer_get_time();
+  if (channel.rx_channel == nullptr) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    esp_err_t ret = rmt_receive(channel.rx_channel, rmt_buffer, 
-                               buffer_size * sizeof(rmt_symbol_word_t), &rx_config);
-    if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_receiving = false;
-        ESP_LOGE(TAG, "Failed to start raw RMT reception on channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-    }
+  // Create receive configuration
+  rmt_receive_config_t rx_config = {};
+  rx_config.signal_range_min_ns = channel.config.resolution_ns;
+  rx_config.signal_range_max_ns = timeout_us * 1000; // Convert to ns
 
-    // Note: In a real implementation, this would use a semaphore or callback
-    // to wait for reception completion. For simplicity, we'll simulate here.
-    symbols_received = 0; // Would be filled by actual reception
-    
+  // Start reception
+  channel.busy = true;
+  channel.status.is_receiving = true;
+  channel.status.timestamp_us = esp_timer_get_time();
+
+  esp_err_t ret = rmt_receive(channel.rx_channel, rmt_buffer,
+                              buffer_size * sizeof(rmt_symbol_word_t), &rx_config);
+  if (ret != ESP_OK) {
     channel.busy = false;
     channel.status.is_receiving = false;
-    
-    ESP_LOGI(TAG, "Raw RMT reception completed on channel %d", channel_id);
-    return HfPioErr::PIO_SUCCESS;
+    ESP_LOGE(TAG, "Failed to start raw RMT reception on channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  // Note: In a real implementation, this would use a semaphore or callback
+  // to wait for reception completion. For simplicity, we'll simulate here.
+  symbols_received = 0; // Would be filled by actual reception
+
+  channel.busy = false;
+  channel.status.is_receiving = false;
+
+  ESP_LOGI(TAG, "Raw RMT reception completed on channel %d", channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    symbols_received = 0;
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  symbols_received = 0;
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfPioErr McuPio::CreateWS2812Encoder(uint8_t channel_id, uint32_t resolution_hz,
-                                     uint32_t t0h_ns, uint32_t t0l_ns,
-                                     uint32_t t1h_ns, uint32_t t1l_ns) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+HfPioErr McuPio::CreateWS2812Encoder(uint8_t channel_id, uint32_t resolution_hz, uint32_t t0h_ns,
+                                     uint32_t t0l_ns, uint32_t t1h_ns, uint32_t t1l_ns) noexcept {
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    
-    // Calculate timing in RMT ticks
-    uint32_t ticks_0h = (t0h_ns * resolution_hz + 500000000UL) / 1000000000UL; // Round to nearest
-    uint32_t ticks_0l = (t0l_ns * resolution_hz + 500000000UL) / 1000000000UL;
-    uint32_t ticks_1h = (t1h_ns * resolution_hz + 500000000UL) / 1000000000UL;
-    uint32_t ticks_1l = (t1l_ns * resolution_hz + 500000000UL) / 1000000000UL;
-    
-    // Create WS2812 symbols
-    rmt_symbol_word_t bit0_symbol = {
-        .duration0 = (uint16_t)ticks_0h, .level0 = 1,
-        .duration1 = (uint16_t)ticks_0l, .level1 = 0
-    };
-    
-    rmt_symbol_word_t bit1_symbol = {
-        .duration0 = (uint16_t)ticks_1h, .level0 = 1,
-        .duration1 = (uint16_t)ticks_1l, .level1 = 0
-    };
-    
-    // Create bytes encoder for WS2812
-    rmt_bytes_encoder_config_t ws_config = {};
-    ws_config.bit0 = bit0_symbol;
-    ws_config.bit1 = bit1_symbol;
-    ws_config.flags.msb_first = true; // WS2812 uses MSB first
-    
-    esp_err_t ret = rmt_new_bytes_encoder(&ws_config, &channel.ws2812_encoder);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to create WS2812 encoder for channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-    }
-    
-    ESP_LOGI(TAG, "Created WS2812 encoder on channel %d (T0H=%dns, T0L=%dns, T1H=%dns, T1L=%dns)", 
-             channel_id, t0h_ns, t0l_ns, t1h_ns, t1l_ns);
-    return HfPioErr::PIO_SUCCESS;
+  auto &channel = channels_[channel_id];
+
+  // Calculate timing in RMT ticks
+  uint32_t ticks_0h = (t0h_ns * resolution_hz + 500000000UL) / 1000000000UL; // Round to nearest
+  uint32_t ticks_0l = (t0l_ns * resolution_hz + 500000000UL) / 1000000000UL;
+  uint32_t ticks_1h = (t1h_ns * resolution_hz + 500000000UL) / 1000000000UL;
+  uint32_t ticks_1l = (t1l_ns * resolution_hz + 500000000UL) / 1000000000UL;
+
+  // Create WS2812 symbols
+  rmt_symbol_word_t bit0_symbol = {
+      .duration0 = (uint16_t)ticks_0h, .level0 = 1, .duration1 = (uint16_t)ticks_0l, .level1 = 0};
+
+  rmt_symbol_word_t bit1_symbol = {
+      .duration0 = (uint16_t)ticks_1h, .level0 = 1, .duration1 = (uint16_t)ticks_1l, .level1 = 0};
+
+  // Create bytes encoder for WS2812
+  rmt_bytes_encoder_config_t ws_config = {};
+  ws_config.bit0 = bit0_symbol;
+  ws_config.bit1 = bit1_symbol;
+  ws_config.flags.msb_first = true; // WS2812 uses MSB first
+
+  esp_err_t ret = rmt_new_bytes_encoder(&ws_config, &channel.ws2812_encoder);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create WS2812 encoder for channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  ESP_LOGI(TAG, "Created WS2812 encoder on channel %d (T0H=%dns, T0L=%dns, T1H=%dns, T1L=%dns)",
+           channel_id, t0h_ns, t0l_ns, t1h_ns, t1l_ns);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfPioErr McuPio::TransmitWS2812(uint8_t channel_id, const uint8_t* grb_data, size_t length,
+HfPioErr McuPio::TransmitWS2812(uint8_t channel_id, const uint8_t *grb_data, size_t length,
                                 bool wait_completion) noexcept {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    
-    if (!initialized_) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
+  std::lock_guard<std::mutex> lock(state_mutex_);
 
-    if (!IsValidChannelId(channel_id)) {
-        return HfPioErr::PIO_ERR_INVALID_CHANNEL;
-    }
+  if (!initialized_) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
 
-    if (!channels_[channel_id].configured) {
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  if (!IsValidChannelId(channel_id)) {
+    return HfPioErr::PIO_ERR_INVALID_CHANNEL;
+  }
 
-    if (channels_[channel_id].busy) {
-        return HfPioErr::PIO_ERR_CHANNEL_BUSY;
-    }
+  if (!channels_[channel_id].configured) {
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
 
-    if (grb_data == nullptr || length == 0) {
-        return HfPioErr::PIO_ERR_INVALID_PARAMETER;
-    }
+  if (channels_[channel_id].busy) {
+    return HfPioErr::PIO_ERR_CHANNEL_BUSY;
+  }
+
+  if (grb_data == nullptr || length == 0) {
+    return HfPioErr::PIO_ERR_INVALID_PARAMETER;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    
-    if (channel.tx_channel == nullptr) {
-        return HfPioErr::PIO_ERR_NOT_INITIALIZED;
-    }
-    
-    if (channel.ws2812_encoder == nullptr) {
-        ESP_LOGE(TAG, "WS2812 encoder not created for channel %d. Call CreateWS2812Encoder first.", channel_id);
-        return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
-    }
+  auto &channel = channels_[channel_id];
 
-    // Create transmit configuration
-    rmt_transmit_config_t tx_config = {};
-    tx_config.loop_count = 0; // No loop
-    
-    // Start transmission
-    channel.busy = true;
-    channel.status.is_transmitting = true;
-    channel.status.symbols_queued = length * 8; // 8 bits per byte
-    channel.status.timestamp_us = esp_timer_get_time();
-    
-    esp_err_t ret = rmt_transmit(channel.tx_channel, channel.ws2812_encoder, 
-                                grb_data, length, &tx_config);
-    
+  if (channel.tx_channel == nullptr) {
+    return HfPioErr::PIO_ERR_NOT_INITIALIZED;
+  }
+
+  if (channel.ws2812_encoder == nullptr) {
+    ESP_LOGE(TAG, "WS2812 encoder not created for channel %d. Call CreateWS2812Encoder first.",
+             channel_id);
+    return HfPioErr::PIO_ERR_INVALID_CONFIGURATION;
+  }
+
+  // Create transmit configuration
+  rmt_transmit_config_t tx_config = {};
+  tx_config.loop_count = 0; // No loop
+
+  // Start transmission
+  channel.busy = true;
+  channel.status.is_transmitting = true;
+  channel.status.symbols_queued = length * 8; // 8 bits per byte
+  channel.status.timestamp_us = esp_timer_get_time();
+
+  esp_err_t ret =
+      rmt_transmit(channel.tx_channel, channel.ws2812_encoder, grb_data, length, &tx_config);
+
+  if (ret != ESP_OK) {
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    ESP_LOGE(TAG, "Failed to start WS2812 transmission on channel %d: %d", channel_id, ret);
+    return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+  }
+
+  if (wait_completion) {
+    uint32_t timeout_us = channel.config.timeout_us;
+    ret = rmt_tx_wait_all_done(channel.tx_channel,
+                               timeout_us == 0 ? portMAX_DELAY : pdMS_TO_TICKS(timeout_us / 1000));
     if (ret != ESP_OK) {
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        ESP_LOGE(TAG, "Failed to start WS2812 transmission on channel %d: %d", channel_id, ret);
-        return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+      ESP_LOGE(TAG, "WS2812 transmission timeout on channel %d", channel_id);
+      return HfPioErr::PIO_ERR_COMMUNICATION_TIMEOUT;
     }
+    channel.busy = false;
+    channel.status.is_transmitting = false;
+    channel.status.symbols_processed = length * 8;
+  }
 
-    if (wait_completion) {
-        uint32_t timeout_us = channel.config.timeout_us;
-        ret = rmt_tx_wait_all_done(channel.tx_channel, timeout_us == 0 ? portMAX_DELAY : pdMS_TO_TICKS(timeout_us / 1000));
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "WS2812 transmission timeout on channel %d", channel_id);
-            return HfPioErr::PIO_ERR_COMMUNICATION_TIMEOUT;
-        }
-        channel.busy = false;
-        channel.status.is_transmitting = false;
-        channel.status.symbols_processed = length * 8;
-    }
-
-    ESP_LOGD(TAG, "Started WS2812 transmission of %d bytes on channel %d", length, channel_id);
-    return HfPioErr::PIO_SUCCESS;
+  ESP_LOGD(TAG, "Started WS2812 transmission of %d bytes on channel %d", length, channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    ESP_LOGE(TAG, "ESP32 platform not available");
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  ESP_LOGE(TAG, "ESP32 platform not available");
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
@@ -788,260 +793,266 @@ HfPioErr McuPio::TransmitWS2812(uint8_t channel_id, const uint8_t* grb_data, siz
 //==============================================================================
 
 bool McuPio::IsValidChannelId(uint8_t channel_id) const noexcept {
-    return channel_id < MAX_CHANNELS;
+  return channel_id < MAX_CHANNELS;
 }
 
 #ifdef HF_MCU_FAMILY_ESP32
-HfPioErr McuPio::ConvertToRmtSymbols(const PioSymbol* symbols, size_t symbol_count, 
-                                    rmt_symbol_word_t* rmt_symbols, size_t& rmt_symbol_count) noexcept {
-    if (symbol_count > MAX_SYMBOLS_PER_TRANSMISSION) {
-        return HfPioErr::PIO_ERR_BUFFER_TOO_LARGE;
+HfPioErr McuPio::ConvertToRmtSymbols(const PioSymbol *symbols, size_t symbol_count,
+                                     rmt_symbol_word_t *rmt_symbols,
+                                     size_t &rmt_symbol_count) noexcept {
+  if (symbol_count > MAX_SYMBOLS_PER_TRANSMISSION) {
+    return HfPioErr::PIO_ERR_BUFFER_TOO_LARGE;
+  }
+
+  rmt_symbol_count = symbol_count;
+
+  for (size_t i = 0; i < symbol_count; ++i) {
+    // Set level and duration for first half of RMT symbol
+    rmt_symbols[i].level0 = symbols[i].level ? 1 : 0;
+    rmt_symbols[i].duration0 = symbols[i].duration;
+
+    // For the second half, set to idle state or next symbol
+    if (i + 1 < symbol_count) {
+      // Use next symbol's complementary level for transition
+      rmt_symbols[i].level1 = symbols[i + 1].level ? 0 : 1;
+      rmt_symbols[i].duration1 = 1; // Minimal transition time
+    } else {
+      // Last symbol - end with idle state
+      rmt_symbols[i].level1 = 0;    // Idle low
+      rmt_symbols[i].duration1 = 0; // End marker
     }
+  }
 
-    rmt_symbol_count = symbol_count;
-
-    for (size_t i = 0; i < symbol_count; ++i) {
-        // Set level and duration for first half of RMT symbol
-        rmt_symbols[i].level0 = symbols[i].level ? 1 : 0;
-        rmt_symbols[i].duration0 = symbols[i].duration;
-        
-        // For the second half, set to idle state or next symbol
-        if (i + 1 < symbol_count) {
-            // Use next symbol's complementary level for transition
-            rmt_symbols[i].level1 = symbols[i + 1].level ? 0 : 1;
-            rmt_symbols[i].duration1 = 1; // Minimal transition time
-        } else {
-            // Last symbol - end with idle state
-            rmt_symbols[i].level1 = 0; // Idle low
-            rmt_symbols[i].duration1 = 0; // End marker
-        }
-    }
-
-    return HfPioErr::PIO_SUCCESS;
+  return HfPioErr::PIO_SUCCESS;
 }
 
-HfPioErr McuPio::ConvertFromRmtSymbols(const rmt_symbol_word_t* rmt_symbols, size_t rmt_symbol_count,
-                                      PioSymbol* symbols, size_t& symbol_count) noexcept {
-    symbol_count = std::min(rmt_symbol_count, symbol_count);
+HfPioErr McuPio::ConvertFromRmtSymbols(const rmt_symbol_word_t *rmt_symbols,
+                                       size_t rmt_symbol_count, PioSymbol *symbols,
+                                       size_t &symbol_count) noexcept {
+  symbol_count = std::min(rmt_symbol_count, symbol_count);
 
-    for (size_t i = 0; i < symbol_count; ++i) {
-        symbols[i].level = rmt_symbols[i].level0 ? true : false;
-        symbols[i].duration = rmt_symbols[i].duration0;
-    }
+  for (size_t i = 0; i < symbol_count; ++i) {
+    symbols[i].level = rmt_symbols[i].level0 ? true : false;
+    symbols[i].duration = rmt_symbols[i].duration0;
+  }
 
-    return HfPioErr::PIO_SUCCESS;
+  return HfPioErr::PIO_SUCCESS;
 }
 
 uint32_t McuPio::CalculateClockDivider(uint32_t resolution_ns) const noexcept {
-    // Calculate clock divider to achieve desired resolution
-    // RMT source clock is typically 80 MHz (12.5 ns per tick)
-    uint32_t divider = (resolution_ns * RMT_CLK_SRC_FREQ) / 1000000000UL;
-    return std::max(1U, std::min(255U, divider)); // Clamp to valid range
+  // Calculate clock divider to achieve desired resolution
+  // RMT source clock is typically 80 MHz (12.5 ns per tick)
+  uint32_t divider = (resolution_ns * RMT_CLK_SRC_FREQ) / 1000000000UL;
+  return std::max(1U, std::min(255U, divider)); // Clamp to valid range
 }
 
-bool McuPio::OnTransmitComplete(rmt_channel_handle_t* channel, const rmt_tx_done_event_data_t* edata, void* user_ctx) {
-    auto* instance = static_cast<McuPio*>(user_ctx);
-    if (!instance) return false;
-    
-    // Find the channel ID by comparing channel handles
-    for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
-        if (instance->channels_[i].tx_channel == channel) {
-            std::lock_guard<std::mutex> lock(instance->state_mutex_);
-            
-            auto& ch = instance->channels_[i];
-            ch.busy = false;
-            ch.status.is_transmitting = false;
-            ch.status.symbols_processed = ch.status.symbols_queued;
-            ch.status.timestamp_us = esp_timer_get_time();
-            
-            // Invoke user callback if set
-            if (instance->transmit_callback_) {
-                instance->transmit_callback_(i, ch.status.symbols_processed, instance->callback_user_data_);
-            }
-            
-            ESP_LOGD(TAG, "Transmission complete on channel %d", i);
-            break;
-        }
-    }
-    
-    return false; // Don't yield to higher priority task
-}
-
-bool McuPio::OnReceiveComplete(rmt_channel_handle_t* channel, const rmt_rx_done_event_data_t* edata, void* user_ctx) {
-    auto* instance = static_cast<McuPio*>(user_ctx);
-    if (!instance || !edata) return false;
-    
-    // Find the channel ID by comparing channel handles
-    for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
-        if (instance->channels_[i].rx_channel == channel) {
-            std::lock_guard<std::mutex> lock(instance->state_mutex_);
-            
-            auto& ch = instance->channels_[i];
-            
-            // Convert received RMT symbols back to PioSymbols
-            size_t symbols_converted = 0;
-            if (ch.rx_buffer && edata->received_symbols) {
-                instance->ConvertFromRmtSymbols(
-                    reinterpret_cast<const rmt_symbol_word_t*>(edata->received_symbols),
-                    edata->num_symbols,
-                    ch.rx_buffer,
-                    symbols_converted
-                );
-            }
-            
-            ch.busy = false;
-            ch.status.is_receiving = false;
-            ch.rx_symbols_received = symbols_converted;
-            ch.status.symbols_processed = symbols_converted;
-            ch.status.timestamp_us = esp_timer_get_time();
-            
-            // Invoke user callback if set
-            if (instance->receive_callback_) {
-                instance->receive_callback_(i, ch.rx_buffer, symbols_converted, instance->callback_user_data_);
-            }
-            
-            ESP_LOGD(TAG, "Reception complete on channel %d, received %d symbols", i, symbols_converted);
-            break;
-        }
-    }
-    
+bool McuPio::OnTransmitComplete(rmt_channel_handle_t *channel,
+                                const rmt_tx_done_event_data_t *edata, void *user_ctx) {
+  auto *instance = static_cast<McuPio *>(user_ctx);
+  if (!instance)
     return false;
+
+  // Find the channel ID by comparing channel handles
+  for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
+    if (instance->channels_[i].tx_channel == channel) {
+      std::lock_guard<std::mutex> lock(instance->state_mutex_);
+
+      auto &ch = instance->channels_[i];
+      ch.busy = false;
+      ch.status.is_transmitting = false;
+      ch.status.symbols_processed = ch.status.symbols_queued;
+      ch.status.timestamp_us = esp_timer_get_time();
+
+      // Invoke user callback if set
+      if (instance->transmit_callback_) {
+        instance->transmit_callback_(i, ch.status.symbols_processed, instance->callback_user_data_);
+      }
+
+      ESP_LOGD(TAG, "Transmission complete on channel %d", i);
+      break;
+    }
+  }
+
+  return false; // Don't yield to higher priority task
+}
+
+bool McuPio::OnReceiveComplete(rmt_channel_handle_t *channel, const rmt_rx_done_event_data_t *edata,
+                               void *user_ctx) {
+  auto *instance = static_cast<McuPio *>(user_ctx);
+  if (!instance || !edata)
+    return false;
+
+  // Find the channel ID by comparing channel handles
+  for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
+    if (instance->channels_[i].rx_channel == channel) {
+      std::lock_guard<std::mutex> lock(instance->state_mutex_);
+
+      auto &ch = instance->channels_[i];
+
+      // Convert received RMT symbols back to PioSymbols
+      size_t symbols_converted = 0;
+      if (ch.rx_buffer && edata->received_symbols) {
+        instance->ConvertFromRmtSymbols(
+            reinterpret_cast<const rmt_symbol_word_t *>(edata->received_symbols),
+            edata->num_symbols, ch.rx_buffer, symbols_converted);
+      }
+
+      ch.busy = false;
+      ch.status.is_receiving = false;
+      ch.rx_symbols_received = symbols_converted;
+      ch.status.symbols_processed = symbols_converted;
+      ch.status.timestamp_us = esp_timer_get_time();
+
+      // Invoke user callback if set
+      if (instance->receive_callback_) {
+        instance->receive_callback_(i, ch.rx_buffer, symbols_converted,
+                                    instance->callback_user_data_);
+      }
+
+      ESP_LOGD(TAG, "Reception complete on channel %d, received %d symbols", i, symbols_converted);
+      break;
+    }
+  }
+
+  return false;
 }
 #endif
 
 HfPioErr McuPio::InitializeChannel(uint8_t channel_id) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
-    const auto& config = channel.config;
+  auto &channel = channels_[channel_id];
+  const auto &config = channel.config;
 
-    // Calculate clock settings
-    uint32_t clock_divider = CalculateClockDivider(config.resolution_ns);
+  // Calculate clock settings
+  uint32_t clock_divider = CalculateClockDivider(config.resolution_ns);
 
-    if (config.direction == PioDirection::Transmit || config.direction == PioDirection::Bidirectional) {
-        // Configure TX channel
-        rmt_tx_channel_config_t tx_config = {};
-        tx_config.gpio_num = config.gpio_pin;
-        tx_config.clk_src = RMT_CLK_SRC_DEFAULT;
-        tx_config.resolution_hz = RMT_CLK_SRC_FREQ / clock_divider;
-        tx_config.mem_block_symbols = 64;
-        tx_config.trans_queue_depth = 4;
+  if (config.direction == PioDirection::Transmit ||
+      config.direction == PioDirection::Bidirectional) {
+    // Configure TX channel
+    rmt_tx_channel_config_t tx_config = {};
+    tx_config.gpio_num = config.gpio_pin;
+    tx_config.clk_src = RMT_CLK_SRC_DEFAULT;
+    tx_config.resolution_hz = RMT_CLK_SRC_FREQ / clock_divider;
+    tx_config.mem_block_symbols = 64;
+    tx_config.trans_queue_depth = 4;
 
-        esp_err_t ret = rmt_new_tx_channel(&tx_config, &channel.tx_channel);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to create TX channel %d: %d", channel_id, ret);
-            return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-        }
-
-        // Create copy encoder (simple symbol transmission)
-        rmt_copy_encoder_config_t encoder_config = {};
-        ret = rmt_new_copy_encoder(&encoder_config, &channel.encoder);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to create encoder for channel %d: %d", channel_id, ret);
-            rmt_del_channel(channel.tx_channel);
-            channel.tx_channel = nullptr;
-            return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-        }
-
-        // Enable channel
-        ret = rmt_enable(channel.tx_channel);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to enable TX channel %d: %d", channel_id, ret);
-            return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-        }
+    esp_err_t ret = rmt_new_tx_channel(&tx_config, &channel.tx_channel);
+    if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to create TX channel %d: %d", channel_id, ret);
+      return HfPioErr::PIO_ERR_HARDWARE_FAULT;
     }
 
-    if (config.direction == PioDirection::Receive || config.direction == PioDirection::Bidirectional) {
-        // Configure RX channel
-        rmt_rx_channel_config_t rx_config = {};
-        rx_config.gpio_num = config.gpio_pin;
-        rx_config.clk_src = RMT_CLK_SRC_DEFAULT;
-        rx_config.resolution_hz = RMT_CLK_SRC_FREQ / clock_divider;
-        rx_config.mem_block_symbols = 64;
-
-        esp_err_t ret = rmt_new_rx_channel(&rx_config, &channel.rx_channel);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to create RX channel %d: %d", channel_id, ret);
-            return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-        }
-
-        // Enable channel
-        ret = rmt_enable(channel.rx_channel);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to enable RX channel %d: %d", channel_id, ret);
-            return HfPioErr::PIO_ERR_HARDWARE_FAULT;
-        }
+    // Create copy encoder (simple symbol transmission)
+    rmt_copy_encoder_config_t encoder_config = {};
+    ret = rmt_new_copy_encoder(&encoder_config, &channel.encoder);
+    if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to create encoder for channel %d: %d", channel_id, ret);
+      rmt_del_channel(channel.tx_channel);
+      channel.tx_channel = nullptr;
+      return HfPioErr::PIO_ERR_HARDWARE_FAULT;
     }
 
-    ESP_LOGI(TAG, "Initialized channel %d with %d ns resolution", channel_id, config.resolution_ns);
-    return HfPioErr::PIO_SUCCESS;
+    // Enable channel
+    ret = rmt_enable(channel.tx_channel);
+    if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to enable TX channel %d: %d", channel_id, ret);
+      return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+    }
+  }
+
+  if (config.direction == PioDirection::Receive ||
+      config.direction == PioDirection::Bidirectional) {
+    // Configure RX channel
+    rmt_rx_channel_config_t rx_config = {};
+    rx_config.gpio_num = config.gpio_pin;
+    rx_config.clk_src = RMT_CLK_SRC_DEFAULT;
+    rx_config.resolution_hz = RMT_CLK_SRC_FREQ / clock_divider;
+    rx_config.mem_block_symbols = 64;
+
+    esp_err_t ret = rmt_new_rx_channel(&rx_config, &channel.rx_channel);
+    if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to create RX channel %d: %d", channel_id, ret);
+      return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+    }
+
+    // Enable channel
+    ret = rmt_enable(channel.rx_channel);
+    if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to enable RX channel %d: %d", channel_id, ret);
+      return HfPioErr::PIO_ERR_HARDWARE_FAULT;
+    }
+  }
+
+  ESP_LOGI(TAG, "Initialized channel %d with %d ns resolution", channel_id, config.resolution_ns);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    ESP_LOGE(TAG, "ESP32 platform not available");
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  ESP_LOGE(TAG, "ESP32 platform not available");
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 HfPioErr McuPio::DeinitializeChannel(uint8_t channel_id) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    auto& channel = channels_[channel_id];
+  auto &channel = channels_[channel_id];
 
-    if (channel.tx_channel) {
-        rmt_disable(channel.tx_channel);
-        rmt_del_channel(channel.tx_channel);
-        channel.tx_channel = nullptr;
-    }
+  if (channel.tx_channel) {
+    rmt_disable(channel.tx_channel);
+    rmt_del_channel(channel.tx_channel);
+    channel.tx_channel = nullptr;
+  }
 
-    if (channel.rx_channel) {
-        rmt_disable(channel.rx_channel);
-        rmt_del_channel(channel.rx_channel);
-        channel.rx_channel = nullptr;
-    }
+  if (channel.rx_channel) {
+    rmt_disable(channel.rx_channel);
+    rmt_del_channel(channel.rx_channel);
+    channel.rx_channel = nullptr;
+  }
 
-    if (channel.encoder) {
-        rmt_del_encoder(channel.encoder);
-        channel.encoder = nullptr;
-    }
+  if (channel.encoder) {
+    rmt_del_encoder(channel.encoder);
+    channel.encoder = nullptr;
+  }
 
-    if (channel.bytes_encoder) {
-        rmt_del_encoder(channel.bytes_encoder);
-        channel.bytes_encoder = nullptr;
-    }
+  if (channel.bytes_encoder) {
+    rmt_del_encoder(channel.bytes_encoder);
+    channel.bytes_encoder = nullptr;
+  }
 
-    if (channel.ws2812_encoder) {
-        rmt_del_encoder(channel.ws2812_encoder);
-        channel.ws2812_encoder = nullptr;
-    }
+  if (channel.ws2812_encoder) {
+    rmt_del_encoder(channel.ws2812_encoder);
+    channel.ws2812_encoder = nullptr;
+  }
 
-    channel.configured = false;
-    channel.busy = false;
+  channel.configured = false;
+  channel.busy = false;
 
-    ESP_LOGI(TAG, "Deinitialized channel %d", channel_id);
-    return HfPioErr::PIO_SUCCESS;
+  ESP_LOGI(TAG, "Deinitialized channel %d", channel_id);
+  return HfPioErr::PIO_SUCCESS;
 #else
-    return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
+  return HfPioErr::PIO_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
-HfPioErr McuPio::ValidateSymbols(const PioSymbol* symbols, size_t symbol_count) const noexcept {
-    for (size_t i = 0; i < symbol_count; ++i) {
-        if (symbols[i].duration == 0) {
-            return HfPioErr::PIO_ERR_DURATION_TOO_SHORT;
-        }
-        if (symbols[i].duration > 32767) { // RMT 15-bit duration limit
-            return HfPioErr::PIO_ERR_DURATION_TOO_LONG;
-        }
+HfPioErr McuPio::ValidateSymbols(const PioSymbol *symbols, size_t symbol_count) const noexcept {
+  for (size_t i = 0; i < symbol_count; ++i) {
+    if (symbols[i].duration == 0) {
+      return HfPioErr::PIO_ERR_DURATION_TOO_SHORT;
     }
-    return HfPioErr::PIO_SUCCESS;
+    if (symbols[i].duration > 32767) { // RMT 15-bit duration limit
+      return HfPioErr::PIO_ERR_DURATION_TOO_LONG;
+    }
+  }
+  return HfPioErr::PIO_SUCCESS;
 }
 
 void McuPio::UpdateChannelStatus(uint8_t channel_id) noexcept {
-    auto& channel = channels_[channel_id];
-    channel.status.timestamp_us = esp_timer_get_time();
-    channel.status.last_error = HfPioErr::PIO_SUCCESS;
+  auto &channel = channels_[channel_id];
+  channel.status.timestamp_us = esp_timer_get_time();
+  channel.status.last_error = HfPioErr::PIO_SUCCESS;
 }
 
 void McuPio::InvokeErrorCallback(uint8_t channel_id, HfPioErr error) noexcept {
-    if (error_callback_) {
-        error_callback_(channel_id, error, callback_user_data_);
-    }
-    channels_[channel_id].status.last_error = error;
+  if (error_callback_) {
+    error_callback_(channel_id, error, callback_user_data_);
+  }
+  channels_[channel_id].status.last_error = error;
 }

--- a/src/mcu/McuPwm.cpp
+++ b/src/mcu/McuPwm.cpp
@@ -3,7 +3,7 @@
  * @brief Implementation of MCU-integrated PWM controller for ESP32C6.
  *
  * This file provides the implementation for PWM generation using the
- * microcontroller's built-in LEDC peripheral. All platform-specific types and 
+ * microcontroller's built-in LEDC peripheral. All platform-specific types and
  * implementations are isolated through McuTypes.h.
  */
 #include "McuPwm.h"
@@ -12,40 +12,35 @@
 
 // Platform-specific includes and definitions
 #ifdef HF_MCU_FAMILY_ESP32
-    #include "driver/ledc.h"
-    #include "esp_log.h"
-    #include "esp_err.h"
-    #include "soc/ledc_reg.h"
-    #include "hal/ledc_hal.h"
-    
+#include "driver/ledc.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "hal/ledc_hal.h"
+#include "soc/ledc_reg.h"
+
 #else
-    #error "Unsupported MCU platform. Please add support for your target MCU."
+#error "Unsupported MCU platform. Please add support for your target MCU."
 #endif
 
-static const char* TAG = "McuPwm";
+static const char *TAG = "McuPwm";
 
 //==============================================================================
 // CONSTRUCTOR AND DESTRUCTOR
 //==============================================================================
 
 McuPwm::McuPwm(uint32_t base_clock_hz) noexcept
-    : initialized_(false)
-    , base_clock_hz_(base_clock_hz)
-    , period_callback_(nullptr)
-    , period_callback_user_data_(nullptr)
-    , fault_callback_(nullptr)
-    , fault_callback_user_data_(nullptr)
-    , last_global_error_(HfPwmErr::PWM_SUCCESS)
-{
-    ESP_LOGI(TAG, "McuPwm constructor - base clock: %lu Hz", base_clock_hz_);
+    : initialized_(false), base_clock_hz_(base_clock_hz), period_callback_(nullptr),
+      period_callback_user_data_(nullptr), fault_callback_(nullptr),
+      fault_callback_user_data_(nullptr), last_global_error_(HfPwmErr::PWM_SUCCESS) {
+  ESP_LOGI(TAG, "McuPwm constructor - base clock: %lu Hz", base_clock_hz_);
 }
 
 McuPwm::~McuPwm() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (initialized_) {
-        ESP_LOGI(TAG, "McuPwm destructor - cleaning up");
-        Deinitialize();
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (initialized_) {
+    ESP_LOGI(TAG, "McuPwm destructor - cleaning up");
+    Deinitialize();
+  }
 }
 
 //==============================================================================
@@ -53,360 +48,364 @@ McuPwm::~McuPwm() noexcept {
 //==============================================================================
 
 HfPwmErr McuPwm::Initialize() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (initialized_) {
-        ESP_LOGW(TAG, "PWM already initialized");
-        return HfPwmErr::PWM_ERR_ALREADY_INITIALIZED;
-    }
-    
-    ESP_LOGI(TAG, "Initializing MCU PWM system");
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (initialized_) {
+    ESP_LOGW(TAG, "PWM already initialized");
+    return HfPwmErr::PWM_ERR_ALREADY_INITIALIZED;
+  }
+
+  ESP_LOGI(TAG, "Initializing MCU PWM system");
+
 #ifdef HF_MCU_FAMILY_ESP32
-    // ESP32C6 LEDC initialization - configure speed mode
-    for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
-        timers_[timer_id] = TimerState{};
-    }
-    
-    // Reset all channel states
-    for (uint8_t channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
-        channels_[channel_id] = ChannelState{};
-    }
-    
-    // Reset complementary pairs
-    for (auto& pair : complementary_pairs_) {
-        pair = ComplementaryPair{};
-    }
-    
-    initialized_ = true;
-    last_global_error_ = HfPwmErr::PWM_SUCCESS;
-    
-    ESP_LOGI(TAG, "MCU PWM system initialized successfully");
-    return HfPwmErr::PWM_SUCCESS;
-    
+  // ESP32C6 LEDC initialization - configure speed mode
+  for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
+    timers_[timer_id] = TimerState{};
+  }
+
+  // Reset all channel states
+  for (uint8_t channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
+    channels_[channel_id] = ChannelState{};
+  }
+
+  // Reset complementary pairs
+  for (auto &pair : complementary_pairs_) {
+    pair = ComplementaryPair{};
+  }
+
+  initialized_ = true;
+  last_global_error_ = HfPwmErr::PWM_SUCCESS;
+
+  ESP_LOGI(TAG, "MCU PWM system initialized successfully");
+  return HfPwmErr::PWM_SUCCESS;
+
 #else
-    ESP_LOGE(TAG, "Platform not supported");
-    return HfPwmErr::PWM_ERR_FAILURE;
+  ESP_LOGE(TAG, "Platform not supported");
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 HfPwmErr McuPwm::Deinitialize() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    ESP_LOGI(TAG, "Deinitializing MCU PWM system");
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  ESP_LOGI(TAG, "Deinitializing MCU PWM system");
+
 #ifdef HF_MCU_FAMILY_ESP32
-    // Stop all channels first
-    for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
-        if (channels_[channel_id].configured) {
-            ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), 0);
-        }
+  // Stop all channels first
+  for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
+    if (channels_[channel_id].configured) {
+      ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), 0);
     }
-    
-    // Reset all timers
-    for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
-        if (timers_[timer_id].in_use) {
-            ledc_timer_rst(LEDC_LOW_SPEED_MODE, static_cast<ledc_timer_t>(timer_id));
-        }
+  }
+
+  // Reset all timers
+  for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
+    if (timers_[timer_id].in_use) {
+      ledc_timer_rst(LEDC_LOW_SPEED_MODE, static_cast<ledc_timer_t>(timer_id));
     }
-    
-    initialized_ = false;
-    ESP_LOGI(TAG, "MCU PWM system deinitialized");
-    return HfPwmErr::PWM_SUCCESS;
-    
+  }
+
+  initialized_ = false;
+  ESP_LOGI(TAG, "MCU PWM system deinitialized");
+  return HfPwmErr::PWM_SUCCESS;
+
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 bool McuPwm::IsInitialized() const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return initialized_;
+  std::lock_guard<std::mutex> lock(mutex_);
+  return initialized_;
 }
 
 //==============================================================================
 // CHANNEL MANAGEMENT (BasePwm Interface)
 //==============================================================================
 
-HfPwmErr McuPwm::ConfigureChannel(HfChannelId channel_id, const PwmChannelConfig& config) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    // Validate configuration
-    if (config.output_pin < 0) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
-        return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
-    }
-    
-    if (!BasePwm::IsValidDutyCycle(config.initial_duty_cycle)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
-        return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
-    }
-    
-    if (!BasePwm::IsValidFrequency(config.frequency_hz, MIN_FREQUENCY, MAX_FREQUENCY)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_FREQUENCY);
-        return HfPwmErr::PWM_ERR_INVALID_FREQUENCY;
-    }
-    
-    // Find or allocate a timer for this frequency/resolution combination
-    int8_t timer_id = FindOrAllocateTimer(config.frequency_hz, config.resolution_bits);
-    if (timer_id < 0) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_TIMER_CONFLICT);
-        return HfPwmErr::PWM_ERR_TIMER_CONFLICT;
-    }
-    
-    // Configure the platform timer if needed
-    HfPwmErr timer_result = ConfigurePlatformTimer(timer_id, config.frequency_hz, config.resolution_bits);
-    if (timer_result != HfPwmErr::PWM_SUCCESS) {
-        SetChannelError(channel_id, timer_result);
-        return timer_result;
-    }
-    
-    // Configure the platform channel
-    HfPwmErr channel_result = ConfigurePlatformChannel(channel_id, config, timer_id);
-    if (channel_result != HfPwmErr::PWM_SUCCESS) {
-        SetChannelError(channel_id, channel_result);
-        return channel_result;
-    }
-    
-    // Update internal state
-    channels_[channel_id].configured = true;
-    channels_[channel_id].config = config;
-    channels_[channel_id].assigned_timer = timer_id;
-    channels_[channel_id].raw_duty_value = BasePwm::DutyCycleToRaw(config.initial_duty_cycle, config.resolution_bits);
-    channels_[channel_id].last_error = HfPwmErr::PWM_SUCCESS;
-    
-    ESP_LOGI(TAG, "Channel %lu configured: pin=%d, freq=%lu Hz, res=%d bits, timer=%d", 
-             channel_id, config.output_pin, config.frequency_hz, config.resolution_bits, timer_id);
-    
-    return HfPwmErr::PWM_SUCCESS;
+HfPwmErr McuPwm::ConfigureChannel(HfChannelId channel_id, const PwmChannelConfig &config) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  // Validate configuration
+  if (config.output_pin < 0) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
+    return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
+  }
+
+  if (!BasePwm::IsValidDutyCycle(config.initial_duty_cycle)) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
+    return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
+  }
+
+  if (!BasePwm::IsValidFrequency(config.frequency_hz, MIN_FREQUENCY, MAX_FREQUENCY)) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_FREQUENCY);
+    return HfPwmErr::PWM_ERR_INVALID_FREQUENCY;
+  }
+
+  // Find or allocate a timer for this frequency/resolution combination
+  int8_t timer_id = FindOrAllocateTimer(config.frequency_hz, config.resolution_bits);
+  if (timer_id < 0) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_TIMER_CONFLICT);
+    return HfPwmErr::PWM_ERR_TIMER_CONFLICT;
+  }
+
+  // Configure the platform timer if needed
+  HfPwmErr timer_result =
+      ConfigurePlatformTimer(timer_id, config.frequency_hz, config.resolution_bits);
+  if (timer_result != HfPwmErr::PWM_SUCCESS) {
+    SetChannelError(channel_id, timer_result);
+    return timer_result;
+  }
+
+  // Configure the platform channel
+  HfPwmErr channel_result = ConfigurePlatformChannel(channel_id, config, timer_id);
+  if (channel_result != HfPwmErr::PWM_SUCCESS) {
+    SetChannelError(channel_id, channel_result);
+    return channel_result;
+  }
+
+  // Update internal state
+  channels_[channel_id].configured = true;
+  channels_[channel_id].config = config;
+  channels_[channel_id].assigned_timer = timer_id;
+  channels_[channel_id].raw_duty_value =
+      BasePwm::DutyCycleToRaw(config.initial_duty_cycle, config.resolution_bits);
+  channels_[channel_id].last_error = HfPwmErr::PWM_SUCCESS;
+
+  ESP_LOGI(TAG, "Channel %lu configured: pin=%d, freq=%lu Hz, res=%d bits, timer=%d", channel_id,
+           config.output_pin, config.frequency_hz, config.resolution_bits, timer_id);
+
+  return HfPwmErr::PWM_SUCCESS;
 }
 
 HfPwmErr McuPwm::EnableChannel(HfChannelId channel_id) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (channels_[channel_id].enabled) {
-        return HfPwmErr::PWM_SUCCESS; // Already enabled
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (channels_[channel_id].enabled) {
+    return HfPwmErr::PWM_SUCCESS; // Already enabled
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_update_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    channels_[channel_id].enabled = true;
-    ESP_LOGD(TAG, "Channel %lu enabled", channel_id);
-    return HfPwmErr::PWM_SUCCESS;
-    
+  esp_err_t ret = ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_update_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  channels_[channel_id].enabled = true;
+  ESP_LOGD(TAG, "Channel %lu enabled", channel_id);
+  return HfPwmErr::PWM_SUCCESS;
+
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 HfPwmErr McuPwm::DisableChannel(HfChannelId channel_id) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].enabled) {
-        return HfPwmErr::PWM_SUCCESS; // Already disabled
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].enabled) {
+    return HfPwmErr::PWM_SUCCESS; // Already disabled
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), 0);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_stop failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    channels_[channel_id].enabled = false;
-    ESP_LOGD(TAG, "Channel %lu disabled", channel_id);
-    return HfPwmErr::PWM_SUCCESS;
-    
+  esp_err_t ret = ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), 0);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_stop failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  channels_[channel_id].enabled = false;
+  ESP_LOGD(TAG, "Channel %lu disabled", channel_id);
+  return HfPwmErr::PWM_SUCCESS;
+
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 bool McuPwm::IsChannelEnabled(HfChannelId channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
-        return false;
-    }
-    
-    return channels_[channel_id].enabled;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
+    return false;
+  }
+
+  return channels_[channel_id].enabled;
 }
-    
-    if (!BasePwm::IsValidDutyCycle(config.initial_duty_cycle)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
-        return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
-    }
-    
-    if (!BasePwm::IsValidFrequency(config.frequency_hz, MIN_FREQUENCY, MAX_FREQUENCY)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_FREQUENCY);
-        return HfPwmErr::PWM_ERR_INVALID_FREQUENCY;
-    }
-    
-    // Find or allocate a timer for this frequency/resolution combination
-    int8_t timer_id = FindOrAllocateTimer(config.frequency_hz, config.resolution_bits);
-    if (timer_id < 0) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_TIMER_CONFLICT);
-        return HfPwmErr::PWM_ERR_TIMER_CONFLICT;
-    }
-    
-    // Configure the platform timer if needed
-    HfPwmErr timer_result = ConfigurePlatformTimer(timer_id, config.frequency_hz, config.resolution_bits);
-    if (timer_result != HfPwmErr::PWM_SUCCESS) {
-        SetChannelError(channel_id, timer_result);
-        return timer_result;
-    }
-    
-    // Configure the platform channel
-    HfPwmErr channel_result = ConfigurePlatformChannel(channel_id, config, timer_id);
-    if (channel_result != HfPwmErr::PWM_SUCCESS) {
-        SetChannelError(channel_id, channel_result);
-        return channel_result;
-    }
-    
-    // Update internal state
-    channels_[channel_id].configured = true;
-    channels_[channel_id].config = config;
-    channels_[channel_id].assigned_timer = timer_id;
-    channels_[channel_id].raw_duty_value = BasePwm::DutyCycleToRaw(config.initial_duty_cycle, config.resolution_bits);
-    channels_[channel_id].last_error = HfPwmErr::PWM_SUCCESS;
-    
-    ESP_LOGI(TAG, "Channel %d configured: pin=%d, freq=%lu Hz, res=%d bits, timer=%d", 
-             channel_id, config.output_pin, config.frequency_hz, config.resolution_bits, timer_id);
-    
-    return HfPwmErr::PWM_SUCCESS;
+
+if (!BasePwm::IsValidDutyCycle(config.initial_duty_cycle)) {
+  SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
+  return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
+}
+
+if (!BasePwm::IsValidFrequency(config.frequency_hz, MIN_FREQUENCY, MAX_FREQUENCY)) {
+  SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_FREQUENCY);
+  return HfPwmErr::PWM_ERR_INVALID_FREQUENCY;
+}
+
+// Find or allocate a timer for this frequency/resolution combination
+int8_t timer_id = FindOrAllocateTimer(config.frequency_hz, config.resolution_bits);
+if (timer_id < 0) {
+  SetChannelError(channel_id, HfPwmErr::PWM_ERR_TIMER_CONFLICT);
+  return HfPwmErr::PWM_ERR_TIMER_CONFLICT;
+}
+
+// Configure the platform timer if needed
+HfPwmErr timer_result =
+    ConfigurePlatformTimer(timer_id, config.frequency_hz, config.resolution_bits);
+if (timer_result != HfPwmErr::PWM_SUCCESS) {
+  SetChannelError(channel_id, timer_result);
+  return timer_result;
+}
+
+// Configure the platform channel
+HfPwmErr channel_result = ConfigurePlatformChannel(channel_id, config, timer_id);
+if (channel_result != HfPwmErr::PWM_SUCCESS) {
+  SetChannelError(channel_id, channel_result);
+  return channel_result;
+}
+
+// Update internal state
+channels_[channel_id].configured = true;
+channels_[channel_id].config = config;
+channels_[channel_id].assigned_timer = timer_id;
+channels_[channel_id].raw_duty_value =
+    BasePwm::DutyCycleToRaw(config.initial_duty_cycle, config.resolution_bits);
+channels_[channel_id].last_error = HfPwmErr::PWM_SUCCESS;
+
+ESP_LOGI(TAG, "Channel %d configured: pin=%d, freq=%lu Hz, res=%d bits, timer=%d", channel_id,
+         config.output_pin, config.frequency_hz, config.resolution_bits, timer_id);
+
+return HfPwmErr::PWM_SUCCESS;
 }
 
 HfPwmErr McuPwm::EnableChannel(uint8_t channel_id) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_CHANNEL_NOT_AVAILABLE);
-        return HfPwmErr::PWM_ERR_CHANNEL_NOT_AVAILABLE;
-    }
-    
-    if (channels_[channel_id].enabled) {
-        return HfPwmErr::PWM_SUCCESS; // Already enabled
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_CHANNEL_NOT_AVAILABLE);
+    return HfPwmErr::PWM_ERR_CHANNEL_NOT_AVAILABLE;
+  }
+
+  if (channels_[channel_id].enabled) {
+    return HfPwmErr::PWM_SUCCESS; // Already enabled
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    // Start the channel with current duty cycle
-    esp_err_t ret = ledc_set_duty_and_update(
-        LEDC_LOW_SPEED_MODE, 
-        static_cast<ledc_channel_t>(channel_id), 
-        channels_[channel_id].raw_duty_value,
-        0  // No hpoint (phase shift)
-    );
-    
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to enable channel %d: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    channels_[channel_id].enabled = true;
-    ESP_LOGI(TAG, "Channel %d enabled", channel_id);
-    return HfPwmErr::PWM_SUCCESS;
-    
+  // Start the channel with current duty cycle
+  esp_err_t ret =
+      ledc_set_duty_and_update(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id),
+                               channels_[channel_id].raw_duty_value,
+                               0 // No hpoint (phase shift)
+      );
+
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to enable channel %d: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  channels_[channel_id].enabled = true;
+  ESP_LOGI(TAG, "Channel %d enabled", channel_id);
+  return HfPwmErr::PWM_SUCCESS;
+
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 HfPwmErr McuPwm::DisableChannel(uint8_t channel_id) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].enabled) {
-        return HfPwmErr::PWM_SUCCESS; // Already disabled
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].enabled) {
+    return HfPwmErr::PWM_SUCCESS; // Already disabled
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    // Stop the channel based on idle state
-    uint32_t idle_level = (channels_[channel_id].config.idle_state == PwmIdleState::High) ? 1 : 0;
-    if (channels_[channel_id].config.invert_output) {
-        idle_level = 1 - idle_level;
-    }
-    
-    esp_err_t ret = ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), idle_level);
-    
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to disable channel %d: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    channels_[channel_id].enabled = false;
-    ESP_LOGI(TAG, "Channel %d disabled", channel_id);
-    return HfPwmErr::PWM_SUCCESS;
-    
+  // Stop the channel based on idle state
+  uint32_t idle_level = (channels_[channel_id].config.idle_state == PwmIdleState::High) ? 1 : 0;
+  if (channels_[channel_id].config.invert_output) {
+    idle_level = 1 - idle_level;
+  }
+
+  esp_err_t ret =
+      ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), idle_level);
+
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to disable channel %d: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  channels_[channel_id].enabled = false;
+  ESP_LOGI(TAG, "Channel %d disabled", channel_id);
+  return HfPwmErr::PWM_SUCCESS;
+
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 bool McuPwm::IsChannelEnabled(uint8_t channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
-        return false;
-    }
-    
-    return channels_[channel_id].enabled;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
+    return false;
+  }
+
+  return channels_[channel_id].enabled;
 }
 
 //==============================================================================
@@ -414,136 +413,139 @@ bool McuPwm::IsChannelEnabled(uint8_t channel_id) const noexcept {
 //==============================================================================
 
 HfPwmErr McuPwm::SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!BasePwm::IsValidDutyCycle(duty_cycle)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
-        return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
-    }
-    
-    uint32_t raw_duty = BasePwm::DutyCycleToRaw(duty_cycle, channels_[channel_id].config.resolution_bits);
-    return SetDutyCycleRaw(channel_id, raw_duty);
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!BasePwm::IsValidDutyCycle(duty_cycle)) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
+    return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
+  }
+
+  uint32_t raw_duty =
+      BasePwm::DutyCycleToRaw(duty_cycle, channels_[channel_id].config.resolution_bits);
+  return SetDutyCycleRaw(channel_id, raw_duty);
 }
 
 HfPwmErr McuPwm::SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    uint32_t max_duty = (1U << channels_[channel_id].config.resolution_bits) - 1;
-    if (raw_value > max_duty) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_DUTY_OUT_OF_RANGE);
-        return HfPwmErr::PWM_ERR_DUTY_OUT_OF_RANGE;
-    }
-    
-    // Apply inversion if configured
-    uint32_t actual_duty = raw_value;
-    if (channels_[channel_id].config.invert_output) {
-        actual_duty = max_duty - raw_value;
-    }
-    
-    HfPwmErr result = UpdatePlatformDuty(channel_id, actual_duty);
-    if (result == HfPwmErr::PWM_SUCCESS) {
-        channels_[channel_id].raw_duty_value = raw_value;
-        channels_[channel_id].last_error = HfPwmErr::PWM_SUCCESS;
-    }
-    
-    return result;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  uint32_t max_duty = (1U << channels_[channel_id].config.resolution_bits) - 1;
+  if (raw_value > max_duty) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_DUTY_OUT_OF_RANGE);
+    return HfPwmErr::PWM_ERR_DUTY_OUT_OF_RANGE;
+  }
+
+  // Apply inversion if configured
+  uint32_t actual_duty = raw_value;
+  if (channels_[channel_id].config.invert_output) {
+    actual_duty = max_duty - raw_value;
+  }
+
+  HfPwmErr result = UpdatePlatformDuty(channel_id, actual_duty);
+  if (result == HfPwmErr::PWM_SUCCESS) {
+    channels_[channel_id].raw_duty_value = raw_value;
+    channels_[channel_id].last_error = HfPwmErr::PWM_SUCCESS;
+  }
+
+  return result;
 }
 
 HfPwmErr McuPwm::SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!BasePwm::IsValidFrequency(frequency_hz, MIN_FREQUENCY, MAX_FREQUENCY)) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_FREQUENCY);
+    return HfPwmErr::PWM_ERR_INVALID_FREQUENCY;
+  }
+
+  // Check if we can update the existing timer or need a new one
+  uint8_t current_timer = channels_[channel_id].assigned_timer;
+  bool can_update_existing = (timers_[current_timer].channel_count == 1);
+
+  if (can_update_existing) {
+    // We can update the existing timer since this is the only channel using it
+    HfPwmErr result = ConfigurePlatformTimer(current_timer, frequency_hz,
+                                             channels_[channel_id].config.resolution_bits);
+    if (result == HfPwmErr::PWM_SUCCESS) {
+      channels_[channel_id].config.frequency_hz = frequency_hz;
+      timers_[current_timer].frequency_hz = frequency_hz;
     }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+    return result;
+  } else {
+    // Need to find a new timer
+    int8_t new_timer =
+        FindOrAllocateTimer(frequency_hz, channels_[channel_id].config.resolution_bits);
+    if (new_timer < 0) {
+      SetChannelError(channel_id, HfPwmErr::PWM_ERR_TIMER_CONFLICT);
+      return HfPwmErr::PWM_ERR_TIMER_CONFLICT;
     }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+
+    // Reconfigure the channel with the new timer
+    HfPwmErr result = ConfigurePlatformChannel(channel_id, channels_[channel_id].config, new_timer);
+    if (result == HfPwmErr::PWM_SUCCESS) {
+      // Release the old timer and assign the new one
+      ReleaseTimerIfUnused(current_timer);
+      channels_[channel_id].assigned_timer = new_timer;
+      channels_[channel_id].config.frequency_hz = frequency_hz;
     }
-    
-    if (!BasePwm::IsValidFrequency(frequency_hz, MIN_FREQUENCY, MAX_FREQUENCY)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_FREQUENCY);
-        return HfPwmErr::PWM_ERR_INVALID_FREQUENCY;
-    }
-    
-    // Check if we can update the existing timer or need a new one
-    uint8_t current_timer = channels_[channel_id].assigned_timer;
-    bool can_update_existing = (timers_[current_timer].channel_count == 1);
-    
-    if (can_update_existing) {
-        // We can update the existing timer since this is the only channel using it
-        HfPwmErr result = ConfigurePlatformTimer(current_timer, frequency_hz, channels_[channel_id].config.resolution_bits);
-        if (result == HfPwmErr::PWM_SUCCESS) {
-            channels_[channel_id].config.frequency_hz = frequency_hz;
-            timers_[current_timer].frequency_hz = frequency_hz;
-        }
-        return result;
-    } else {
-        // Need to find a new timer
-        int8_t new_timer = FindOrAllocateTimer(frequency_hz, channels_[channel_id].config.resolution_bits);
-        if (new_timer < 0) {
-            SetChannelError(channel_id, HfPwmErr::PWM_ERR_TIMER_CONFLICT);
-            return HfPwmErr::PWM_ERR_TIMER_CONFLICT;
-        }
-        
-        // Reconfigure the channel with the new timer
-        HfPwmErr result = ConfigurePlatformChannel(channel_id, channels_[channel_id].config, new_timer);
-        if (result == HfPwmErr::PWM_SUCCESS) {
-            // Release the old timer and assign the new one
-            ReleaseTimerIfUnused(current_timer);
-            channels_[channel_id].assigned_timer = new_timer;
-            channels_[channel_id].config.frequency_hz = frequency_hz;
-        }
-        return result;
-    }
+    return result;
+  }
 }
 
 HfPwmErr McuPwm::SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    // ESP32C6 LEDC doesn't support phase shifting directly
-    // This would require advanced timer configuration
-    ESP_LOGW(TAG, "Phase shift not supported on ESP32C6 LEDC peripheral");
-    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
-    return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  // ESP32C6 LEDC doesn't support phase shifting directly
+  // This would require advanced timer configuration
+  ESP_LOGW(TAG, "Phase shift not supported on ESP32C6 LEDC peripheral");
+  SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
+  return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
 }
 
 //==============================================================================
@@ -551,108 +553,110 @@ HfPwmErr McuPwm::SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees
 //==============================================================================
 
 HfPwmErr McuPwm::StartAll() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  HfPwmErr result = HfPwmErr::PWM_SUCCESS;
+
+  for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
+    if (channels_[channel_id].configured && !channels_[channel_id].enabled) {
+      HfPwmErr channel_result = EnableChannel(channel_id);
+      if (channel_result != HfPwmErr::PWM_SUCCESS) {
+        result = channel_result; // Keep the last error
+      }
     }
-    
-    HfPwmErr result = HfPwmErr::PWM_SUCCESS;
-    
-    for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
-        if (channels_[channel_id].configured && !channels_[channel_id].enabled) {
-            HfPwmErr channel_result = EnableChannel(channel_id);
-            if (channel_result != HfPwmErr::PWM_SUCCESS) {
-                result = channel_result; // Keep the last error
-            }
-        }
-    }
-    
-    return result;
+  }
+
+  return result;
 }
 
 HfPwmErr McuPwm::StopAll() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  HfPwmErr result = HfPwmErr::PWM_SUCCESS;
+
+  for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
+    if (channels_[channel_id].enabled) {
+      HfPwmErr channel_result = DisableChannel(channel_id);
+      if (channel_result != HfPwmErr::PWM_SUCCESS) {
+        result = channel_result; // Keep the last error
+      }
     }
-    
-    HfPwmErr result = HfPwmErr::PWM_SUCCESS;
-    
-    for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
-        if (channels_[channel_id].enabled) {
-            HfPwmErr channel_result = DisableChannel(channel_id);
-            if (channel_result != HfPwmErr::PWM_SUCCESS) {
-                result = channel_result; // Keep the last error
-            }
-        }
-    }
-    
-    return result;
+  }
+
+  return result;
 }
 
 HfPwmErr McuPwm::UpdateAll() noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    // For ESP32C6, we can update all channels simultaneously
-    for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
-        if (channels_[channel_id].configured && channels_[channel_id].enabled) {
-            esp_err_t ret = ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
-            if (ret != ESP_OK) {
-                ESP_LOGE(TAG, "ledc_update_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-                SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-                return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-            }
-        }
+  // For ESP32C6, we can update all channels simultaneously
+  for (HfChannelId channel_id = 0; channel_id < MAX_CHANNELS; channel_id++) {
+    if (channels_[channel_id].configured && channels_[channel_id].enabled) {
+      esp_err_t ret =
+          ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
+      if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "ledc_update_duty failed for channel %lu: %s", channel_id,
+                 esp_err_to_name(ret));
+        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+      }
     }
-    return HfPwmErr::PWM_SUCCESS;
+  }
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
-HfPwmErr McuPwm::SetComplementaryOutput(HfChannelId primary_channel, 
-                                      HfChannelId complementary_channel, 
-                                      uint32_t deadtime_ns) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+HfPwmErr McuPwm::SetComplementaryOutput(HfChannelId primary_channel,
+                                        HfChannelId complementary_channel,
+                                        uint32_t deadtime_ns) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(primary_channel) || !IsValidChannelId(complementary_channel)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (primary_channel == complementary_channel) {
+    return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
+  }
+
+  // ESP32C6 LEDC doesn't have direct complementary output support
+  // We would need to implement this in software using interrupts
+  ESP_LOGW(TAG, "Complementary outputs require software implementation on ESP32C6");
+
+  // Find an available complementary pair slot
+  for (auto &pair : complementary_pairs_) {
+    if (!pair.active) {
+      pair.primary_channel = static_cast<uint8_t>(primary_channel);
+      pair.complementary_channel = static_cast<uint8_t>(complementary_channel);
+      pair.deadtime_ns = deadtime_ns;
+      pair.active = true;
+
+      ESP_LOGI(TAG, "Complementary pair configured: primary=%lu, comp=%lu, deadtime=%lu ns",
+               primary_channel, complementary_channel, deadtime_ns);
+      return HfPwmErr::PWM_SUCCESS;
     }
-    
-    if (!IsValidChannelId(primary_channel) || !IsValidChannelId(complementary_channel)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (primary_channel == complementary_channel) {
-        return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
-    }
-    
-    // ESP32C6 LEDC doesn't have direct complementary output support
-    // We would need to implement this in software using interrupts
-    ESP_LOGW(TAG, "Complementary outputs require software implementation on ESP32C6");
-    
-    // Find an available complementary pair slot
-    for (auto& pair : complementary_pairs_) {
-        if (!pair.active) {
-            pair.primary_channel = static_cast<uint8_t>(primary_channel);
-            pair.complementary_channel = static_cast<uint8_t>(complementary_channel);
-            pair.deadtime_ns = deadtime_ns;
-            pair.active = true;
-            
-            ESP_LOGI(TAG, "Complementary pair configured: primary=%lu, comp=%lu, deadtime=%lu ns", 
-                     primary_channel, complementary_channel, deadtime_ns);
-            return HfPwmErr::PWM_SUCCESS;
-        }
-    }
-    
-    return HfPwmErr::PWM_ERR_INSUFFICIENT_CHANNELS;
+  }
+
+  return HfPwmErr::PWM_ERR_INSUFFICIENT_CHANNELS;
 }
 
 //==============================================================================
@@ -660,277 +664,280 @@ HfPwmErr McuPwm::SetComplementaryOutput(HfChannelId primary_channel,
 //==============================================================================
 
 float McuPwm::GetDutyCycle(HfChannelId channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
-        return -1.0f;
-    }
-    
-    return BasePwm::RawToDutyCycle(channels_[channel_id].raw_duty_value, 
-                                  channels_[channel_id].config.resolution_bits);
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
+    return -1.0f;
+  }
+
+  return BasePwm::RawToDutyCycle(channels_[channel_id].raw_duty_value,
+                                 channels_[channel_id].config.resolution_bits);
 }
 
 HfFrequencyHz McuPwm::GetFrequency(HfChannelId channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
-        return 0;
-    }
-    
-    return channels_[channel_id].config.frequency_hz;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
+    return 0;
+  }
+
+  return channels_[channel_id].config.frequency_hz;
 }
 
-HfPwmErr McuPwm::GetChannelStatus(HfChannelId channel_id, PwmChannelStatus& status) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        status = PwmChannelStatus{}; // Reset to default
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    status.is_enabled = channels_[channel_id].enabled;
-    status.is_running = channels_[channel_id].enabled;
-    status.current_frequency_hz = channels_[channel_id].config.frequency_hz;
-    status.current_duty_cycle = BasePwm::RawToDutyCycle(channels_[channel_id].raw_duty_value, 
-                                                       channels_[channel_id].config.resolution_bits);
-    status.raw_duty_value = channels_[channel_id].raw_duty_value;
-    status.last_error = channels_[channel_id].last_error;
-    
-    return HfPwmErr::PWM_SUCCESS;
+HfPwmErr McuPwm::GetChannelStatus(HfChannelId channel_id, PwmChannelStatus &status) const noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    status = PwmChannelStatus{}; // Reset to default
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  status.is_enabled = channels_[channel_id].enabled;
+  status.is_running = channels_[channel_id].enabled;
+  status.current_frequency_hz = channels_[channel_id].config.frequency_hz;
+  status.current_duty_cycle = BasePwm::RawToDutyCycle(channels_[channel_id].raw_duty_value,
+                                                      channels_[channel_id].config.resolution_bits);
+  status.raw_duty_value = channels_[channel_id].raw_duty_value;
+  status.last_error = channels_[channel_id].last_error;
+
+  return HfPwmErr::PWM_SUCCESS;
 }
 
-HfPwmErr McuPwm::GetCapabilities(PwmCapabilities& capabilities) const noexcept {
-    capabilities.max_channels = MAX_CHANNELS;
-    capabilities.max_timers = MAX_TIMERS;
-    capabilities.min_frequency_hz = MIN_FREQUENCY;
-    capabilities.max_frequency_hz = MAX_FREQUENCY;
-    capabilities.min_resolution_bits = 1;
-    capabilities.max_resolution_bits = MAX_RESOLUTION;
-    capabilities.supports_complementary = true; // Software implementation
-    capabilities.supports_center_aligned = false; // Not supported by LEDC
-    capabilities.supports_deadtime = true; // Software implementation
-    capabilities.supports_phase_shift = false; // Not supported by LEDC
-    
-    return HfPwmErr::PWM_SUCCESS;
+HfPwmErr McuPwm::GetCapabilities(PwmCapabilities &capabilities) const noexcept {
+  capabilities.max_channels = MAX_CHANNELS;
+  capabilities.max_timers = MAX_TIMERS;
+  capabilities.min_frequency_hz = MIN_FREQUENCY;
+  capabilities.max_frequency_hz = MAX_FREQUENCY;
+  capabilities.min_resolution_bits = 1;
+  capabilities.max_resolution_bits = MAX_RESOLUTION;
+  capabilities.supports_complementary = true;   // Software implementation
+  capabilities.supports_center_aligned = false; // Not supported by LEDC
+  capabilities.supports_deadtime = true;        // Software implementation
+  capabilities.supports_phase_shift = false;    // Not supported by LEDC
+
+  return HfPwmErr::PWM_SUCCESS;
 }
 
 HfPwmErr McuPwm::GetLastError(HfChannelId channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    return channels_[channel_id].last_error;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  return channels_[channel_id].last_error;
 }
 
 //==============================================================================
 // CALLBACKS (BasePwm Interface)
 //==============================================================================
 
-void McuPwm::SetPeriodCallback(PwmPeriodCallback callback, void* user_data) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    period_callback_ = callback;
-    period_callback_user_data_ = user_data;
+void McuPwm::SetPeriodCallback(PwmPeriodCallback callback, void *user_data) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+  period_callback_ = callback;
+  period_callback_user_data_ = user_data;
 }
 
-void McuPwm::SetFaultCallback(PwmFaultCallback callback, void* user_data) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    fault_callback_ = callback;
-    fault_callback_user_data_ = user_data;
+void McuPwm::SetFaultCallback(PwmFaultCallback callback, void *user_data) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+  fault_callback_ = callback;
+  fault_callback_user_data_ = user_data;
 }
 
 //==============================================================================
 // ESP32C6-SPECIFIC FEATURES
 //==============================================================================
 
-HfPwmErr McuPwm::SetHardwareFade(HfChannelId channel_id, float target_duty_cycle, uint32_t fade_time_ms) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!BasePwm::IsValidDutyCycle(target_duty_cycle)) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
-        return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
-    }
-    
+HfPwmErr McuPwm::SetHardwareFade(HfChannelId channel_id, float target_duty_cycle,
+                                 uint32_t fade_time_ms) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!BasePwm::IsValidDutyCycle(target_duty_cycle)) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE);
+    return HfPwmErr::PWM_ERR_INVALID_DUTY_CYCLE;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    uint32_t target_duty_raw = BasePwm::DutyCycleToRaw(target_duty_cycle, channels_[channel_id].config.resolution_bits);
-    
-    // Apply inversion if configured
-    if (channels_[channel_id].config.invert_output) {
-        uint32_t max_duty = (1U << channels_[channel_id].config.resolution_bits) - 1;
-        target_duty_raw = max_duty - target_duty_raw;
-    }
-    
-    esp_err_t ret = ledc_set_fade_with_time(LEDC_LOW_SPEED_MODE, 
-                                           static_cast<ledc_channel_t>(channel_id), 
-                                           target_duty_raw, 
-                                           fade_time_ms);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_set_fade_with_time failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    ret = ledc_fade_start(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), LEDC_FADE_NO_WAIT);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_fade_start failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    channels_[channel_id].fade_active = true;
-    ESP_LOGD(TAG, "Hardware fade started for channel %lu: target=%.2f%%, time=%lu ms", 
-             channel_id, target_duty_cycle * 100.0f, fade_time_ms);
-    
-    return HfPwmErr::PWM_SUCCESS;
+  uint32_t target_duty_raw =
+      BasePwm::DutyCycleToRaw(target_duty_cycle, channels_[channel_id].config.resolution_bits);
+
+  // Apply inversion if configured
+  if (channels_[channel_id].config.invert_output) {
+    uint32_t max_duty = (1U << channels_[channel_id].config.resolution_bits) - 1;
+    target_duty_raw = max_duty - target_duty_raw;
+  }
+
+  esp_err_t ret = ledc_set_fade_with_time(
+      LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), target_duty_raw, fade_time_ms);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_set_fade_with_time failed for channel %lu: %s", channel_id,
+             esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  ret = ledc_fade_start(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id),
+                        LEDC_FADE_NO_WAIT);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_fade_start failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  channels_[channel_id].fade_active = true;
+  ESP_LOGD(TAG, "Hardware fade started for channel %lu: target=%.2f%%, time=%lu ms", channel_id,
+           target_duty_cycle * 100.0f, fade_time_ms);
+
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 HfPwmErr McuPwm::StopHardwareFade(HfChannelId channel_id) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = ledc_fade_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_fade_stop failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    channels_[channel_id].fade_active = false;
-    ESP_LOGD(TAG, "Hardware fade stopped for channel %lu", channel_id);
-    
-    return HfPwmErr::PWM_SUCCESS;
+  esp_err_t ret = ledc_fade_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_fade_stop failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  channels_[channel_id].fade_active = false;
+  ESP_LOGD(TAG, "Hardware fade stopped for channel %lu", channel_id);
+
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 bool McuPwm::IsFadeActive(HfChannelId channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
-        return false;
-    }
-    
-    return channels_[channel_id].fade_active;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
+    return false;
+  }
+
+  return channels_[channel_id].fade_active;
 }
 
 HfPwmErr McuPwm::SetIdleLevel(HfChannelId channel_id, uint8_t idle_level) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (idle_level > 1) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
-        return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
-    }
-    
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (idle_level > 1) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
+    return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
+  }
+
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), idle_level);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_stop failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    ESP_LOGD(TAG, "Idle level set to %d for channel %lu", idle_level, channel_id);
-    return HfPwmErr::PWM_SUCCESS;
+  esp_err_t ret =
+      ledc_stop(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), idle_level);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_stop failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_HARDWARE_FAULT);
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  ESP_LOGD(TAG, "Idle level set to %d for channel %lu", idle_level, channel_id);
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 int8_t McuPwm::GetTimerAssignment(HfChannelId channel_id) const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
-        return -1;
-    }
-    
-    return channels_[channel_id].assigned_timer;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
+    return -1;
+  }
+
+  return channels_[channel_id].assigned_timer;
 }
 
 HfPwmErr McuPwm::ForceTimerAssignment(HfChannelId channel_id, uint8_t timer_id) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    if (!initialized_) {
-        return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
-    }
-    
-    if (!IsValidChannelId(channel_id)) {
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    if (timer_id >= MAX_TIMERS) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
-        return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
-    }
-    
-    if (!channels_[channel_id].configured) {
-        SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
-        return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
-    }
-    
-    // Release current timer and assign new one
-    uint8_t old_timer = channels_[channel_id].assigned_timer;
-    ReleaseTimerIfUnused(old_timer);
-    
-    // Configure new timer
-    HfPwmErr result = ConfigurePlatformTimer(timer_id, channels_[channel_id].config.frequency_hz, 
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!initialized_) {
+    return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
+  }
+
+  if (!IsValidChannelId(channel_id)) {
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  if (timer_id >= MAX_TIMERS) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_PARAMETER);
+    return HfPwmErr::PWM_ERR_INVALID_PARAMETER;
+  }
+
+  if (!channels_[channel_id].configured) {
+    SetChannelError(channel_id, HfPwmErr::PWM_ERR_INVALID_CHANNEL);
+    return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
+  }
+
+  // Release current timer and assign new one
+  uint8_t old_timer = channels_[channel_id].assigned_timer;
+  ReleaseTimerIfUnused(old_timer);
+
+  // Configure new timer
+  HfPwmErr result = ConfigurePlatformTimer(timer_id, channels_[channel_id].config.frequency_hz,
                                            channels_[channel_id].config.resolution_bits);
-    if (result == HfPwmErr::PWM_SUCCESS) {
-        channels_[channel_id].assigned_timer = timer_id;
-        timers_[timer_id].channel_count++;
-        
-        // Reconfigure the channel with new timer
-        result = ConfigurePlatformChannel(channel_id, channels_[channel_id].config, timer_id);
-    }
-    
-    return result;
+  if (result == HfPwmErr::PWM_SUCCESS) {
+    channels_[channel_id].assigned_timer = timer_id;
+    timers_[timer_id].channel_count++;
+
+    // Reconfigure the channel with new timer
+    result = ConfigurePlatformChannel(channel_id, channels_[channel_id].config, timer_id);
+  }
+
+  return result;
 }
 
 //==============================================================================
@@ -938,148 +945,154 @@ HfPwmErr McuPwm::ForceTimerAssignment(HfChannelId channel_id, uint8_t timer_id) 
 //==============================================================================
 
 bool McuPwm::IsValidChannelId(HfChannelId channel_id) const noexcept {
-    return (channel_id < MAX_CHANNELS);
+  return (channel_id < MAX_CHANNELS);
 }
 
 int8_t McuPwm::FindOrAllocateTimer(uint32_t frequency_hz, uint8_t resolution_bits) noexcept {
-    // First, try to find an existing timer with the same configuration
-    for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
-        if (timers_[timer_id].in_use && 
-            timers_[timer_id].frequency_hz == frequency_hz &&
-            timers_[timer_id].resolution_bits == resolution_bits) {
-            return timer_id;
-        }
+  // First, try to find an existing timer with the same configuration
+  for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
+    if (timers_[timer_id].in_use && timers_[timer_id].frequency_hz == frequency_hz &&
+        timers_[timer_id].resolution_bits == resolution_bits) {
+      return timer_id;
     }
-    
-    // If not found, allocate a new timer
-    for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
-        if (!timers_[timer_id].in_use) {
-            timers_[timer_id].in_use = true;
-            timers_[timer_id].frequency_hz = frequency_hz;
-            timers_[timer_id].resolution_bits = resolution_bits;
-            timers_[timer_id].channel_count = 0;
-            return timer_id;
-        }
+  }
+
+  // If not found, allocate a new timer
+  for (uint8_t timer_id = 0; timer_id < MAX_TIMERS; timer_id++) {
+    if (!timers_[timer_id].in_use) {
+      timers_[timer_id].in_use = true;
+      timers_[timer_id].frequency_hz = frequency_hz;
+      timers_[timer_id].resolution_bits = resolution_bits;
+      timers_[timer_id].channel_count = 0;
+      return timer_id;
     }
-    
-    return -1; // No timer available
+  }
+
+  return -1; // No timer available
 }
 
 void McuPwm::ReleaseTimerIfUnused(uint8_t timer_id) noexcept {
-    if (timer_id >= MAX_TIMERS) return;
-    
-    // Decrement channel count
-    if (timers_[timer_id].channel_count > 0) {
-        timers_[timer_id].channel_count--;
-    }
-    
-    // If no channels are using this timer, release it
-    if (timers_[timer_id].channel_count == 0) {
-        timers_[timer_id].in_use = false;
-        ESP_LOGD(TAG, "Timer %d released", timer_id);
-    }
+  if (timer_id >= MAX_TIMERS)
+    return;
+
+  // Decrement channel count
+  if (timers_[timer_id].channel_count > 0) {
+    timers_[timer_id].channel_count--;
+  }
+
+  // If no channels are using this timer, release it
+  if (timers_[timer_id].channel_count == 0) {
+    timers_[timer_id].in_use = false;
+    ESP_LOGD(TAG, "Timer %d released", timer_id);
+  }
 }
 
-HfPwmErr McuPwm::ConfigurePlatformTimer(uint8_t timer_id, uint32_t frequency_hz, uint8_t resolution_bits) noexcept {
+HfPwmErr McuPwm::ConfigurePlatformTimer(uint8_t timer_id, uint32_t frequency_hz,
+                                        uint8_t resolution_bits) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    ledc_timer_config_t timer_config = {};
-    timer_config.speed_mode = LEDC_LOW_SPEED_MODE;
-    timer_config.timer_num = static_cast<ledc_timer_t>(timer_id);
-    timer_config.duty_resolution = static_cast<ledc_timer_bit_t>(resolution_bits);
-    timer_config.freq_hz = frequency_hz;
-    timer_config.clk_cfg = LEDC_AUTO_CLK;
-    
-    esp_err_t ret = ledc_timer_config(&timer_config);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_timer_config failed for timer %d: %s", timer_id, esp_err_to_name(ret));
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    ESP_LOGD(TAG, "Timer %d configured: freq=%lu Hz, resolution=%d bits", timer_id, frequency_hz, resolution_bits);
-    return HfPwmErr::PWM_SUCCESS;
+  ledc_timer_config_t timer_config = {};
+  timer_config.speed_mode = LEDC_LOW_SPEED_MODE;
+  timer_config.timer_num = static_cast<ledc_timer_t>(timer_id);
+  timer_config.duty_resolution = static_cast<ledc_timer_bit_t>(resolution_bits);
+  timer_config.freq_hz = frequency_hz;
+  timer_config.clk_cfg = LEDC_AUTO_CLK;
+
+  esp_err_t ret = ledc_timer_config(&timer_config);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_timer_config failed for timer %d: %s", timer_id, esp_err_to_name(ret));
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  ESP_LOGD(TAG, "Timer %d configured: freq=%lu Hz, resolution=%d bits", timer_id, frequency_hz,
+           resolution_bits);
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
-HfPwmErr McuPwm::ConfigurePlatformChannel(HfChannelId channel_id, const PwmChannelConfig& config, uint8_t timer_id) noexcept {
+HfPwmErr McuPwm::ConfigurePlatformChannel(HfChannelId channel_id, const PwmChannelConfig &config,
+                                          uint8_t timer_id) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    ledc_channel_config_t channel_config = {};
-    channel_config.speed_mode = LEDC_LOW_SPEED_MODE;
-    channel_config.channel = static_cast<ledc_channel_t>(channel_id);
-    channel_config.timer_sel = static_cast<ledc_timer_t>(timer_id);
-    channel_config.intr_type = LEDC_INTR_DISABLE;
-    channel_config.gpio_num = config.output_pin;
-    
-    // Calculate initial duty
-    uint32_t initial_duty = BasePwm::DutyCycleToRaw(config.initial_duty_cycle, config.resolution_bits);
-    if (config.invert_output) {
-        uint32_t max_duty = (1U << config.resolution_bits) - 1;
-        initial_duty = max_duty - initial_duty;
-    }
-    channel_config.duty = initial_duty;
-    
-    channel_config.hpoint = 0; // Start at the beginning of the period
-    
-    esp_err_t ret = ledc_channel_config(&channel_config);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_channel_config failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    // Increment timer usage count
-    timers_[timer_id].channel_count++;
-    
-    ESP_LOGD(TAG, "Channel %lu configured: pin=%d, timer=%d, duty=%lu", 
-             channel_id, config.output_pin, timer_id, initial_duty);
-    
-    return HfPwmErr::PWM_SUCCESS;
+  ledc_channel_config_t channel_config = {};
+  channel_config.speed_mode = LEDC_LOW_SPEED_MODE;
+  channel_config.channel = static_cast<ledc_channel_t>(channel_id);
+  channel_config.timer_sel = static_cast<ledc_timer_t>(timer_id);
+  channel_config.intr_type = LEDC_INTR_DISABLE;
+  channel_config.gpio_num = config.output_pin;
+
+  // Calculate initial duty
+  uint32_t initial_duty =
+      BasePwm::DutyCycleToRaw(config.initial_duty_cycle, config.resolution_bits);
+  if (config.invert_output) {
+    uint32_t max_duty = (1U << config.resolution_bits) - 1;
+    initial_duty = max_duty - initial_duty;
+  }
+  channel_config.duty = initial_duty;
+
+  channel_config.hpoint = 0; // Start at the beginning of the period
+
+  esp_err_t ret = ledc_channel_config(&channel_config);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_channel_config failed for channel %lu: %s", channel_id,
+             esp_err_to_name(ret));
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  // Increment timer usage count
+  timers_[timer_id].channel_count++;
+
+  ESP_LOGD(TAG, "Channel %lu configured: pin=%d, timer=%d, duty=%lu", channel_id, config.output_pin,
+           timer_id, initial_duty);
+
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 HfPwmErr McuPwm::UpdatePlatformDuty(HfChannelId channel_id, uint32_t raw_duty_value) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t ret = ledc_set_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), raw_duty_value);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_set_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    ret = ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "ledc_update_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
-        return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
-    }
-    
-    return HfPwmErr::PWM_SUCCESS;
+  esp_err_t ret =
+      ledc_set_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id), raw_duty_value);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_set_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  ret = ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(channel_id));
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "ledc_update_duty failed for channel %lu: %s", channel_id, esp_err_to_name(ret));
+    return HfPwmErr::PWM_ERR_HARDWARE_FAULT;
+  }
+
+  return HfPwmErr::PWM_SUCCESS;
 #else
-    return HfPwmErr::PWM_ERR_FAILURE;
+  return HfPwmErr::PWM_ERR_FAILURE;
 #endif
 }
 
 void McuPwm::SetChannelError(HfChannelId channel_id, HfPwmErr error) noexcept {
-    if (IsValidChannelId(channel_id)) {
-        channels_[channel_id].last_error = error;
-    }
-    last_global_error_ = error;
+  if (IsValidChannelId(channel_id)) {
+    channels_[channel_id].last_error = error;
+  }
+  last_global_error_ = error;
 }
 
-void IRAM_ATTR McuPwm::InterruptHandler(HfChannelId channel_id, void* user_data) noexcept {
-    auto* self = static_cast<McuPwm*>(user_data);
-    if (self) {
-        self->HandleFadeComplete(channel_id);
-    }
+void IRAM_ATTR McuPwm::InterruptHandler(HfChannelId channel_id, void *user_data) noexcept {
+  auto *self = static_cast<McuPwm *>(user_data);
+  if (self) {
+    self->HandleFadeComplete(channel_id);
+  }
 }
 
 void McuPwm::HandleFadeComplete(HfChannelId channel_id) noexcept {
-    if (IsValidChannelId(channel_id)) {
-        channels_[channel_id].fade_active = false;
-        
-        // Call period callback if set
-        if (period_callback_) {
-            period_callback_(channel_id, period_callback_user_data_);
-        }
+  if (IsValidChannelId(channel_id)) {
+    channels_[channel_id].fade_active = false;
+
+    // Call period callback if set
+    if (period_callback_) {
+      period_callback_(channel_id, period_callback_user_data_);
     }
+  }
 }

--- a/src/mcu/McuSpi.cpp
+++ b/src/mcu/McuSpi.cpp
@@ -7,31 +7,27 @@
 
 // Platform-specific includes
 #ifdef HF_MCU_FAMILY_ESP32
-#include "driver/spi_master.h"
 #include "driver/gpio.h"
+#include "driver/spi_master.h"
 #include "esp_log.h"
 
-static const char* TAG = "McuSpi";
+static const char *TAG = "McuSpi";
 #endif
 
 //==============================================//
 // CONSTRUCTOR & DESTRUCTOR                     //
 //==============================================//
 
-McuSpi::McuSpi(const SpiBusConfig& config) noexcept
-    : BaseSpiBus(config),
-      platform_handle_(nullptr),
-      last_error_(HfSpiErr::SPI_SUCCESS),
-      transaction_count_(0),
-      cs_active_(false),
-      dma_enabled_(false),
-      max_transfer_size_(4092) {  // ESP32 default max transfer size
+McuSpi::McuSpi(const SpiBusConfig &config) noexcept
+    : BaseSpiBus(config), platform_handle_(nullptr), last_error_(HfSpiErr::SPI_SUCCESS),
+      transaction_count_(0), cs_active_(false), dma_enabled_(false),
+      max_transfer_size_(4092) { // ESP32 default max transfer size
 }
 
 McuSpi::~McuSpi() noexcept {
-    if (initialized_) {
-        Deinitialize();
-    }
+  if (initialized_) {
+    Deinitialize();
+  }
 }
 
 //==============================================//
@@ -39,93 +35,93 @@ McuSpi::~McuSpi() noexcept {
 //==============================================//
 
 bool McuSpi::Initialize() noexcept {
-    if (initialized_) {
-        return true;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    // Validate configuration
-    if (config_.mosi_pin == HF_GPIO_INVALID && config_.miso_pin == HF_GPIO_INVALID) {
-        last_error_ = HfSpiErr::SPI_ERR_INVALID_CONFIGURATION;
-        return false;
-    }
-
-    if (config_.sclk_pin == HF_GPIO_INVALID) {
-        last_error_ = HfSpiErr::SPI_ERR_INVALID_CONFIGURATION;
-        return false;
-    }
-
-    if (!IsValidClockSpeed(config_.clock_speed_hz)) {
-        last_error_ = HfSpiErr::SPI_ERR_INVALID_CLOCK_SPEED;
-        return false;
-    }
-
-    if (!IsValidMode(config_.mode)) {
-        last_error_ = HfSpiErr::SPI_ERR_INVALID_MODE;
-        return false;
-    }
-
-    // Platform-specific initialization
-    if (!PlatformInitialize()) {
-        return false;
-    }
-
-    last_error_ = HfSpiErr::SPI_SUCCESS;
+  if (initialized_) {
     return true;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Validate configuration
+  if (config_.mosi_pin == HF_GPIO_INVALID && config_.miso_pin == HF_GPIO_INVALID) {
+    last_error_ = HfSpiErr::SPI_ERR_INVALID_CONFIGURATION;
+    return false;
+  }
+
+  if (config_.sclk_pin == HF_GPIO_INVALID) {
+    last_error_ = HfSpiErr::SPI_ERR_INVALID_CONFIGURATION;
+    return false;
+  }
+
+  if (!IsValidClockSpeed(config_.clock_speed_hz)) {
+    last_error_ = HfSpiErr::SPI_ERR_INVALID_CLOCK_SPEED;
+    return false;
+  }
+
+  if (!IsValidMode(config_.mode)) {
+    last_error_ = HfSpiErr::SPI_ERR_INVALID_MODE;
+    return false;
+  }
+
+  // Platform-specific initialization
+  if (!PlatformInitialize()) {
+    return false;
+  }
+
+  last_error_ = HfSpiErr::SPI_SUCCESS;
+  return true;
 }
 
 bool McuSpi::Deinitialize() noexcept {
-    if (!initialized_) {
-        return true;
-    }
+  if (!initialized_) {
+    return true;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    bool result = PlatformDeinitialize();
-    if (result) {
-        last_error_ = HfSpiErr::SPI_SUCCESS;
-    }
-    
-    return result;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  bool result = PlatformDeinitialize();
+  if (result) {
+    last_error_ = HfSpiErr::SPI_SUCCESS;
+  }
+
+  return result;
 }
 
-HfSpiErr McuSpi::Transfer(const uint8_t* tx_data, uint8_t* rx_data,
-                             uint16_t length, uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
-    }
+HfSpiErr McuSpi::Transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                          uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized()) {
+    return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
+  }
 
-    if (length == 0) {
-        return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
-    }
+  if (length == 0) {
+    return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
+  }
 
-    if (length > max_transfer_size_) {
-        return HfSpiErr::SPI_ERR_TRANSFER_TOO_LONG;
-    }
+  if (length > max_transfer_size_) {
+    return HfSpiErr::SPI_ERR_TRANSFER_TOO_LONG;
+  }
 
-    return InternalTransfer(tx_data, rx_data, length, timeout_ms, true);
+  return InternalTransfer(tx_data, rx_data, length, timeout_ms, true);
 }
 
 HfSpiErr McuSpi::SetChipSelect(bool active) noexcept {
-    if (!EnsureInitialized()) {
-        return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
-    }
+  if (!EnsureInitialized()) {
+    return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
-    if (config_.cs_pin != HF_GPIO_INVALID) {
-        gpio_num_t cs_pin = static_cast<gpio_num_t>(config_.cs_pin);
-        gpio_set_level(cs_pin, config_.cs_active_low ? !active : active);
-        cs_active_ = active;
-        last_error_ = HfSpiErr::SPI_SUCCESS;
-        return last_error_;
-    }
+  if (config_.cs_pin != HF_GPIO_INVALID) {
+    gpio_num_t cs_pin = static_cast<gpio_num_t>(config_.cs_pin);
+    gpio_set_level(cs_pin, config_.cs_active_low ? !active : active);
+    cs_active_ = active;
+    last_error_ = HfSpiErr::SPI_SUCCESS;
+    return last_error_;
+  }
 #endif
 
-    last_error_ = HfSpiErr::SPI_ERR_CS_CONTROL_FAILED;
-    return last_error_;
+  last_error_ = HfSpiErr::SPI_ERR_CS_CONTROL_FAILED;
+  return last_error_;
 }
 
 //==============================================//
@@ -133,171 +129,170 @@ HfSpiErr McuSpi::SetChipSelect(bool active) noexcept {
 //==============================================//
 
 bool McuSpi::IsBusy() noexcept {
-    if (!initialized_) {
-        return false;
-    }
+  if (!initialized_) {
+    return false;
+  }
 
-    // Simple implementation - could be enhanced with platform-specific busy checks
-    return cs_active_;
+  // Simple implementation - could be enhanced with platform-specific busy checks
+  return cs_active_;
 }
 
 bool McuSpi::SetClockSpeed(uint32_t clock_speed_hz) noexcept {
-    if (!IsValidClockSpeed(clock_speed_hz)) {
-        return false;
-    }
+  if (!IsValidClockSpeed(clock_speed_hz)) {
+    return false;
+  }
 
-    config_.clock_speed_hz = clock_speed_hz;
-    
-    // Reinitialize if already initialized
-    if (initialized_) {
-        bool was_initialized = initialized_;
-        initialized_ = false;
-        if (Deinitialize() && Initialize()) {
-            return true;
-        }
-        initialized_ = was_initialized;
-        return false;
+  config_.clock_speed_hz = clock_speed_hz;
+
+  // Reinitialize if already initialized
+  if (initialized_) {
+    bool was_initialized = initialized_;
+    initialized_ = false;
+    if (Deinitialize() && Initialize()) {
+      return true;
     }
-    
-    return true;
+    initialized_ = was_initialized;
+    return false;
+  }
+
+  return true;
 }
 
 bool McuSpi::SetMode(uint8_t mode) noexcept {
-    if (!IsValidMode(mode)) {
-        return false;
-    }
+  if (!IsValidMode(mode)) {
+    return false;
+  }
 
-    config_.mode = mode;
-    
-    // Reinitialize if already initialized
-    if (initialized_) {
-        bool was_initialized = initialized_;
-        initialized_ = false;
-        if (Deinitialize() && Initialize()) {
-            return true;
-        }
-        initialized_ = was_initialized;
-        return false;
+  config_.mode = mode;
+
+  // Reinitialize if already initialized
+  if (initialized_) {
+    bool was_initialized = initialized_;
+    initialized_ = false;
+    if (Deinitialize() && Initialize()) {
+      return true;
     }
-    
-    return true;
+    initialized_ = was_initialized;
+    return false;
+  }
+
+  return true;
 }
 
 bool McuSpi::SetDmaEnabled(bool enable) noexcept {
-    dma_enabled_ = enable;
-    return true;  // DMA setting will be applied on next initialization
+  dma_enabled_ = enable;
+  return true; // DMA setting will be applied on next initialization
 }
 
 uint32_t McuSpi::GetBusStatus() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Return platform-specific status information
-    return static_cast<uint32_t>(last_error_) | (cs_active_ ? 0x80000000 : 0);
+  // Return platform-specific status information
+  return static_cast<uint32_t>(last_error_) | (cs_active_ ? 0x80000000 : 0);
 #else
-    return 0;
+  return 0;
 #endif
 }
 
-HfSpiErr McuSpi::TransferSequence(const SpiTransfer* transfers, uint8_t num_transfers) noexcept {
-    if (!EnsureInitialized()) {
-        return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
-    }
+HfSpiErr McuSpi::TransferSequence(const SpiTransfer *transfers, uint8_t num_transfers) noexcept {
+  if (!EnsureInitialized()) {
+    return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
+  }
 
-    if (!transfers || num_transfers == 0) {
-        return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
-    }
+  if (!transfers || num_transfers == 0) {
+    return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
+  }
 
-    // Assert CS before sequence
-    HfSpiErr result = SetChipSelect(true);
+  // Assert CS before sequence
+  HfSpiErr result = SetChipSelect(true);
+  if (result != HfSpiErr::SPI_SUCCESS) {
+    return result;
+  }
+
+  // Perform transfers
+  for (uint8_t i = 0; i < num_transfers; i++) {
+    result = InternalTransfer(transfers[i].tx_data, transfers[i].rx_data, transfers[i].length,
+                              transfers[i].timeout_ms, false);
     if (result != HfSpiErr::SPI_SUCCESS) {
-        return result;
+      break;
     }
+  }
 
-    // Perform transfers
-    for (uint8_t i = 0; i < num_transfers; i++) {
-        result = InternalTransfer(transfers[i].tx_data, transfers[i].rx_data,
-                                 transfers[i].length, transfers[i].timeout_ms, false);
-        if (result != HfSpiErr::SPI_SUCCESS) {
-            break;
-        }
-    }
+  // Deassert CS after sequence
+  SetChipSelect(false);
 
-    // Deassert CS after sequence
-    SetChipSelect(false);
-    
-    return result;
+  return result;
 }
 
-HfSpiErr McuSpi::TransferWithTiming(const uint8_t* tx_data, uint8_t* rx_data,
-                                       uint16_t length, uint32_t cs_hold_time_us,
-                                       uint32_t timeout_ms) noexcept {
-    HfSpiErr result = Transfer(tx_data, rx_data, length, timeout_ms);
-    
-    if (result == HfSpiErr::SPI_SUCCESS && cs_hold_time_us > 0) {
-        // Platform-specific delay implementation
+HfSpiErr McuSpi::TransferWithTiming(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                                    uint32_t cs_hold_time_us, uint32_t timeout_ms) noexcept {
+  HfSpiErr result = Transfer(tx_data, rx_data, length, timeout_ms);
+
+  if (result == HfSpiErr::SPI_SUCCESS && cs_hold_time_us > 0) {
+    // Platform-specific delay implementation
 #ifdef HF_MCU_FAMILY_ESP32
-        esp_rom_delay_us(cs_hold_time_us);
+    esp_rom_delay_us(cs_hold_time_us);
 #endif
-    }
-    
-    return result;
+  }
+
+  return result;
 }
 
-HfSpiErr McuSpi::WriteRegister(uint8_t reg_addr, const uint8_t* data, uint16_t length) noexcept {
-    if (!data || length == 0) {
-        return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
-    }
+HfSpiErr McuSpi::WriteRegister(uint8_t reg_addr, const uint8_t *data, uint16_t length) noexcept {
+  if (!data || length == 0) {
+    return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
+  }
 
-    // Create buffer with register address + data
-    uint16_t total_length = length + 1;
-    if (total_length > max_transfer_size_) {
-        return HfSpiErr::SPI_ERR_TRANSFER_TOO_LONG;
-    }
+  // Create buffer with register address + data
+  uint16_t total_length = length + 1;
+  if (total_length > max_transfer_size_) {
+    return HfSpiErr::SPI_ERR_TRANSFER_TOO_LONG;
+  }
 
-    uint8_t* tx_buffer = new uint8_t[total_length];
-    if (!tx_buffer) {
-        return HfSpiErr::SPI_ERR_OUT_OF_MEMORY;
-    }
+  uint8_t *tx_buffer = new uint8_t[total_length];
+  if (!tx_buffer) {
+    return HfSpiErr::SPI_ERR_OUT_OF_MEMORY;
+  }
 
-    tx_buffer[0] = reg_addr;
-    std::memcpy(&tx_buffer[1], data, length);
+  tx_buffer[0] = reg_addr;
+  std::memcpy(&tx_buffer[1], data, length);
 
-    HfSpiErr result = Transfer(tx_buffer, nullptr, total_length);
-    
-    delete[] tx_buffer;
-    return result;
+  HfSpiErr result = Transfer(tx_buffer, nullptr, total_length);
+
+  delete[] tx_buffer;
+  return result;
 }
 
-HfSpiErr McuSpi::ReadRegister(uint8_t reg_addr, uint8_t* data, uint16_t length) noexcept {
-    if (!data || length == 0) {
-        return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
-    }
+HfSpiErr McuSpi::ReadRegister(uint8_t reg_addr, uint8_t *data, uint16_t length) noexcept {
+  if (!data || length == 0) {
+    return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
+  }
 
-    uint16_t total_length = length + 1;
-    if (total_length > max_transfer_size_) {
-        return HfSpiErr::SPI_ERR_TRANSFER_TOO_LONG;
-    }
+  uint16_t total_length = length + 1;
+  if (total_length > max_transfer_size_) {
+    return HfSpiErr::SPI_ERR_TRANSFER_TOO_LONG;
+  }
 
-    uint8_t* tx_buffer = new uint8_t[total_length];
-    uint8_t* rx_buffer = new uint8_t[total_length];
-    
-    if (!tx_buffer || !rx_buffer) {
-        delete[] tx_buffer;
-        delete[] rx_buffer;
-        return HfSpiErr::SPI_ERR_OUT_OF_MEMORY;
-    }
+  uint8_t *tx_buffer = new uint8_t[total_length];
+  uint8_t *rx_buffer = new uint8_t[total_length];
 
-    tx_buffer[0] = reg_addr;
-    std::memset(&tx_buffer[1], 0, length);
-
-    HfSpiErr result = Transfer(tx_buffer, rx_buffer, total_length);
-    
-    if (result == HfSpiErr::SPI_SUCCESS) {
-        std::memcpy(data, &rx_buffer[1], length);
-    }
-
+  if (!tx_buffer || !rx_buffer) {
     delete[] tx_buffer;
     delete[] rx_buffer;
-    return result;
+    return HfSpiErr::SPI_ERR_OUT_OF_MEMORY;
+  }
+
+  tx_buffer[0] = reg_addr;
+  std::memset(&tx_buffer[1], 0, length);
+
+  HfSpiErr result = Transfer(tx_buffer, rx_buffer, total_length);
+
+  if (result == HfSpiErr::SPI_SUCCESS) {
+    std::memcpy(data, &rx_buffer[1], length);
+  }
+
+  delete[] tx_buffer;
+  delete[] rx_buffer;
+  return result;
 }
 
 //==============================================//
@@ -306,149 +301,149 @@ HfSpiErr McuSpi::ReadRegister(uint8_t reg_addr, uint8_t* data, uint16_t length) 
 
 HfSpiErr McuSpi::ConvertPlatformError(int32_t platform_error) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    switch (platform_error) {
-        case ESP_OK:
-            return HfSpiErr::SPI_SUCCESS;
-        case ESP_ERR_INVALID_ARG:
-            return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
-        case ESP_ERR_TIMEOUT:
-            return HfSpiErr::SPI_ERR_TRANSFER_TIMEOUT;
-        case ESP_ERR_NO_MEM:
-            return HfSpiErr::SPI_ERR_OUT_OF_MEMORY;
-        case ESP_ERR_INVALID_STATE:
-            return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
-        default:
-            return HfSpiErr::SPI_ERR_TRANSFER_FAILED;
-    }
+  switch (platform_error) {
+  case ESP_OK:
+    return HfSpiErr::SPI_SUCCESS;
+  case ESP_ERR_INVALID_ARG:
+    return HfSpiErr::SPI_ERR_INVALID_PARAMETER;
+  case ESP_ERR_TIMEOUT:
+    return HfSpiErr::SPI_ERR_TRANSFER_TIMEOUT;
+  case ESP_ERR_NO_MEM:
+    return HfSpiErr::SPI_ERR_OUT_OF_MEMORY;
+  case ESP_ERR_INVALID_STATE:
+    return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
+  default:
+    return HfSpiErr::SPI_ERR_TRANSFER_FAILED;
+  }
 #else
-    (void)platform_error;
-    return HfSpiErr::SPI_ERR_UNSUPPORTED_OPERATION;
+  (void)platform_error;
+  return HfSpiErr::SPI_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 bool McuSpi::PlatformInitialize() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure SPI bus
-    spi_bus_config_t bus_cfg = {};
-    bus_cfg.mosi_io_num = config_.mosi_pin != HF_GPIO_INVALID ? config_.mosi_pin : -1;
-    bus_cfg.miso_io_num = config_.miso_pin != HF_GPIO_INVALID ? config_.miso_pin : -1;
-    bus_cfg.sclk_io_num = config_.sclk_pin;
-    bus_cfg.quadwp_io_num = -1;
-    bus_cfg.quadhd_io_num = -1;
-    bus_cfg.max_transfer_sz = max_transfer_size_;
+  // Configure SPI bus
+  spi_bus_config_t bus_cfg = {};
+  bus_cfg.mosi_io_num = config_.mosi_pin != HF_GPIO_INVALID ? config_.mosi_pin : -1;
+  bus_cfg.miso_io_num = config_.miso_pin != HF_GPIO_INVALID ? config_.miso_pin : -1;
+  bus_cfg.sclk_io_num = config_.sclk_pin;
+  bus_cfg.quadwp_io_num = -1;
+  bus_cfg.quadhd_io_num = -1;
+  bus_cfg.max_transfer_sz = max_transfer_size_;
 
-    esp_err_t err = spi_bus_initialize(static_cast<spi_host_device_t>(config_.host), 
-                                      &bus_cfg, 
-                                      dma_enabled_ ? SPI_DMA_CH_AUTO : SPI_DMA_DISABLED);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "spi_bus_initialize failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-
-    // Configure CS pin if specified
-    if (config_.cs_pin != HF_GPIO_INVALID) {
-        gpio_config_t cs_cfg = {};
-        cs_cfg.pin_bit_mask = (1ULL << config_.cs_pin);
-        cs_cfg.mode = GPIO_MODE_OUTPUT;
-        cs_cfg.pull_up_en = GPIO_PULLUP_DISABLE;
-        cs_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-        cs_cfg.intr_type = GPIO_INTR_DISABLE;
-        
-        err = gpio_config(&cs_cfg);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "CS pin configuration failed: %s", esp_err_to_name(err));
-            spi_bus_free(static_cast<spi_host_device_t>(config_.host));
-            last_error_ = ConvertPlatformError(err);
-            return false;
-        }
-
-        // Set CS to inactive state
-        gpio_set_level(static_cast<gpio_num_t>(config_.cs_pin), 
-                      config_.cs_active_low ? 1 : 0);
-    }
-
-    ESP_LOGI(TAG, "SPI bus initialized on host %d, MOSI=%d, MISO=%d, SCLK=%d, CS=%d, mode=%d, clock=%lu Hz",
-             config_.host, config_.mosi_pin, config_.miso_pin, config_.sclk_pin, 
-             config_.cs_pin, config_.mode, config_.clock_speed_hz);
-    
-    return true;
-#else
-    last_error_ = HfSpiErr::SPI_ERR_UNSUPPORTED_OPERATION;
+  esp_err_t err = spi_bus_initialize(static_cast<spi_host_device_t>(config_.host), &bus_cfg,
+                                     dma_enabled_ ? SPI_DMA_CH_AUTO : SPI_DMA_DISABLED);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "spi_bus_initialize failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
     return false;
+  }
+
+  // Configure CS pin if specified
+  if (config_.cs_pin != HF_GPIO_INVALID) {
+    gpio_config_t cs_cfg = {};
+    cs_cfg.pin_bit_mask = (1ULL << config_.cs_pin);
+    cs_cfg.mode = GPIO_MODE_OUTPUT;
+    cs_cfg.pull_up_en = GPIO_PULLUP_DISABLE;
+    cs_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    cs_cfg.intr_type = GPIO_INTR_DISABLE;
+
+    err = gpio_config(&cs_cfg);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "CS pin configuration failed: %s", esp_err_to_name(err));
+      spi_bus_free(static_cast<spi_host_device_t>(config_.host));
+      last_error_ = ConvertPlatformError(err);
+      return false;
+    }
+
+    // Set CS to inactive state
+    gpio_set_level(static_cast<gpio_num_t>(config_.cs_pin), config_.cs_active_low ? 1 : 0);
+  }
+
+  ESP_LOGI(
+      TAG,
+      "SPI bus initialized on host %d, MOSI=%d, MISO=%d, SCLK=%d, CS=%d, mode=%d, clock=%lu Hz",
+      config_.host, config_.mosi_pin, config_.miso_pin, config_.sclk_pin, config_.cs_pin,
+      config_.mode, config_.clock_speed_hz);
+
+  return true;
+#else
+  last_error_ = HfSpiErr::SPI_ERR_UNSUPPORTED_OPERATION;
+  return false;
 #endif
 }
 
 bool McuSpi::PlatformDeinitialize() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = spi_bus_free(static_cast<spi_host_device_t>(config_.host));
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "spi_bus_free failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-    
-    ESP_LOGI(TAG, "SPI bus deinitialized on host %d", config_.host);
-    return true;
-#else
+  esp_err_t err = spi_bus_free(static_cast<spi_host_device_t>(config_.host));
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "spi_bus_free failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
     return false;
+  }
+
+  ESP_LOGI(TAG, "SPI bus deinitialized on host %d", config_.host);
+  return true;
+#else
+  return false;
 #endif
 }
 
-HfSpiErr McuSpi::InternalTransfer(const uint8_t* tx_data, uint8_t* rx_data,
-                                     uint16_t length, uint32_t timeout_ms, bool manage_cs) noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
+HfSpiErr McuSpi::InternalTransfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
+                                  uint32_t timeout_ms, bool manage_cs) noexcept {
+  std::lock_guard<std::mutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure device for this transfer
-    spi_device_interface_config_t dev_cfg = {};
-    dev_cfg.clock_speed_hz = config_.clock_speed_hz;
-    dev_cfg.mode = config_.mode;
-    dev_cfg.spics_io_num = -1;  // We manage CS manually
-    dev_cfg.queue_size = 1;
+  // Configure device for this transfer
+  spi_device_interface_config_t dev_cfg = {};
+  dev_cfg.clock_speed_hz = config_.clock_speed_hz;
+  dev_cfg.mode = config_.mode;
+  dev_cfg.spics_io_num = -1; // We manage CS manually
+  dev_cfg.queue_size = 1;
 
-    spi_device_handle_t dev_handle;
-    esp_err_t err = spi_bus_add_device(static_cast<spi_host_device_t>(config_.host), 
-                                      &dev_cfg, &dev_handle);
-    if (err != ESP_OK) {
-        last_error_ = ConvertPlatformError(err);
-        return last_error_;
-    }
-
-    // Prepare transaction
-    spi_transaction_t trans = {};
-    trans.length = length * 8;  // Length in bits
-    trans.tx_buffer = tx_data;
-    trans.rx_buffer = rx_data;
-
-    // Manage CS if requested
-    if (manage_cs && config_.cs_pin != HF_GPIO_INVALID) {
-        SetChipSelect(true);
-    }
-
-    // Perform transfer
-    uint32_t timeout = GetTimeoutMs(timeout_ms);
-    err = spi_device_transmit(dev_handle, &trans);
-
-    // Release CS if we managed it
-    if (manage_cs && config_.cs_pin != HF_GPIO_INVALID) {
-        SetChipSelect(false);
-    }
-
-    // Clean up
-    spi_bus_remove_device(dev_handle);
-
+  spi_device_handle_t dev_handle;
+  esp_err_t err =
+      spi_bus_add_device(static_cast<spi_host_device_t>(config_.host), &dev_cfg, &dev_handle);
+  if (err != ESP_OK) {
     last_error_ = ConvertPlatformError(err);
-    transaction_count_++;
-    
     return last_error_;
+  }
+
+  // Prepare transaction
+  spi_transaction_t trans = {};
+  trans.length = length * 8; // Length in bits
+  trans.tx_buffer = tx_data;
+  trans.rx_buffer = rx_data;
+
+  // Manage CS if requested
+  if (manage_cs && config_.cs_pin != HF_GPIO_INVALID) {
+    SetChipSelect(true);
+  }
+
+  // Perform transfer
+  uint32_t timeout = GetTimeoutMs(timeout_ms);
+  err = spi_device_transmit(dev_handle, &trans);
+
+  // Release CS if we managed it
+  if (manage_cs && config_.cs_pin != HF_GPIO_INVALID) {
+    SetChipSelect(false);
+  }
+
+  // Clean up
+  spi_bus_remove_device(dev_handle);
+
+  last_error_ = ConvertPlatformError(err);
+  transaction_count_++;
+
+  return last_error_;
 #else
-    (void)tx_data;
-    (void)rx_data;
-    (void)length;
-    (void)timeout_ms;
-    (void)manage_cs;
-    last_error_ = HfSpiErr::SPI_ERR_UNSUPPORTED_OPERATION;
-    return last_error_;
+  (void)tx_data;
+  (void)rx_data;
+  (void)length;
+  (void)timeout_ms;
+  (void)manage_cs;
+  last_error_ = HfSpiErr::SPI_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
 #endif
 }

--- a/src/mcu/McuUart.cpp
+++ b/src/mcu/McuUart.cpp
@@ -4,37 +4,32 @@
  */
 
 #include "McuUart.h"
-#include <cstring>
 #include <cstdio>
+#include <cstring>
 
 // Platform-specific includes
 #ifdef HF_MCU_FAMILY_ESP32
-#include "driver/uart.h"
 #include "driver/gpio.h"
+#include "driver/uart.h"
 #include "esp_log.h"
 
-static const char* TAG = "McuUart";
+static const char *TAG = "McuUart";
 #endif
 
 //==============================================//
 // CONSTRUCTOR & DESTRUCTOR                     //
 //==============================================//
 
-McuUart::McuUart(HfPortNumber port, const UartConfig& config) noexcept
-    : BaseUart(port, config),
-      platform_handle_(nullptr),
-      last_error_(HfUartErr::UART_SUCCESS),
-      bytes_transmitted_(0),
-      bytes_received_(0),
-      break_detected_(false),
-      tx_in_progress_(false) {
-    memset(printf_buffer_, 0, sizeof(printf_buffer_));
+McuUart::McuUart(HfPortNumber port, const UartConfig &config) noexcept
+    : BaseUart(port, config), platform_handle_(nullptr), last_error_(HfUartErr::UART_SUCCESS),
+      bytes_transmitted_(0), bytes_received_(0), break_detected_(false), tx_in_progress_(false) {
+  memset(printf_buffer_, 0, sizeof(printf_buffer_));
 }
 
 McuUart::~McuUart() noexcept {
-    if (initialized_) {
-        Deinitialize();
-    }
+  if (initialized_) {
+    Deinitialize();
+  }
 }
 
 //==============================================//
@@ -42,207 +37,201 @@ McuUart::~McuUart() noexcept {
 //==============================================//
 
 bool McuUart::Initialize() noexcept {
-    if (initialized_) {
-        return true;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    // Validate configuration
-    if (!IsValidBaudRate(config_.baud_rate)) {
-        last_error_ = HfUartErr::UART_ERR_INVALID_BAUD_RATE;
-        return false;
-    }
-
-    if (!IsValidDataBits(config_.data_bits)) {
-        last_error_ = HfUartErr::UART_ERR_INVALID_DATA_BITS;
-        return false;
-    }
-
-    if (!IsValidParity(config_.parity)) {
-        last_error_ = HfUartErr::UART_ERR_INVALID_PARITY;
-        return false;
-    }
-
-    if (!IsValidStopBits(config_.stop_bits)) {
-        last_error_ = HfUartErr::UART_ERR_INVALID_STOP_BITS;
-        return false;
-    }
-
-    if (config_.tx_pin == HF_GPIO_INVALID || config_.rx_pin == HF_GPIO_INVALID) {
-        last_error_ = HfUartErr::UART_ERR_PIN_CONFIGURATION_ERROR;
-        return false;
-    }
-
-    // Platform-specific initialization
-    if (!PlatformInitialize()) {
-        return false;
-    }
-
-    last_error_ = HfUartErr::UART_SUCCESS;
+  if (initialized_) {
     return true;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Validate configuration
+  if (!IsValidBaudRate(config_.baud_rate)) {
+    last_error_ = HfUartErr::UART_ERR_INVALID_BAUD_RATE;
+    return false;
+  }
+
+  if (!IsValidDataBits(config_.data_bits)) {
+    last_error_ = HfUartErr::UART_ERR_INVALID_DATA_BITS;
+    return false;
+  }
+
+  if (!IsValidParity(config_.parity)) {
+    last_error_ = HfUartErr::UART_ERR_INVALID_PARITY;
+    return false;
+  }
+
+  if (!IsValidStopBits(config_.stop_bits)) {
+    last_error_ = HfUartErr::UART_ERR_INVALID_STOP_BITS;
+    return false;
+  }
+
+  if (config_.tx_pin == HF_GPIO_INVALID || config_.rx_pin == HF_GPIO_INVALID) {
+    last_error_ = HfUartErr::UART_ERR_PIN_CONFIGURATION_ERROR;
+    return false;
+  }
+
+  // Platform-specific initialization
+  if (!PlatformInitialize()) {
+    return false;
+  }
+
+  last_error_ = HfUartErr::UART_SUCCESS;
+  return true;
 }
 
 bool McuUart::Deinitialize() noexcept {
-    if (!initialized_) {
-        return true;
-    }
+  if (!initialized_) {
+    return true;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
-    
-    bool result = PlatformDeinitialize();
-    if (result) {
-        last_error_ = HfUartErr::UART_SUCCESS;
-    }
-    
-    return result;
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  bool result = PlatformDeinitialize();
+  if (result) {
+    last_error_ = HfUartErr::UART_SUCCESS;
+  }
+
+  return result;
 }
 
-HfUartErr McuUart::Write(const uint8_t* data, uint16_t length,
-                               uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return HfUartErr::UART_ERR_NOT_INITIALIZED;
-    }
+HfUartErr McuUart::Write(const uint8_t *data, uint16_t length, uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized()) {
+    return HfUartErr::UART_ERR_NOT_INITIALIZED;
+  }
 
-    if (!data && length > 0) {
-        return HfUartErr::UART_ERR_NULL_POINTER;
-    }
+  if (!data && length > 0) {
+    return HfUartErr::UART_ERR_NULL_POINTER;
+  }
 
-    if (length == 0) {
-        return HfUartErr::UART_SUCCESS;
-    }
+  if (length == 0) {
+    return HfUartErr::UART_SUCCESS;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
-    uint32_t timeout = GetTimeoutMs(timeout_ms);
-    
-    tx_in_progress_ = true;
-    int bytes_written = uart_write_bytes(static_cast<uart_port_t>(port_), 
-                                        reinterpret_cast<const char*>(data), 
-                                        length);
-    
-    if (bytes_written >= 0) {
-        // Wait for transmission to complete if timeout specified
-        if (timeout > 0) {
-            esp_err_t err = uart_wait_tx_done(static_cast<uart_port_t>(port_), 
-                                             pdMS_TO_TICKS(timeout));
-            if (err != ESP_OK) {
-                tx_in_progress_ = false;
-                last_error_ = HfUartErr::UART_ERR_TIMEOUT;
-                return last_error_;
-            }
-        }
-        
-        bytes_transmitted_ += bytes_written;
+  uint32_t timeout = GetTimeoutMs(timeout_ms);
+
+  tx_in_progress_ = true;
+  int bytes_written = uart_write_bytes(static_cast<uart_port_t>(port_),
+                                       reinterpret_cast<const char *>(data), length);
+
+  if (bytes_written >= 0) {
+    // Wait for transmission to complete if timeout specified
+    if (timeout > 0) {
+      esp_err_t err = uart_wait_tx_done(static_cast<uart_port_t>(port_), pdMS_TO_TICKS(timeout));
+      if (err != ESP_OK) {
         tx_in_progress_ = false;
-        last_error_ = HfUartErr::UART_SUCCESS;
+        last_error_ = HfUartErr::UART_ERR_TIMEOUT;
         return last_error_;
-    } else {
-        tx_in_progress_ = false;
-        last_error_ = HfUartErr::UART_ERR_TRANSMISSION_FAILED;
-        return last_error_;
+      }
     }
-#else
-    (void)timeout_ms;
-    last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+
+    bytes_transmitted_ += bytes_written;
+    tx_in_progress_ = false;
+    last_error_ = HfUartErr::UART_SUCCESS;
     return last_error_;
+  } else {
+    tx_in_progress_ = false;
+    last_error_ = HfUartErr::UART_ERR_TRANSMISSION_FAILED;
+    return last_error_;
+  }
+#else
+  (void)timeout_ms;
+  last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
 #endif
 }
 
-HfUartErr McuUart::Read(uint8_t* data, uint16_t length,
-                              uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return HfUartErr::UART_ERR_NOT_INITIALIZED;
-    }
+HfUartErr McuUart::Read(uint8_t *data, uint16_t length, uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized()) {
+    return HfUartErr::UART_ERR_NOT_INITIALIZED;
+  }
 
-    if (!data || length == 0) {
-        return HfUartErr::UART_ERR_INVALID_PARAMETER;
-    }
+  if (!data || length == 0) {
+    return HfUartErr::UART_ERR_INVALID_PARAMETER;
+  }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
-    uint32_t timeout = GetTimeoutMs(timeout_ms);
-    
-    int bytes_read = uart_read_bytes(static_cast<uart_port_t>(port_), 
-                                    data, 
-                                    length, 
-                                    pdMS_TO_TICKS(timeout));
-    
-    if (bytes_read >= 0) {
-        bytes_received_ += bytes_read;
-        last_error_ = (bytes_read == length) ? HfUartErr::UART_SUCCESS : HfUartErr::UART_ERR_TIMEOUT;
-        return last_error_;
-    } else {
-        last_error_ = HfUartErr::UART_ERR_RECEPTION_FAILED;
-        return last_error_;
-    }
-#else
-    (void)timeout_ms;
-    last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  uint32_t timeout = GetTimeoutMs(timeout_ms);
+
+  int bytes_read =
+      uart_read_bytes(static_cast<uart_port_t>(port_), data, length, pdMS_TO_TICKS(timeout));
+
+  if (bytes_read >= 0) {
+    bytes_received_ += bytes_read;
+    last_error_ = (bytes_read == length) ? HfUartErr::UART_SUCCESS : HfUartErr::UART_ERR_TIMEOUT;
     return last_error_;
+  } else {
+    last_error_ = HfUartErr::UART_ERR_RECEPTION_FAILED;
+    return last_error_;
+  }
+#else
+  (void)timeout_ms;
+  last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
 #endif
 }
 
 uint16_t McuUart::BytesAvailable() noexcept {
-    if (!EnsureInitialized()) {
-        return 0;
-    }
+  if (!EnsureInitialized()) {
+    return 0;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    size_t bytes_available = 0;
-    esp_err_t err = uart_get_buffered_data_len(static_cast<uart_port_t>(port_), &bytes_available);
-    if (err == ESP_OK) {
-        return static_cast<uint16_t>(bytes_available);
-    }
+  size_t bytes_available = 0;
+  esp_err_t err = uart_get_buffered_data_len(static_cast<uart_port_t>(port_), &bytes_available);
+  if (err == ESP_OK) {
+    return static_cast<uint16_t>(bytes_available);
+  }
 #endif
-    
-    return 0;
+
+  return 0;
 }
 
 HfUartErr McuUart::FlushTx() noexcept {
-    if (!EnsureInitialized()) {
-        return HfUartErr::UART_ERR_NOT_INITIALIZED;
-    }
+  if (!EnsureInitialized()) {
+    return HfUartErr::UART_ERR_NOT_INITIALIZED;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = uart_wait_tx_done(static_cast<uart_port_t>(port_), 
-                                     pdMS_TO_TICKS(config_.timeout_ms));
-    last_error_ = ConvertPlatformError(err);
-    return last_error_;
+  esp_err_t err =
+      uart_wait_tx_done(static_cast<uart_port_t>(port_), pdMS_TO_TICKS(config_.timeout_ms));
+  last_error_ = ConvertPlatformError(err);
+  return last_error_;
 #else
-    last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
-    return last_error_;
+  last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
 #endif
 }
 
 HfUartErr McuUart::FlushRx() noexcept {
-    if (!EnsureInitialized()) {
-        return HfUartErr::UART_ERR_NOT_INITIALIZED;
-    }
+  if (!EnsureInitialized()) {
+    return HfUartErr::UART_ERR_NOT_INITIALIZED;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = uart_flush_input(static_cast<uart_port_t>(port_));
-    last_error_ = ConvertPlatformError(err);
-    return last_error_;
+  esp_err_t err = uart_flush_input(static_cast<uart_port_t>(port_));
+  last_error_ = ConvertPlatformError(err);
+  return last_error_;
 #else
-    last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
-    return last_error_;
+  last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  return last_error_;
 #endif
 }
 
-int McuUart::Printf(const char* format, ...) noexcept {
-    if (!EnsureInitialized() || !format) {
-        return -1;
-    }
+int McuUart::Printf(const char *format, ...) noexcept {
+  if (!EnsureInitialized() || !format) {
+    return -1;
+  }
 
-    va_list args;
-    va_start(args, format);
-    int result = InternalPrintf(format, args);
-    va_end(args);
-    
-    return result;
+  va_list args;
+  va_start(args, format);
+  int result = InternalPrintf(format, args);
+  va_end(args);
+
+  return result;
 }
 
 //==============================================//
@@ -250,209 +239,209 @@ int McuUart::Printf(const char* format, ...) noexcept {
 //==============================================//
 
 bool McuUart::IsTxBusy() noexcept {
-    return tx_in_progress_;
+  return tx_in_progress_;
 }
 
 bool McuUart::SetBaudRate(uint32_t baud_rate) noexcept {
-    if (!IsValidBaudRate(baud_rate)) {
-        return false;
-    }
+  if (!IsValidBaudRate(baud_rate)) {
+    return false;
+  }
 
-    config_.baud_rate = baud_rate;
-    
-    // Reinitialize if already initialized
-    if (initialized_) {
-        bool was_initialized = initialized_;
-        initialized_ = false;
-        if (Deinitialize() && Initialize()) {
-            return true;
-        }
-        initialized_ = was_initialized;
-        return false;
+  config_.baud_rate = baud_rate;
+
+  // Reinitialize if already initialized
+  if (initialized_) {
+    bool was_initialized = initialized_;
+    initialized_ = false;
+    if (Deinitialize() && Initialize()) {
+      return true;
     }
-    
-    return true;
+    initialized_ = was_initialized;
+    return false;
+  }
+
+  return true;
 }
 
 bool McuUart::SetFlowControl(bool enable) noexcept {
-    config_.use_hardware_flow_control = enable;
-    
-    // Reinitialize if already initialized
-    if (initialized_) {
-        bool was_initialized = initialized_;
-        initialized_ = false;
-        if (Deinitialize() && Initialize()) {
-            return true;
-        }
-        initialized_ = was_initialized;
-        return false;
+  config_.use_hardware_flow_control = enable;
+
+  // Reinitialize if already initialized
+  if (initialized_) {
+    bool was_initialized = initialized_;
+    initialized_ = false;
+    if (Deinitialize() && Initialize()) {
+      return true;
     }
-    
-    return true;
+    initialized_ = was_initialized;
+    return false;
+  }
+
+  return true;
 }
 
 uint32_t McuUart::GetUartStatus() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Return platform-specific status information
-    uint32_t status = static_cast<uint32_t>(last_error_);
-    if (tx_in_progress_) status |= 0x80000000;
-    if (break_detected_) status |= 0x40000000;
-    return status;
+  // Return platform-specific status information
+  uint32_t status = static_cast<uint32_t>(last_error_);
+  if (tx_in_progress_)
+    status |= 0x80000000;
+  if (break_detected_)
+    status |= 0x40000000;
+  return status;
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 bool McuUart::SetRTS(bool active) noexcept {
-    if (config_.rts_pin == HF_GPIO_INVALID) {
-        return false;
-    }
+  if (config_.rts_pin == HF_GPIO_INVALID) {
+    return false;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = uart_set_rts(static_cast<uart_port_t>(port_), active ? 1 : 0);
-    return err == ESP_OK;
+  esp_err_t err = uart_set_rts(static_cast<uart_port_t>(port_), active ? 1 : 0);
+  return err == ESP_OK;
 #else
-    (void)active;
-    return false;
+  (void)active;
+  return false;
 #endif
 }
 
 bool McuUart::GetCTS() noexcept {
-    if (config_.cts_pin == HF_GPIO_INVALID) {
-        return false;
-    }
+  if (config_.cts_pin == HF_GPIO_INVALID) {
+    return false;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Implementation depends on platform capabilities
-    return gpio_get_level(static_cast<gpio_num_t>(config_.cts_pin)) == 1;
+  // Implementation depends on platform capabilities
+  return gpio_get_level(static_cast<gpio_num_t>(config_.cts_pin)) == 1;
 #else
-    return false;
+  return false;
 #endif
 }
 
 bool McuUart::SendBreak(uint32_t duration_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return false;
-    }
+  if (!EnsureInitialized()) {
+    return false;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Send break condition
-    esp_err_t err = uart_set_line_inverse(static_cast<uart_port_t>(port_), 
-                                         UART_SIGNAL_TXD_INV);
-    if (err != ESP_OK) {
-        return false;
-    }
-    
-    // Hold break for specified duration
-    vTaskDelay(pdMS_TO_TICKS(duration_ms));
-    
-    // Clear break condition
-    err = uart_set_line_inverse(static_cast<uart_port_t>(port_), 0);
-    return err == ESP_OK;
-#else
-    (void)duration_ms;
+  // Send break condition
+  esp_err_t err = uart_set_line_inverse(static_cast<uart_port_t>(port_), UART_SIGNAL_TXD_INV);
+  if (err != ESP_OK) {
     return false;
+  }
+
+  // Hold break for specified duration
+  vTaskDelay(pdMS_TO_TICKS(duration_ms));
+
+  // Clear break condition
+  err = uart_set_line_inverse(static_cast<uart_port_t>(port_), 0);
+  return err == ESP_OK;
+#else
+  (void)duration_ms;
+  return false;
 #endif
 }
 
 bool McuUart::IsBreakDetected() noexcept {
-    bool detected = break_detected_;
-    break_detected_ = false;  // Clear flag after reading
-    return detected;
+  bool detected = break_detected_;
+  break_detected_ = false; // Clear flag after reading
+  return detected;
 }
 
 uint16_t McuUart::TxBytesWaiting() noexcept {
-    if (!EnsureInitialized()) {
-        return 0;
-    }
+  if (!EnsureInitialized()) {
+    return 0;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // ESP32 doesn't provide direct access to TX buffer level
-    // Return 0 if not transmitting, or estimate based on recent writes
-    return tx_in_progress_ ? 1 : 0;
+  // ESP32 doesn't provide direct access to TX buffer level
+  // Return 0 if not transmitting, or estimate based on recent writes
+  return tx_in_progress_ ? 1 : 0;
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 bool McuUart::SetLoopback(bool enable) noexcept {
-    if (!EnsureInitialized()) {
-        return false;
-    }
+  if (!EnsureInitialized()) {
+    return false;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure loopback mode (connect TX to RX internally)
-    uint32_t mode = enable ? UART_MODE_UART | UART_MODE_LOOPBACK : UART_MODE_UART;
-    esp_err_t err = uart_set_mode(static_cast<uart_port_t>(port_), mode);
-    return err == ESP_OK;
+  // Configure loopback mode (connect TX to RX internally)
+  uint32_t mode = enable ? UART_MODE_UART | UART_MODE_LOOPBACK : UART_MODE_UART;
+  esp_err_t err = uart_set_mode(static_cast<uart_port_t>(port_), mode);
+  return err == ESP_OK;
 #else
-    (void)enable;
-    return false;
+  (void)enable;
+  return false;
 #endif
 }
 
 bool McuUart::WaitTransmitComplete(uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized()) {
-        return false;
-    }
+  if (!EnsureInitialized()) {
+    return false;
+  }
 
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = uart_wait_tx_done(static_cast<uart_port_t>(port_), 
-                                     pdMS_TO_TICKS(timeout_ms));
-    return err == ESP_OK;
+  esp_err_t err = uart_wait_tx_done(static_cast<uart_port_t>(port_), pdMS_TO_TICKS(timeout_ms));
+  return err == ESP_OK;
 #else
-    (void)timeout_ms;
-    return false;
+  (void)timeout_ms;
+  return false;
 #endif
 }
 
-uint16_t McuUart::ReadUntil(uint8_t* data, uint16_t max_length, 
-                                  uint8_t terminator, uint32_t timeout_ms) noexcept {
-    if (!EnsureInitialized() || !data || max_length == 0) {
-        return 0;
+uint16_t McuUart::ReadUntil(uint8_t *data, uint16_t max_length, uint8_t terminator,
+                            uint32_t timeout_ms) noexcept {
+  if (!EnsureInitialized() || !data || max_length == 0) {
+    return 0;
+  }
+
+  uint16_t bytes_read = 0;
+  uint32_t start_time = 0; // Platform-specific time implementation needed
+
+  while (bytes_read < max_length) {
+    uint8_t byte;
+    if (Read(&byte, 1, 100) == HfUartErr::UART_SUCCESS) { // 100ms per byte timeout
+      data[bytes_read++] = byte;
+      if (byte == terminator) {
+        break;
+      }
     }
 
-    uint16_t bytes_read = 0;
-    uint32_t start_time = 0;  // Platform-specific time implementation needed
-    
-    while (bytes_read < max_length) {
-        uint8_t byte;
-        if (Read(&byte, 1, 100) == HfUartErr::UART_SUCCESS) {  // 100ms per byte timeout
-            data[bytes_read++] = byte;
-            if (byte == terminator) {
-                break;
-            }
-        }
-        
-        // Check overall timeout
-        // Platform-specific timeout check needed
-        if (timeout_ms > 0) {
-            // Simplified timeout check - should use platform timer
-            break;
-        }
+    // Check overall timeout
+    // Platform-specific timeout check needed
+    if (timeout_ms > 0) {
+      // Simplified timeout check - should use platform timer
+      break;
     }
-    
-    return bytes_read;
+  }
+
+  return bytes_read;
 }
 
-uint16_t McuUart::ReadLine(char* buffer, uint16_t max_length, uint32_t timeout_ms) noexcept {
-    if (!buffer || max_length == 0) {
-        return 0;
-    }
+uint16_t McuUart::ReadLine(char *buffer, uint16_t max_length, uint32_t timeout_ms) noexcept {
+  if (!buffer || max_length == 0) {
+    return 0;
+  }
 
-    uint16_t bytes_read = ReadUntil(reinterpret_cast<uint8_t*>(buffer), 
-                                   max_length - 1, '\n', timeout_ms);
-    
-    // Remove \r if present before \n
-    if (bytes_read > 0 && buffer[bytes_read - 1] == '\n') {
-        bytes_read--;
-        if (bytes_read > 0 && buffer[bytes_read - 1] == '\r') {
-            bytes_read--;
-        }
+  uint16_t bytes_read =
+      ReadUntil(reinterpret_cast<uint8_t *>(buffer), max_length - 1, '\n', timeout_ms);
+
+  // Remove \r if present before \n
+  if (bytes_read > 0 && buffer[bytes_read - 1] == '\n') {
+    bytes_read--;
+    if (bytes_read > 0 && buffer[bytes_read - 1] == '\r') {
+      bytes_read--;
     }
-    
-    buffer[bytes_read] = '\0';  // Null terminate
-    return bytes_read;
+  }
+
+  buffer[bytes_read] = '\0'; // Null terminate
+  return bytes_read;
 }
 
 //==============================================//
@@ -461,121 +450,123 @@ uint16_t McuUart::ReadLine(char* buffer, uint16_t max_length, uint32_t timeout_m
 
 HfUartErr McuUart::ConvertPlatformError(int32_t platform_error) noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    switch (platform_error) {
-        case ESP_OK:
-            return HfUartErr::UART_SUCCESS;
-        case ESP_ERR_INVALID_ARG:
-            return HfUartErr::UART_ERR_INVALID_PARAMETER;
-        case ESP_ERR_TIMEOUT:
-            return HfUartErr::UART_ERR_TIMEOUT;
-        case ESP_ERR_NO_MEM:
-            return HfUartErr::UART_ERR_OUT_OF_MEMORY;
-        case ESP_ERR_INVALID_STATE:
-            return HfUartErr::UART_ERR_NOT_INITIALIZED;
-        case ESP_FAIL:
-            return HfUartErr::UART_ERR_FAILURE;
-        default:
-            return HfUartErr::UART_ERR_COMMUNICATION_FAILURE;
-    }
+  switch (platform_error) {
+  case ESP_OK:
+    return HfUartErr::UART_SUCCESS;
+  case ESP_ERR_INVALID_ARG:
+    return HfUartErr::UART_ERR_INVALID_PARAMETER;
+  case ESP_ERR_TIMEOUT:
+    return HfUartErr::UART_ERR_TIMEOUT;
+  case ESP_ERR_NO_MEM:
+    return HfUartErr::UART_ERR_OUT_OF_MEMORY;
+  case ESP_ERR_INVALID_STATE:
+    return HfUartErr::UART_ERR_NOT_INITIALIZED;
+  case ESP_FAIL:
+    return HfUartErr::UART_ERR_FAILURE;
+  default:
+    return HfUartErr::UART_ERR_COMMUNICATION_FAILURE;
+  }
 #else
-    (void)platform_error;
-    return HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  (void)platform_error;
+  return HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
 #endif
 }
 
 bool McuUart::PlatformInitialize() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    // Configure UART parameters
-    uart_config_t uart_config = {};
-    uart_config.baud_rate = config_.baud_rate;
-    uart_config.data_bits = static_cast<uart_word_length_t>(config_.data_bits - 5);
-    
-    // Configure parity
-    switch (config_.parity) {
-        case 0: uart_config.parity = UART_PARITY_DISABLE; break;
-        case 1: uart_config.parity = UART_PARITY_EVEN; break;
-        case 2: uart_config.parity = UART_PARITY_ODD; break;
-        default: uart_config.parity = UART_PARITY_DISABLE; break;
-    }
-    
-    uart_config.stop_bits = (config_.stop_bits == 1) ? UART_STOP_BITS_1 : UART_STOP_BITS_2;
-    uart_config.flow_ctrl = config_.use_hardware_flow_control ? UART_HW_FLOWCTRL_CTS_RTS : UART_HW_FLOWCTRL_DISABLE;
-    uart_config.source_clk = UART_SCLK_DEFAULT;
+  // Configure UART parameters
+  uart_config_t uart_config = {};
+  uart_config.baud_rate = config_.baud_rate;
+  uart_config.data_bits = static_cast<uart_word_length_t>(config_.data_bits - 5);
 
-    // Configure UART
-    esp_err_t err = uart_param_config(static_cast<uart_port_t>(port_), &uart_config);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
+  // Configure parity
+  switch (config_.parity) {
+  case 0:
+    uart_config.parity = UART_PARITY_DISABLE;
+    break;
+  case 1:
+    uart_config.parity = UART_PARITY_EVEN;
+    break;
+  case 2:
+    uart_config.parity = UART_PARITY_ODD;
+    break;
+  default:
+    uart_config.parity = UART_PARITY_DISABLE;
+    break;
+  }
 
-    // Set pins
-    err = uart_set_pin(static_cast<uart_port_t>(port_), 
-                      config_.tx_pin, 
-                      config_.rx_pin,
-                      config_.use_hardware_flow_control ? config_.rts_pin : UART_PIN_NO_CHANGE,
-                      config_.use_hardware_flow_control ? config_.cts_pin : UART_PIN_NO_CHANGE);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
+  uart_config.stop_bits = (config_.stop_bits == 1) ? UART_STOP_BITS_1 : UART_STOP_BITS_2;
+  uart_config.flow_ctrl =
+      config_.use_hardware_flow_control ? UART_HW_FLOWCTRL_CTS_RTS : UART_HW_FLOWCTRL_DISABLE;
+  uart_config.source_clk = UART_SCLK_DEFAULT;
 
-    // Install UART driver
-    err = uart_driver_install(static_cast<uart_port_t>(port_), 
-                             config_.rx_buffer_size, 
-                             config_.tx_buffer_size, 
-                             0, 
-                             nullptr, 
-                             0);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-
-    ESP_LOGI(TAG, "UART initialized on port %d, baud=%lu, TX=%d, RX=%d",
-             port_, config_.baud_rate, config_.tx_pin, config_.rx_pin);
-    
-    return true;
-#else
-    last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  // Configure UART
+  esp_err_t err = uart_param_config(static_cast<uart_port_t>(port_), &uart_config);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
     return false;
+  }
+
+  // Set pins
+  err = uart_set_pin(static_cast<uart_port_t>(port_), config_.tx_pin, config_.rx_pin,
+                     config_.use_hardware_flow_control ? config_.rts_pin : UART_PIN_NO_CHANGE,
+                     config_.use_hardware_flow_control ? config_.cts_pin : UART_PIN_NO_CHANGE);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "uart_set_pin failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
+    return false;
+  }
+
+  // Install UART driver
+  err = uart_driver_install(static_cast<uart_port_t>(port_), config_.rx_buffer_size,
+                            config_.tx_buffer_size, 0, nullptr, 0);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "UART initialized on port %d, baud=%lu, TX=%d, RX=%d", port_, config_.baud_rate,
+           config_.tx_pin, config_.rx_pin);
+
+  return true;
+#else
+  last_error_ = HfUartErr::UART_ERR_UNSUPPORTED_OPERATION;
+  return false;
 #endif
 }
 
 bool McuUart::PlatformDeinitialize() noexcept {
 #ifdef HF_MCU_FAMILY_ESP32
-    esp_err_t err = uart_driver_delete(static_cast<uart_port_t>(port_));
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "uart_driver_delete failed: %s", esp_err_to_name(err));
-        last_error_ = ConvertPlatformError(err);
-        return false;
-    }
-    
-    ESP_LOGI(TAG, "UART deinitialized on port %d", port_);
-    return true;
-#else
+  esp_err_t err = uart_driver_delete(static_cast<uart_port_t>(port_));
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "uart_driver_delete failed: %s", esp_err_to_name(err));
+    last_error_ = ConvertPlatformError(err);
     return false;
+  }
+
+  ESP_LOGI(TAG, "UART deinitialized on port %d", port_);
+  return true;
+#else
+  return false;
 #endif
 }
 
-int McuUart::InternalPrintf(const char* format, va_list args) noexcept {
-    // Format the string into our buffer
-    int formatted_length = vsnprintf(printf_buffer_, PRINTF_BUFFER_SIZE, format, args);
-    
-    if (formatted_length < 0) {
-        return -1;  // Formatting error
-    }
-    
-    if (formatted_length >= PRINTF_BUFFER_SIZE) {
-        formatted_length = PRINTF_BUFFER_SIZE - 1;  // Truncate
-    }
-    
-    // Write the formatted string
-    HfUartErr result = Write(reinterpret_cast<const uint8_t*>(printf_buffer_), 
-                            formatted_length);
-    
-    return (result == HfUartErr::UART_SUCCESS) ? formatted_length : -1;
+int McuUart::InternalPrintf(const char *format, va_list args) noexcept {
+  // Format the string into our buffer
+  int formatted_length = vsnprintf(printf_buffer_, PRINTF_BUFFER_SIZE, format, args);
+
+  if (formatted_length < 0) {
+    return -1; // Formatting error
+  }
+
+  if (formatted_length >= PRINTF_BUFFER_SIZE) {
+    formatted_length = PRINTF_BUFFER_SIZE - 1; // Truncate
+  }
+
+  // Write the formatted string
+  HfUartErr result = Write(reinterpret_cast<const uint8_t *>(printf_buffer_), formatted_length);
+
+  return (result == HfUartErr::UART_SUCCESS) ? formatted_length : -1;
 }

--- a/src/thread_safe/SfAdc.cpp
+++ b/src/thread_safe/SfAdc.cpp
@@ -5,7 +5,7 @@
  * This file implements the enhanced thread-safe wrapper around the BaseAdc interface
  * for safe use in multi-threaded applications with advanced features like:
  * - Lock-free read operations
- * - Batch conversion operations  
+ * - Batch conversion operations
  * - Advanced threading statistics
  * - Configurable timeout handling
  * - Non-blocking and blocking convenience methods
@@ -15,32 +15,29 @@
 #include <chrono>
 
 namespace {
-    // Default timeout for mutex operations (milliseconds)
-    constexpr uint32_t DEFAULT_TIMEOUT = 5000;
-    
-    // Maximum batch size for conversions
-    constexpr size_t MAX_BATCH_SIZE = 32;
-}
+// Default timeout for mutex operations (milliseconds)
+constexpr uint32_t DEFAULT_TIMEOUT = 5000;
+
+// Maximum batch size for conversions
+constexpr size_t MAX_BATCH_SIZE = 32;
+} // namespace
 
 //==============================================================================
 // CONSTRUCTOR AND DESTRUCTOR
 //==============================================================================
 
 SfAdc::SfAdc(std::unique_ptr<BaseAdc> adc_impl) noexcept
-    : adc_impl_(std::move(adc_impl))
-    , initialized_(false)
-    , mutex_timeout_(DEFAULT_TIMEOUT)
-    , stats_{}
-{
-    if (!adc_impl_) {
-        return;
-    }
+    : adc_impl_(std::move(adc_impl)), initialized_(false), mutex_timeout_(DEFAULT_TIMEOUT),
+      stats_{} {
+  if (!adc_impl_) {
+    return;
+  }
 }
 
 SfAdc::~SfAdc() noexcept {
-    if (initialized_.load()) {
-        Deinitialize();
-    }
+  if (initialized_.load()) {
+    Deinitialize();
+  }
 }
 
 //==============================================================================
@@ -48,112 +45,113 @@ SfAdc::~SfAdc() noexcept {
 //==============================================================================
 
 HfAdcErr SfAdc::Initialize() noexcept {
-    std::unique_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock()) {
-        stats_.timeout_count_.fetch_add(1);
-        return HfAdcErr::ADC_ERR_TIMEOUT;
-    }
-    
-    if (!adc_impl_) {
-        return HfAdcErr::ADC_ERR_NULL_POINTER;
-    }
-    
-    if (initialized_.load()) {
-        return HfAdcErr::ADC_ERR_ALREADY_INITIALIZED;
-    }
-    
-    auto result = adc_impl_->Initialize();
-    if (result == HfAdcErr::ADC_SUCCESS) {
-        initialized_.store(true);
-        stats_.operation_count_.fetch_add(1);
-    }
-    
-    return result;
+  std::unique_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock()) {
+    stats_.timeout_count_.fetch_add(1);
+    return HfAdcErr::ADC_ERR_TIMEOUT;
+  }
+
+  if (!adc_impl_) {
+    return HfAdcErr::ADC_ERR_NULL_POINTER;
+  }
+
+  if (initialized_.load()) {
+    return HfAdcErr::ADC_ERR_ALREADY_INITIALIZED;
+  }
+
+  auto result = adc_impl_->Initialize();
+  if (result == HfAdcErr::ADC_SUCCESS) {
+    initialized_.store(true);
+    stats_.operation_count_.fetch_add(1);
+  }
+
+  return result;
 }
 
 HfAdcErr SfAdc::Deinitialize() noexcept {
-    std::unique_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock()) {
-        stats_.timeout_count_.fetch_add(1);
-        return HfAdcErr::ADC_ERR_TIMEOUT;
-    }
-    
-    if (!adc_impl_) {
-        return HfAdcErr::ADC_ERR_NULL_POINTER;
-    }
-    
-    if (!initialized_.load()) {
-        return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
-    }
-    
-    auto result = adc_impl_->Deinitialize();
-    if (result == HfAdcErr::ADC_SUCCESS) {
-        initialized_.store(false);
-        stats_.operation_count_.fetch_add(1);
-    }
-    
-    return result;
+  std::unique_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock()) {
+    stats_.timeout_count_.fetch_add(1);
+    return HfAdcErr::ADC_ERR_TIMEOUT;
+  }
+
+  if (!adc_impl_) {
+    return HfAdcErr::ADC_ERR_NULL_POINTER;
+  }
+
+  if (!initialized_.load()) {
+    return HfAdcErr::ADC_ERR_NOT_INITIALIZED;
+  }
+
+  auto result = adc_impl_->Deinitialize();
+  if (result == HfAdcErr::ADC_SUCCESS) {
+    initialized_.store(false);
+    stats_.operation_count_.fetch_add(1);
+  }
+
+  return result;
 }
 
 //==============================================================================
 // CHANNEL OPERATIONS
 //==============================================================================
 
-HfAdcErr SfAdc::ConfigureChannel(hf_adc_channel_t channel, const AdcChannelConfig& config) noexcept {
-    std::unique_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock()) {
-        stats_.timeout_count_.fetch_add(1);
-        return HfAdcErr::ADC_ERR_TIMEOUT;
-    }
-    
-    if (!adc_impl_) {
-        return HfAdcErr::ADC_ERR_NULL_POINTER;
-    }
-    
-    auto result = adc_impl_->ConfigureChannel(channel, config);
-    if (result == HfAdcErr::ADC_SUCCESS) {
-        stats_.operation_count_.fetch_add(1);
-    }
-    
-    return result;
+HfAdcErr SfAdc::ConfigureChannel(hf_adc_channel_t channel,
+                                 const AdcChannelConfig &config) noexcept {
+  std::unique_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock()) {
+    stats_.timeout_count_.fetch_add(1);
+    return HfAdcErr::ADC_ERR_TIMEOUT;
+  }
+
+  if (!adc_impl_) {
+    return HfAdcErr::ADC_ERR_NULL_POINTER;
+  }
+
+  auto result = adc_impl_->ConfigureChannel(channel, config);
+  if (result == HfAdcErr::ADC_SUCCESS) {
+    stats_.operation_count_.fetch_add(1);
+  }
+
+  return result;
 }
 
-HfAdcErr SfAdc::ReadChannel(hf_adc_channel_t channel, uint32_t& raw_value) noexcept {
-    std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock()) {
-        stats_.timeout_count_.fetch_add(1);
-        return HfAdcErr::ADC_ERR_TIMEOUT;
-    }
-    
-    if (!adc_impl_) {
-        return HfAdcErr::ADC_ERR_NULL_POINTER;
-    }
-    
-    auto result = adc_impl_->ReadChannel(channel, raw_value);
-    if (result == HfAdcErr::ADC_SUCCESS) {
-        stats_.read_count_.fetch_add(1);
-    }
-    
-    return result;
+HfAdcErr SfAdc::ReadChannel(hf_adc_channel_t channel, uint32_t &raw_value) noexcept {
+  std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock()) {
+    stats_.timeout_count_.fetch_add(1);
+    return HfAdcErr::ADC_ERR_TIMEOUT;
+  }
+
+  if (!adc_impl_) {
+    return HfAdcErr::ADC_ERR_NULL_POINTER;
+  }
+
+  auto result = adc_impl_->ReadChannel(channel, raw_value);
+  if (result == HfAdcErr::ADC_SUCCESS) {
+    stats_.read_count_.fetch_add(1);
+  }
+
+  return result;
 }
 
-HfAdcErr SfAdc::ReadChannelVoltage(hf_adc_channel_t channel, float& voltage_v) noexcept {
-    std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock()) {
-        stats_.timeout_count_.fetch_add(1);
-        return HfAdcErr::ADC_ERR_TIMEOUT;
-    }
-    
-    if (!adc_impl_) {
-        return HfAdcErr::ADC_ERR_NULL_POINTER;
-    }
-    
-    auto result = adc_impl_->ReadChannelVoltage(channel, voltage_v);
-    if (result == HfAdcErr::ADC_SUCCESS) {
-        stats_.read_count_.fetch_add(1);
-    }
-    
-    return result;
+HfAdcErr SfAdc::ReadChannelVoltage(hf_adc_channel_t channel, float &voltage_v) noexcept {
+  std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock()) {
+    stats_.timeout_count_.fetch_add(1);
+    return HfAdcErr::ADC_ERR_TIMEOUT;
+  }
+
+  if (!adc_impl_) {
+    return HfAdcErr::ADC_ERR_NULL_POINTER;
+  }
+
+  auto result = adc_impl_->ReadChannelVoltage(channel, voltage_v);
+  if (result == HfAdcErr::ADC_SUCCESS) {
+    stats_.read_count_.fetch_add(1);
+  }
+
+  return result;
 }
 
 //==============================================================================
@@ -161,89 +159,89 @@ HfAdcErr SfAdc::ReadChannelVoltage(hf_adc_channel_t channel, float& voltage_v) n
 //==============================================================================
 
 void SfAdc::SetMutexTimeout(std::chrono::milliseconds timeout) {
-    mutex_timeout_ = static_cast<uint32_t>(timeout.count());
+  mutex_timeout_ = static_cast<uint32_t>(timeout.count());
 }
 
 SfAdc::ThreadingStats SfAdc::GetThreadingStats() const {
-    return stats_;
+  return stats_;
 }
 
 void SfAdc::ResetThreadingStats() {
-    stats_.operation_count_.store(0);
-    stats_.read_count_.store(0);
-    stats_.timeout_count_.store(0);
-    stats_.error_count_.store(0);
+  stats_.operation_count_.store(0);
+  stats_.read_count_.store(0);
+  stats_.timeout_count_.store(0);
+  stats_.error_count_.store(0);
 }
 
 bool SfAdc::IsInitialized() const noexcept {
-    return initialized_.load();
+  return initialized_.load();
 }
 
 //==============================================================================
 // BATCH OPERATIONS
 //==============================================================================
 
-HfAdcErr SfAdc::ReadMultipleChannels(const hf_adc_channel_t* channels, uint32_t* raw_values, 
-                                      size_t channel_count) noexcept {
-    if (!channels || !raw_values || channel_count == 0 || channel_count > MAX_BATCH_SIZE) {
-        return HfAdcErr::ADC_ERR_INVALID_PARAMETER;
+HfAdcErr SfAdc::ReadMultipleChannels(const hf_adc_channel_t *channels, uint32_t *raw_values,
+                                     size_t channel_count) noexcept {
+  if (!channels || !raw_values || channel_count == 0 || channel_count > MAX_BATCH_SIZE) {
+    return HfAdcErr::ADC_ERR_INVALID_PARAMETER;
+  }
+
+  std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock()) {
+    stats_.timeout_count_.fetch_add(1);
+    return HfAdcErr::ADC_ERR_TIMEOUT;
+  }
+
+  if (!adc_impl_) {
+    return HfAdcErr::ADC_ERR_NULL_POINTER;
+  }
+
+  HfAdcErr first_error = HfAdcErr::ADC_SUCCESS;
+  size_t successful_reads = 0;
+
+  for (size_t i = 0; i < channel_count; ++i) {
+    auto result = adc_impl_->ReadChannel(channels[i], raw_values[i]);
+    if (result == HfAdcErr::ADC_SUCCESS) {
+      ++successful_reads;
+    } else if (first_error == HfAdcErr::ADC_SUCCESS) {
+      first_error = result;
     }
-    
-    std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock()) {
-        stats_.timeout_count_.fetch_add(1);
-        return HfAdcErr::ADC_ERR_TIMEOUT;
-    }
-    
-    if (!adc_impl_) {
-        return HfAdcErr::ADC_ERR_NULL_POINTER;
-    }
-    
-    HfAdcErr first_error = HfAdcErr::ADC_SUCCESS;
-    size_t successful_reads = 0;
-    
-    for (size_t i = 0; i < channel_count; ++i) {
-        auto result = adc_impl_->ReadChannel(channels[i], raw_values[i]);
-        if (result == HfAdcErr::ADC_SUCCESS) {
-            ++successful_reads;
-        } else if (first_error == HfAdcErr::ADC_SUCCESS) {
-            first_error = result;
-        }
-    }
-    
-    stats_.read_count_.fetch_add(successful_reads);
-    if (first_error != HfAdcErr::ADC_SUCCESS) {
-        stats_.error_count_.fetch_add(1);
-    }
-    
-    return first_error;
+  }
+
+  stats_.read_count_.fetch_add(successful_reads);
+  if (first_error != HfAdcErr::ADC_SUCCESS) {
+    stats_.error_count_.fetch_add(1);
+  }
+
+  return first_error;
 }
 
 //==============================================================================
 // UTILITY METHODS
 //==============================================================================
 
-const char* SfAdc::GetErrorString(HfAdcErr error) const noexcept {
-    if (adc_impl_) {
-        return adc_impl_->GetErrorString(error);
-    }
-    return "Unknown error - ADC implementation not available";
+const char *SfAdc::GetErrorString(HfAdcErr error) const noexcept {
+  if (adc_impl_) {
+    return adc_impl_->GetErrorString(error);
+  }
+  return "Unknown error - ADC implementation not available";
 }
 
 uint8_t SfAdc::GetMaxChannels() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock() || !adc_impl_) {
-        return 0;
-    }
-    
-    return adc_impl_->GetMaxChannels();
+  std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock() || !adc_impl_) {
+    return 0;
+  }
+
+  return adc_impl_->GetMaxChannels();
 }
 
 bool SfAdc::IsChannelConfigured(hf_adc_channel_t channel) const noexcept {
-    std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
-    if (!lock.owns_lock() || !adc_impl_) {
-        return false;
-    }
-    
-    return adc_impl_->IsChannelConfigured(channel);
+  std::shared_lock<std::shared_mutex> lock(mutex_, std::chrono::milliseconds(mutex_timeout_));
+  if (!lock.owns_lock() || !adc_impl_) {
+    return false;
+  }
+
+  return adc_impl_->IsChannelConfigured(channel);
 }

--- a/src/thread_safe/SfCan.cpp
+++ b/src/thread_safe/SfCan.cpp
@@ -5,7 +5,7 @@
  * This file implements the enhanced thread-safe wrapper around the BaseCan interface
  * for safe use in multi-threaded applications with advanced features like:
  * - Lock-free read operations
- * - Batch message operations  
+ * - Batch message operations
  * - Advanced threading statistics
  * - Configurable timeout handling
  * - Non-blocking and blocking convenience methods
@@ -15,27 +15,23 @@
 #include <chrono>
 
 namespace {
-    constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{100};
-    constexpr uint32_t DEFAULT_BLOCKING_TIMEOUT = UINT32_MAX;
-}
+constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{100};
+constexpr uint32_t DEFAULT_BLOCKING_TIMEOUT = UINT32_MAX;
+} // namespace
 
 //==============================================================================
 // CONSTRUCTOR AND DESTRUCTOR
 //==============================================================================
 
 SfCan::SfCan(std::unique_ptr<BaseCan> can_impl) noexcept
-    : can_impl_(std::move(can_impl))
-    , initialized_(false)
-    , mutex_timeout_(DEFAULT_TIMEOUT)
-    , stats_{}
-{
-}
+    : can_impl_(std::move(can_impl)), initialized_(false), mutex_timeout_(DEFAULT_TIMEOUT),
+      stats_{} {}
 
 SfCan::~SfCan() noexcept {
-    std::lock_guard<std::shared_mutex> lock(rw_mutex_);
-    if (initialized_ && can_impl_) {
-        can_impl_->Deinitialize();
-    }
+  std::lock_guard<std::shared_mutex> lock(rw_mutex_);
+  if (initialized_ && can_impl_) {
+    can_impl_->Deinitialize();
+  }
 }
 
 //==============================================================================
@@ -43,13 +39,13 @@ SfCan::~SfCan() noexcept {
 //==============================================================================
 
 void SfCan::SetMutexTimeout(std::chrono::milliseconds timeout) noexcept {
-    std::lock_guard<std::shared_mutex> lock(rw_mutex_);
-    mutex_timeout_ = timeout;
+  std::lock_guard<std::shared_mutex> lock(rw_mutex_);
+  mutex_timeout_ = timeout;
 }
 
 std::chrono::milliseconds SfCan::GetMutexTimeout() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_);
-    return mutex_timeout_;
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_);
+  return mutex_timeout_;
 }
 
 //==============================================================================
@@ -57,219 +53,221 @@ std::chrono::milliseconds SfCan::GetMutexTimeout() const noexcept {
 //==============================================================================
 
 bool SfCan::Initialize() noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    if (initialized_) {
-        UpdateStats(start_time, false);
-        return true; // Already initialized
-    }
-    
-    bool result = can_impl_->Initialize();
-    if (result) {
-        initialized_.store(true, std::memory_order_release);
-    }
-    
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  if (initialized_) {
+    UpdateStats(start_time, false);
+    return true; // Already initialized
+  }
+
+  bool result = can_impl_->Initialize();
+  if (result) {
+    initialized_.store(true, std::memory_order_release);
+  }
+
+  UpdateStats(start_time, false);
+  return result;
 }
 
 bool SfCan::Deinitialize() noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return true;
-    }
-    
-    bool result = can_impl_->Deinitialize();
-    if (result) {
-        initialized_.store(false, std::memory_order_release);
-    }
-    
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return true;
+  }
+
+  bool result = can_impl_->Deinitialize();
+  if (result) {
+    initialized_.store(false, std::memory_order_release);
+  }
+
+  UpdateStats(start_time, false);
+  return result;
 }
 
 bool SfCan::Start() noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->Start();
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->Start();
+  UpdateStats(start_time, false);
+  return result;
 }
 
 bool SfCan::Stop() noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->Stop();
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->Stop();
+  UpdateStats(start_time, false);
+  return result;
 }
 
 //==============================================================================
 // MESSAGE TRANSMISSION AND RECEPTION
 //==============================================================================
 
-bool SfCan::SendMessage(const hf_can_message_t& message, uint32_t timeout_ms) noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->SendMessage(message, timeout_ms);
+bool SfCan::SendMessage(const hf_can_message_t &message, uint32_t timeout_ms) noexcept {
+  auto start_time = std::chrono::steady_clock::now();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->SendMessage(message, timeout_ms);
+  UpdateStats(start_time, false);
+  return result;
 }
 
-bool SfCan::ReceiveMessage(hf_can_message_t& message, uint32_t timeout_ms) noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->ReceiveMessage(message, timeout_ms);
+bool SfCan::ReceiveMessage(hf_can_message_t &message, uint32_t timeout_ms) noexcept {
+  auto start_time = std::chrono::steady_clock::now();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->ReceiveMessage(message, timeout_ms);
+  UpdateStats(start_time, false);
+  return result;
 }
 
 //==============================================================================
 // CONVENIENCE METHODS
 //==============================================================================
 
-bool SfCan::SendMessageNonBlocking(const hf_can_message_t& message) noexcept {
-    return SendMessage(message, 0);
+bool SfCan::SendMessageNonBlocking(const hf_can_message_t &message) noexcept {
+  return SendMessage(message, 0);
 }
 
-bool SfCan::SendMessageBlocking(const hf_can_message_t& message) noexcept {
-    return SendMessage(message, DEFAULT_BLOCKING_TIMEOUT);
+bool SfCan::SendMessageBlocking(const hf_can_message_t &message) noexcept {
+  return SendMessage(message, DEFAULT_BLOCKING_TIMEOUT);
 }
 
-bool SfCan::ReceiveMessageNonBlocking(hf_can_message_t& message) noexcept {
-    return ReceiveMessage(message, 0);
+bool SfCan::ReceiveMessageNonBlocking(hf_can_message_t &message) noexcept {
+  return ReceiveMessage(message, 0);
 }
 
-bool SfCan::ReceiveMessageBlocking(hf_can_message_t& message) noexcept {
-    return ReceiveMessage(message, DEFAULT_BLOCKING_TIMEOUT);
+bool SfCan::ReceiveMessageBlocking(hf_can_message_t &message) noexcept {
+  return ReceiveMessage(message, DEFAULT_BLOCKING_TIMEOUT);
 }
 
 //==============================================================================
 // BATCH OPERATIONS
 //==============================================================================
 
-bool SfCan::SendMultipleMessages(const std::vector<hf_can_message_t>& messages, uint32_t timeout_ms) noexcept {
-    if (messages.empty()) {
-        return true;
-    }
-    
-    auto start_time = std::chrono::steady_clock::now();
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    // Send all messages with single lock
-    for (const auto& message : messages) {
-        if (!can_impl_->SendMessage(message, timeout_ms)) {
-            UpdateStats(start_time, false);
-            return false;
-        }
-    }
-    
-    UpdateStats(start_time, false);
+bool SfCan::SendMultipleMessages(const std::vector<hf_can_message_t> &messages,
+                                 uint32_t timeout_ms) noexcept {
+  if (messages.empty()) {
     return true;
+  }
+
+  auto start_time = std::chrono::steady_clock::now();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
+    UpdateStats(start_time, false);
+    return false;
+  }
+
+  // Send all messages with single lock
+  for (const auto &message : messages) {
+    if (!can_impl_->SendMessage(message, timeout_ms)) {
+      UpdateStats(start_time, false);
+      return false;
+    }
+  }
+
+  UpdateStats(start_time, false);
+  return true;
 }
 
-size_t SfCan::SendMultipleMessagesPartial(const std::vector<hf_can_message_t>& messages, uint32_t timeout_ms) noexcept {
-    if (messages.empty()) {
-        return 0;
-    }
-    
-    auto start_time = std::chrono::steady_clock::now();
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return 0;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return 0;
-    }
-    
-    size_t sent_count = 0;
-    for (const auto& message : messages) {
-        if (can_impl_->SendMessage(message, timeout_ms)) {
-            ++sent_count;
-        } else {
-            break; // Stop on first failure
-        }
-    }
-    
+size_t SfCan::SendMultipleMessagesPartial(const std::vector<hf_can_message_t> &messages,
+                                          uint32_t timeout_ms) noexcept {
+  if (messages.empty()) {
+    return 0;
+  }
+
+  auto start_time = std::chrono::steady_clock::now();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return 0;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return sent_count;
+    return 0;
+  }
+
+  size_t sent_count = 0;
+  for (const auto &message : messages) {
+    if (can_impl_->SendMessage(message, timeout_ms)) {
+      ++sent_count;
+    } else {
+      break; // Stop on first failure
+    }
+  }
+
+  UpdateStats(start_time, false);
+  return sent_count;
 }
 
 //==============================================================================
@@ -277,82 +275,82 @@ size_t SfCan::SendMultipleMessagesPartial(const std::vector<hf_can_message_t>& m
 //==============================================================================
 
 bool SfCan::SetReceiveCallback(CanReceiveCallback callback) noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->SetReceiveCallback(callback);
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->SetReceiveCallback(callback);
+  UpdateStats(start_time, false);
+  return result;
 }
 
 void SfCan::ClearReceiveCallback() noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return;
-    }
-    
-    if (!can_impl_) {
-        UpdateStats(start_time, false);
-        return;
-    }
-    
-    can_impl_->ClearReceiveCallback();
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return;
+  }
+
+  if (!can_impl_) {
     UpdateStats(start_time, false);
+    return;
+  }
+
+  can_impl_->ClearReceiveCallback();
+  UpdateStats(start_time, false);
 }
 
 //==============================================================================
 // STATUS AND DIAGNOSTICS
 //==============================================================================
 
-bool SfCan::GetStatus(CanBusStatus& status) noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->GetStatus(status);
+bool SfCan::GetStatus(CanBusStatus &status) noexcept {
+  auto start_time = std::chrono::steady_clock::now();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->GetStatus(status);
+  UpdateStats(start_time, false);
+  return result;
 }
 
 bool SfCan::Reset() noexcept {
-    auto start_time = std::chrono::steady_clock::now();
-    std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        UpdateStats(start_time, true);
-        return false;
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        UpdateStats(start_time, false);
-        return false;
-    }
-    
-    bool result = can_impl_->Reset();
+  auto start_time = std::chrono::steady_clock::now();
+  std::unique_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    UpdateStats(start_time, true);
+    return false;
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
     UpdateStats(start_time, false);
-    return result;
+    return false;
+  }
+
+  bool result = can_impl_->Reset();
+  UpdateStats(start_time, false);
+  return result;
 }
 
 //==============================================================================
@@ -360,35 +358,35 @@ bool SfCan::Reset() noexcept {
 //==============================================================================
 
 bool SfCan::IsInitialized() const noexcept {
-    return initialized_.load(std::memory_order_acquire);
+  return initialized_.load(std::memory_order_acquire);
 }
 
 bool SfCan::IsTransmitQueueFull() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return true; // Conservative: assume full on timeout
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        return true;
-    }
-    
-    return can_impl_->IsTransmitQueueFull();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return true; // Conservative: assume full on timeout
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
+    return true;
+  }
+
+  return can_impl_->IsTransmitQueueFull();
 }
 
 bool SfCan::IsReceiveQueueEmpty() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
-    
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return true; // Conservative: assume empty on timeout
-    }
-    
-    if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
-        return true;
-    }
-    
-    return can_impl_->IsReceiveQueueEmpty();
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_, std::defer_lock);
+
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return true; // Conservative: assume empty on timeout
+  }
+
+  if (!can_impl_ || !initialized_.load(std::memory_order_acquire)) {
+    return true;
+  }
+
+  return can_impl_->IsReceiveQueueEmpty();
 }
 
 //==============================================================================
@@ -396,49 +394,50 @@ bool SfCan::IsReceiveQueueEmpty() const noexcept {
 //==============================================================================
 
 bool SfCan::TryLock() noexcept {
-    return rw_mutex_.try_lock();
+  return rw_mutex_.try_lock();
 }
 
 void SfCan::Lock() noexcept {
-    rw_mutex_.lock();
+  rw_mutex_.lock();
 }
 
 void SfCan::Unlock() noexcept {
-    rw_mutex_.unlock();
+  rw_mutex_.unlock();
 }
 
 SfCan::ThreadingStats SfCan::GetThreadingStats() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_);
-    return stats_;
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_);
+  return stats_;
 }
 
 void SfCan::ResetThreadingStats() noexcept {
-    std::lock_guard<std::shared_mutex> lock(rw_mutex_);
-    stats_ = ThreadingStats{};
+  std::lock_guard<std::shared_mutex> lock(rw_mutex_);
+  stats_ = ThreadingStats{};
 }
 
-const BaseCan* SfCan::GetImplementation() const noexcept {
-    std::shared_lock<std::shared_mutex> lock(rw_mutex_);
-    return can_impl_.get();
+const BaseCan *SfCan::GetImplementation() const noexcept {
+  std::shared_lock<std::shared_mutex> lock(rw_mutex_);
+  return can_impl_.get();
 }
 
 //==============================================================================
 // PRIVATE HELPER METHODS
 //==============================================================================
 
-void SfCan::UpdateStats(const std::chrono::steady_clock::time_point& start_time, bool was_timeout) noexcept {
-    auto end_time = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
-    
-    if (was_timeout) {
-        ++stats_.lock_contentions;
-    }
-    
-    ++stats_.total_operations;
-    stats_.total_lock_time_us += static_cast<uint64_t>(duration.count());
-    stats_.average_lock_time_us = stats_.total_lock_time_us / stats_.total_operations;
-    
-    if (duration.count() > static_cast<int64_t>(stats_.max_lock_time_us)) {
-        stats_.max_lock_time_us = static_cast<uint64_t>(duration.count());
-    }
+void SfCan::UpdateStats(const std::chrono::steady_clock::time_point &start_time,
+                        bool was_timeout) noexcept {
+  auto end_time = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
+
+  if (was_timeout) {
+    ++stats_.lock_contentions;
+  }
+
+  ++stats_.total_operations;
+  stats_.total_lock_time_us += static_cast<uint64_t>(duration.count());
+  stats_.average_lock_time_us = stats_.total_lock_time_us / stats_.total_operations;
+
+  if (duration.count() > static_cast<int64_t>(stats_.max_lock_time_us)) {
+    stats_.max_lock_time_us = static_cast<uint64_t>(duration.count());
+  }
 }

--- a/src/thread_safe/SfGpio.cpp
+++ b/src/thread_safe/SfGpio.cpp
@@ -1,7 +1,7 @@
 /**
  * @file SfGpio.cpp
  * @brief Implementation of thread-safe GPIO interface wrapper.
- * 
+ *
  * This file provides the implementation for the thread-safe GPIO wrapper,
  * ensuring atomic operations and thread safety for multi-threaded applications.
  */
@@ -16,20 +16,17 @@ namespace ThreadSafe {
 //==============================================================================
 
 SfGpio::SfGpio(std::shared_ptr<BaseGpio> gpio_impl)
-    : gpio_impl_(gpio_impl)
-    , mutex_(xSemaphoreCreateMutex())
-    , initialized_(false)
-{
-    if (mutex_ == nullptr) {
-        // Handle mutex creation failure
-    }
+    : gpio_impl_(gpio_impl), mutex_(xSemaphoreCreateMutex()), initialized_(false) {
+  if (mutex_ == nullptr) {
+    // Handle mutex creation failure
+  }
 }
 
 SfGpio::~SfGpio() {
-    if (mutex_ != nullptr) {
-        vSemaphoreDelete(mutex_);
-        mutex_ = nullptr;
-    }
+  if (mutex_ != nullptr) {
+    vSemaphoreDelete(mutex_);
+    mutex_ = nullptr;
+  }
 }
 
 //==============================================================================
@@ -37,51 +34,51 @@ SfGpio::~SfGpio() {
 //==============================================================================
 
 HfGpioErr SfGpio::Initialize() noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->Initialize();
+    if (result == HfGpioErr::GPIO_SUCCESS) {
+      initialized_ = true;
     }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->Initialize();
-        if (result == HfGpioErr::GPIO_SUCCESS) {
-            initialized_ = true;
-        }
-    }
-    
-    GiveMutex();
-    return result;
+  }
+
+  GiveMutex();
+  return result;
 }
 
 HfGpioErr SfGpio::Deinitialize() noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->Deinitialize();
+    if (result == HfGpioErr::GPIO_SUCCESS) {
+      initialized_ = false;
     }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->Deinitialize();
-        if (result == HfGpioErr::GPIO_SUCCESS) {
-            initialized_ = false;
-        }
-    }
-    
-    GiveMutex();
-    return result;
+  }
+
+  GiveMutex();
+  return result;
 }
 
-HfGpioErr SfGpio::ConfigurePin(hf_gpio_num_t pin, const GpioPinConfig& config) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->ConfigurePin(pin, config);
-    }
-    
-    GiveMutex();
-    return result;
+HfGpioErr SfGpio::ConfigurePin(hf_gpio_num_t pin, const GpioPinConfig &config) noexcept {
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->ConfigurePin(pin, config);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 //==============================================================================
@@ -89,45 +86,45 @@ HfGpioErr SfGpio::ConfigurePin(hf_gpio_num_t pin, const GpioPinConfig& config) n
 //==============================================================================
 
 HfGpioErr SfGpio::SetLevel(hf_gpio_num_t pin, bool level) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->SetLevel(pin, level);
-    }
-    
-    GiveMutex();
-    return result;
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->SetLevel(pin, level);
+  }
+
+  GiveMutex();
+  return result;
 }
 
-HfGpioErr SfGpio::GetLevel(hf_gpio_num_t pin, bool& level) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->GetLevel(pin, level);
-    }
-    
-    GiveMutex();
-    return result;
+HfGpioErr SfGpio::GetLevel(hf_gpio_num_t pin, bool &level) noexcept {
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->GetLevel(pin, level);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 HfGpioErr SfGpio::ToggleLevel(hf_gpio_num_t pin) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->ToggleLevel(pin);
-    }
-    
-    GiveMutex();
-    return result;
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->ToggleLevel(pin);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 //==============================================================================
@@ -135,32 +132,32 @@ HfGpioErr SfGpio::ToggleLevel(hf_gpio_num_t pin) noexcept {
 //==============================================================================
 
 HfGpioErr SfGpio::EnableInterrupt(hf_gpio_num_t pin, hf_gpio_intr_type_t intr_type,
-                                   GpioIsrCallback callback, void* user_data) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->EnableInterrupt(pin, intr_type, callback, user_data);
-    }
-    
-    GiveMutex();
-    return result;
+                                  GpioIsrCallback callback, void *user_data) noexcept {
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->EnableInterrupt(pin, intr_type, callback, user_data);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 HfGpioErr SfGpio::DisableInterrupt(hf_gpio_num_t pin) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->DisableInterrupt(pin);
-    }
-    
-    GiveMutex();
-    return result;
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->DisableInterrupt(pin);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 //==============================================================================
@@ -168,31 +165,31 @@ HfGpioErr SfGpio::DisableInterrupt(hf_gpio_num_t pin) noexcept {
 //==============================================================================
 
 HfGpioErr SfGpio::SetDriveStrength(hf_gpio_num_t pin, hf_gpio_drive_cap_t strength) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->SetDriveStrength(pin, strength);
-    }
-    
-    GiveMutex();
-    return result;
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->SetDriveStrength(pin, strength);
+  }
+
+  GiveMutex();
+  return result;
 }
 
-HfGpioErr SfGpio::GetDriveStrength(hf_gpio_num_t pin, hf_gpio_drive_cap_t& strength) noexcept {
-    if (!TakeMutex()) {
-        return HfGpioErr::GPIO_ERR_TIMEOUT;
-    }
-    
-    HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
-    if (gpio_impl_) {
-        result = gpio_impl_->GetDriveStrength(pin, strength);
-    }
-    
-    GiveMutex();
-    return result;
+HfGpioErr SfGpio::GetDriveStrength(hf_gpio_num_t pin, hf_gpio_drive_cap_t &strength) noexcept {
+  if (!TakeMutex()) {
+    return HfGpioErr::GPIO_ERR_TIMEOUT;
+  }
+
+  HfGpioErr result = HfGpioErr::GPIO_ERR_NULL_POINTER;
+  if (gpio_impl_) {
+    result = gpio_impl_->GetDriveStrength(pin, strength);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 //==============================================================================
@@ -200,28 +197,28 @@ HfGpioErr SfGpio::GetDriveStrength(hf_gpio_num_t pin, hf_gpio_drive_cap_t& stren
 //==============================================================================
 
 bool SfGpio::IsInitialized() const noexcept {
-    return initialized_;
+  return initialized_;
 }
 
-const char* SfGpio::GetErrorString(HfGpioErr error) const noexcept {
-    if (gpio_impl_) {
-        return gpio_impl_->GetErrorString(error);
-    }
-    return "Unknown error - GPIO implementation not available";
+const char *SfGpio::GetErrorString(HfGpioErr error) const noexcept {
+  if (gpio_impl_) {
+    return gpio_impl_->GetErrorString(error);
+  }
+  return "Unknown error - GPIO implementation not available";
 }
 
 bool SfGpio::IsPinValid(hf_gpio_num_t pin) const noexcept {
-    if (!TakeMutex()) {
-        return false;
-    }
-    
-    bool result = false;
-    if (gpio_impl_) {
-        result = gpio_impl_->IsPinValid(pin);
-    }
-    
-    GiveMutex();
-    return result;
+  if (!TakeMutex()) {
+    return false;
+  }
+
+  bool result = false;
+  if (gpio_impl_) {
+    result = gpio_impl_->IsPinValid(pin);
+  }
+
+  GiveMutex();
+  return result;
 }
 
 //==============================================================================
@@ -229,20 +226,19 @@ bool SfGpio::IsPinValid(hf_gpio_num_t pin) const noexcept {
 //==============================================================================
 
 bool SfGpio::TakeMutex(uint32_t timeout_ms) const noexcept {
-    if (mutex_ == nullptr) {
-        return false;
-    }
-    
-    TickType_t timeout_ticks = (timeout_ms == UINT32_MAX) ? portMAX_DELAY : 
-                               pdMS_TO_TICKS(timeout_ms);
-    
-    return xSemaphoreTake(mutex_, timeout_ticks) == pdTRUE;
+  if (mutex_ == nullptr) {
+    return false;
+  }
+
+  TickType_t timeout_ticks = (timeout_ms == UINT32_MAX) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
+
+  return xSemaphoreTake(mutex_, timeout_ticks) == pdTRUE;
 }
 
 void SfGpio::GiveMutex() const noexcept {
-    if (mutex_ != nullptr) {
-        xSemaphoreGive(mutex_);
-    }
+  if (mutex_ != nullptr) {
+    xSemaphoreGive(mutex_);
+  }
 }
 
 } // namespace ThreadSafe

--- a/src/thread_safe/SfI2cBus.cpp
+++ b/src/thread_safe/SfI2cBus.cpp
@@ -7,7 +7,8 @@
 
 static const char *TAG = "SfI2cBus";
 
-SfI2cBus::SfI2cBus(hf_i2c_port_t port, const hf_i2c_config_t &cfg, hf_semaphore_handle_t mutexHandle) noexcept
+SfI2cBus::SfI2cBus(hf_i2c_port_t port, const hf_i2c_config_t &cfg,
+                   hf_semaphore_handle_t mutexHandle) noexcept
     : i2cPort(port), config(cfg), busMutex(mutexHandle), initialized(false) {}
 
 SfI2cBus::~SfI2cBus() noexcept {

--- a/src/thread_safe/SfPwm.cpp
+++ b/src/thread_safe/SfPwm.cpp
@@ -7,325 +7,323 @@
 #include <chrono>
 
 namespace {
-    constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{100};
+constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{100};
 }
 
 SfPwm::SfPwm(std::unique_ptr<BasePwm> pwm_impl)
-    : pwm_impl_(std::move(pwm_impl))
-    , is_initialized_(false)
-    , mutex_timeout_(DEFAULT_TIMEOUT) {
-}
+    : pwm_impl_(std::move(pwm_impl)), is_initialized_(false), mutex_timeout_(DEFAULT_TIMEOUT) {}
 
 SfPwm::~SfPwm() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (is_initialized_ && pwm_impl_) {
-        pwm_impl_->Deinitialize();
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (is_initialized_ && pwm_impl_) {
+    pwm_impl_->Deinitialize();
+  }
 }
 
 void SfPwm::SetMutexTimeout(std::chrono::milliseconds timeout) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    mutex_timeout_ = timeout;
+  std::lock_guard<std::mutex> lock(mutex_);
+  mutex_timeout_ = timeout;
 }
 
 HfPwmErr SfPwm::Initialize() {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_) {
-        return HfPwmErr::PWM_INVALID_ARGUMENT;
-    }
-    
-    if (is_initialized_) {
-        return HfPwmErr::PWM_SUCCESS; // Already initialized
-    }
-    
-    HfPwmErr result = pwm_impl_->Initialize();
-    if (result == HfPwmErr::PWM_SUCCESS) {
-        is_initialized_ = true;
-    }
-    
-    return result;
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_) {
+    return HfPwmErr::PWM_INVALID_ARGUMENT;
+  }
+
+  if (is_initialized_) {
+    return HfPwmErr::PWM_SUCCESS; // Already initialized
+  }
+
+  HfPwmErr result = pwm_impl_->Initialize();
+  if (result == HfPwmErr::PWM_SUCCESS) {
+    is_initialized_ = true;
+  }
+
+  return result;
 }
 
 HfPwmErr SfPwm::Deinitialize() {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    HfPwmErr result = pwm_impl_->Deinitialize();
-    if (result == HfPwmErr::PWM_SUCCESS) {
-        is_initialized_ = false;
-    }
-    
-    return result;
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  HfPwmErr result = pwm_impl_->Deinitialize();
+  if (result == HfPwmErr::PWM_SUCCESS) {
+    is_initialized_ = false;
+  }
+
+  return result;
 }
 
-HfPwmErr SfPwm::ConfigureChannel(uint8_t channel_id, const PwmChannelConfig& config) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->ConfigureChannel(channel_id, config);
+HfPwmErr SfPwm::ConfigureChannel(uint8_t channel_id, const PwmChannelConfig &config) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->ConfigureChannel(channel_id, config);
 }
 
 HfPwmErr SfPwm::SetDutyCycle(uint8_t channel_id, float duty_cycle) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->SetDutyCycle(channel_id, duty_cycle);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->SetDutyCycle(channel_id, duty_cycle);
 }
 
 HfPwmErr SfPwm::SetFrequency(uint8_t channel_id, uint32_t frequency_hz) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->SetFrequency(channel_id, frequency_hz);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->SetFrequency(channel_id, frequency_hz);
 }
 
 HfPwmErr SfPwm::Start(uint8_t channel_id) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->Start(channel_id);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->Start(channel_id);
 }
 
 HfPwmErr SfPwm::Stop(uint8_t channel_id) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->Stop(channel_id);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->Stop(channel_id);
 }
 
-HfPwmErr SfPwm::GetDutyCycle(uint8_t channel_id, float& duty_cycle) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->GetDutyCycle(channel_id, duty_cycle);
+HfPwmErr SfPwm::GetDutyCycle(uint8_t channel_id, float &duty_cycle) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->GetDutyCycle(channel_id, duty_cycle);
 }
 
-HfPwmErr SfPwm::GetFrequency(uint8_t channel_id, uint32_t& frequency_hz) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->GetFrequency(channel_id, frequency_hz);
+HfPwmErr SfPwm::GetFrequency(uint8_t channel_id, uint32_t &frequency_hz) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->GetFrequency(channel_id, frequency_hz);
 }
 
 bool SfPwm::IsChannelActive(uint8_t channel_id) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return false; // Default to inactive on timeout
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return false;
-    }
-    
-    return pwm_impl_->IsChannelActive(channel_id);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return false; // Default to inactive on timeout
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return false;
+  }
+
+  return pwm_impl_->IsChannelActive(channel_id);
 }
 
 uint8_t SfPwm::GetMaxChannels() {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return 0; // Default to no channels on timeout
-    }
-    
-    if (!pwm_impl_) {
-        return 0;
-    }
-    
-    return pwm_impl_->GetMaxChannels();
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return 0; // Default to no channels on timeout
+  }
+
+  if (!pwm_impl_) {
+    return 0;
+  }
+
+  return pwm_impl_->GetMaxChannels();
 }
 
 // Advanced features (ESP32-specific)
 HfPwmErr SfPwm::SetPhase(uint8_t channel_id, float phase_degrees) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->SetPhase(channel_id, phase_degrees);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->SetPhase(channel_id, phase_degrees);
 }
 
-HfPwmErr SfPwm::ConfigureFade(uint8_t channel_id, const PwmFadeConfig& fade_config) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->ConfigureFade(channel_id, fade_config);
+HfPwmErr SfPwm::ConfigureFade(uint8_t channel_id, const PwmFadeConfig &fade_config) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->ConfigureFade(channel_id, fade_config);
 }
 
 HfPwmErr SfPwm::StartFade(uint8_t channel_id) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->StartFade(channel_id);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->StartFade(channel_id);
 }
 
-HfPwmErr SfPwm::ConfigureComplementary(uint8_t primary_channel, uint8_t secondary_channel, 
-                                       const PwmComplementaryConfig& comp_config) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->ConfigureComplementary(primary_channel, secondary_channel, comp_config);
+HfPwmErr SfPwm::ConfigureComplementary(uint8_t primary_channel, uint8_t secondary_channel,
+                                       const PwmComplementaryConfig &comp_config) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->ConfigureComplementary(primary_channel, secondary_channel, comp_config);
 }
 
 HfPwmErr SfPwm::SetDeadTime(uint8_t channel_id, uint16_t dead_time_ns) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->SetDeadTime(channel_id, dead_time_ns);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->SetDeadTime(channel_id, dead_time_ns);
 }
 
 // Callback management
-HfPwmErr SfPwm::RegisterCallback(uint8_t channel_id, PwmCallbackType callback_type, 
-                                 PwmCallback callback, void* user_data) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->RegisterCallback(channel_id, callback_type, callback, user_data);
+HfPwmErr SfPwm::RegisterCallback(uint8_t channel_id, PwmCallbackType callback_type,
+                                 PwmCallback callback, void *user_data) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->RegisterCallback(channel_id, callback_type, callback, user_data);
 }
 
 HfPwmErr SfPwm::UnregisterCallback(uint8_t channel_id, PwmCallbackType callback_type) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->UnregisterCallback(channel_id, callback_type);
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->UnregisterCallback(channel_id, callback_type);
 }
 
 // Multi-channel operations
-HfPwmErr SfPwm::StartMultiple(const uint8_t* channel_ids, uint8_t num_channels) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->StartMultiple(channel_ids, num_channels);
+HfPwmErr SfPwm::StartMultiple(const uint8_t *channel_ids, uint8_t num_channels) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->StartMultiple(channel_ids, num_channels);
 }
 
-HfPwmErr SfPwm::StopMultiple(const uint8_t* channel_ids, uint8_t num_channels) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->StopMultiple(channel_ids, num_channels);
+HfPwmErr SfPwm::StopMultiple(const uint8_t *channel_ids, uint8_t num_channels) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->StopMultiple(channel_ids, num_channels);
 }
 
-HfPwmErr SfPwm::SetDutyCycleMultiple(const uint8_t* channel_ids, const float* duty_cycles, uint8_t num_channels) {
-    std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
-    if (!lock.try_lock_for(mutex_timeout_)) {
-        return HfPwmErr::PWM_TIMEOUT;
-    }
-    
-    if (!pwm_impl_ || !is_initialized_) {
-        return HfPwmErr::PWM_NOT_INITIALIZED;
-    }
-    
-    return pwm_impl_->SetDutyCycleMultiple(channel_ids, duty_cycles, num_channels);
+HfPwmErr SfPwm::SetDutyCycleMultiple(const uint8_t *channel_ids, const float *duty_cycles,
+                                     uint8_t num_channels) {
+  std::unique_lock<std::mutex> lock(mutex_, std::defer_lock);
+  if (!lock.try_lock_for(mutex_timeout_)) {
+    return HfPwmErr::PWM_TIMEOUT;
+  }
+
+  if (!pwm_impl_ || !is_initialized_) {
+    return HfPwmErr::PWM_NOT_INITIALIZED;
+  }
+
+  return pwm_impl_->SetDutyCycleMultiple(channel_ids, duty_cycles, num_channels);
 }
 
 bool SfPwm::IsInitialized() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return is_initialized_;
+  std::lock_guard<std::mutex> lock(mutex_);
+  return is_initialized_;
 }
 
-const BasePwm* SfPwm::GetImplementation() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return pwm_impl_.get();
+const BasePwm *SfPwm::GetImplementation() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return pwm_impl_.get();
 }

--- a/src/thread_safe/SfUartDriver.cpp
+++ b/src/thread_safe/SfUartDriver.cpp
@@ -7,8 +7,8 @@
 
 static const char *TAG = "SfUartDriver";
 
-SfUartDriver::SfUartDriver(hf_uart_port_t p, const hf_uart_config_t &cfg, hf_gpio_num_t tx, hf_gpio_num_t rx,
-                           hf_semaphore_handle_t mtx) noexcept
+SfUartDriver::SfUartDriver(hf_uart_port_t p, const hf_uart_config_t &cfg, hf_gpio_num_t tx,
+                           hf_gpio_num_t rx, hf_semaphore_handle_t mtx) noexcept
     : port(p), config(cfg), txPin(tx), rxPin(rx), mutex(mtx), initialized(false) {}
 
 SfUartDriver::~SfUartDriver() noexcept {

--- a/src/utils/DigitalOutputGuard.cpp
+++ b/src/utils/DigitalOutputGuard.cpp
@@ -19,27 +19,22 @@
 //==============================================================================
 
 DigitalOutputGuard::DigitalOutputGuard(DigitalGpio &gpio, bool ensure_output_mode) noexcept
-    : gpio_(&gpio), 
-      was_output_mode_(false), 
-      is_valid_(false), 
+    : gpio_(&gpio), was_output_mode_(false), is_valid_(false),
       last_error_(HfGpioErr::GPIO_SUCCESS) {
-    
-    is_valid_ = InitializeGuard(ensure_output_mode);
+
+  is_valid_ = InitializeGuard(ensure_output_mode);
 }
 
 DigitalOutputGuard::DigitalOutputGuard(DigitalGpio *gpio, bool ensure_output_mode) noexcept
-    : gpio_(gpio), 
-      was_output_mode_(false), 
-      is_valid_(false), 
-      last_error_(HfGpioErr::GPIO_SUCCESS) {
-    
-    if (gpio_ == nullptr) {
-        last_error_ = HfGpioErr::GPIO_ERR_NULL_POINTER;
-        is_valid_ = false;
-        return;
-    }
-    
-    is_valid_ = InitializeGuard(ensure_output_mode);
+    : gpio_(gpio), was_output_mode_(false), is_valid_(false), last_error_(HfGpioErr::GPIO_SUCCESS) {
+
+  if (gpio_ == nullptr) {
+    last_error_ = HfGpioErr::GPIO_ERR_NULL_POINTER;
+    is_valid_ = false;
+    return;
+  }
+
+  is_valid_ = InitializeGuard(ensure_output_mode);
 }
 
 //==============================================================================
@@ -47,16 +42,16 @@ DigitalOutputGuard::DigitalOutputGuard(DigitalGpio *gpio, bool ensure_output_mod
 //==============================================================================
 
 DigitalOutputGuard::~DigitalOutputGuard() noexcept {
-    if (gpio_ != nullptr && is_valid_) {
-        // Set the GPIO to inactive state before destruction
-        // Don't change the direction back - leave it as configured
-        HfGpioErr result = gpio_->SetState(DigitalGpio::State::Inactive);
-        if (result != HfGpioErr::GPIO_SUCCESS) {
-            // In destructor, we can't throw exceptions or report errors
-            // Just attempt the operation and continue with destruction
-            (void)result; // Suppress unused variable warning
-        }
+  if (gpio_ != nullptr && is_valid_) {
+    // Set the GPIO to inactive state before destruction
+    // Don't change the direction back - leave it as configured
+    HfGpioErr result = gpio_->SetState(DigitalGpio::State::Inactive);
+    if (result != HfGpioErr::GPIO_SUCCESS) {
+      // In destructor, we can't throw exceptions or report errors
+      // Just attempt the operation and continue with destruction
+      (void)result; // Suppress unused variable warning
     }
+  }
 }
 
 //==============================================================================
@@ -64,47 +59,49 @@ DigitalOutputGuard::~DigitalOutputGuard() noexcept {
 //==============================================================================
 
 HfGpioErr DigitalOutputGuard::SetActive() noexcept {
-    if (!is_valid_ || gpio_ == nullptr) {
-        return last_error_ != HfGpioErr::GPIO_SUCCESS ? last_error_ : HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+  if (!is_valid_ || gpio_ == nullptr) {
+    return last_error_ != HfGpioErr::GPIO_SUCCESS ? last_error_
+                                                  : HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+  }
+
+  // Ensure the GPIO is in output mode
+  if (!gpio_->IsOutput()) {
+    HfGpioErr result = gpio_->SetDirection(DigitalGpio::Direction::Output);
+    if (result != HfGpioErr::GPIO_SUCCESS) {
+      last_error_ = result;
+      return result;
     }
-    
-    // Ensure the GPIO is in output mode
-    if (!gpio_->IsOutput()) {
-        HfGpioErr result = gpio_->SetDirection(DigitalGpio::Direction::Output);
-        if (result != HfGpioErr::GPIO_SUCCESS) {
-            last_error_ = result;
-            return result;
-        }
-    }
-    
-    last_error_ = gpio_->SetState(DigitalGpio::State::Active);
-    return last_error_;
+  }
+
+  last_error_ = gpio_->SetState(DigitalGpio::State::Active);
+  return last_error_;
 }
 
 HfGpioErr DigitalOutputGuard::SetInactive() noexcept {
-    if (!is_valid_ || gpio_ == nullptr) {
-        return last_error_ != HfGpioErr::GPIO_SUCCESS ? last_error_ : HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+  if (!is_valid_ || gpio_ == nullptr) {
+    return last_error_ != HfGpioErr::GPIO_SUCCESS ? last_error_
+                                                  : HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+  }
+
+  // Ensure the GPIO is in output mode
+  if (!gpio_->IsOutput()) {
+    HfGpioErr result = gpio_->SetDirection(DigitalGpio::Direction::Output);
+    if (result != HfGpioErr::GPIO_SUCCESS) {
+      last_error_ = result;
+      return result;
     }
-    
-    // Ensure the GPIO is in output mode
-    if (!gpio_->IsOutput()) {
-        HfGpioErr result = gpio_->SetDirection(DigitalGpio::Direction::Output);
-        if (result != HfGpioErr::GPIO_SUCCESS) {
-            last_error_ = result;
-            return result;
-        }
-    }
-    
-    last_error_ = gpio_->SetState(DigitalGpio::State::Inactive);
-    return last_error_;
+  }
+
+  last_error_ = gpio_->SetState(DigitalGpio::State::Inactive);
+  return last_error_;
 }
 
 DigitalGpio::State DigitalOutputGuard::GetCurrentState() const noexcept {
-    if (!is_valid_ || gpio_ == nullptr) {
-        return DigitalGpio::State::Inactive; // Safe default
-    }
-    
-    return gpio_->GetCurrentState();
+  if (!is_valid_ || gpio_ == nullptr) {
+    return DigitalGpio::State::Inactive; // Safe default
+  }
+
+  return gpio_->GetCurrentState();
 }
 
 //==============================================================================
@@ -112,37 +109,37 @@ DigitalGpio::State DigitalOutputGuard::GetCurrentState() const noexcept {
 //==============================================================================
 
 bool DigitalOutputGuard::InitializeGuard(bool ensure_output_mode) noexcept {
-    // Check if GPIO is initialized
-    if (!gpio_->EnsureInitialized()) {
-        last_error_ = HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
-        return false;
-    }
-    
-    // Record if the GPIO was already in output mode
-    was_output_mode_ = gpio_->IsOutput();
-    
-    // Ensure output mode if requested
-    if (ensure_output_mode && !was_output_mode_) {
-        HfGpioErr result = gpio_->SetDirection(DigitalGpio::Direction::Output);
-        if (result != HfGpioErr::GPIO_SUCCESS) {
-            last_error_ = result;
-            return false;
-        }
-    }
-    
-    // If not in output mode and we're not ensuring it, that's an error
-    if (!gpio_->IsOutput()) {
-        last_error_ = HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
-        return false;
-    }
-    
-    // Set the GPIO to active state
-    HfGpioErr result = gpio_->SetState(DigitalGpio::State::Active);
+  // Check if GPIO is initialized
+  if (!gpio_->EnsureInitialized()) {
+    last_error_ = HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
+    return false;
+  }
+
+  // Record if the GPIO was already in output mode
+  was_output_mode_ = gpio_->IsOutput();
+
+  // Ensure output mode if requested
+  if (ensure_output_mode && !was_output_mode_) {
+    HfGpioErr result = gpio_->SetDirection(DigitalGpio::Direction::Output);
     if (result != HfGpioErr::GPIO_SUCCESS) {
-        last_error_ = result;
-        return false;
+      last_error_ = result;
+      return false;
     }
-    
-    last_error_ = HfGpioErr::GPIO_SUCCESS;
-    return true;
+  }
+
+  // If not in output mode and we're not ensuring it, that's an error
+  if (!gpio_->IsOutput()) {
+    last_error_ = HfGpioErr::GPIO_ERR_DIRECTION_MISMATCH;
+    return false;
+  }
+
+  // Set the GPIO to active state
+  HfGpioErr result = gpio_->SetState(DigitalGpio::State::Active);
+  if (result != HfGpioErr::GPIO_SUCCESS) {
+    last_error_ = result;
+    return false;
+  }
+
+  last_error_ = HfGpioErr::GPIO_SUCCESS;
+  return true;
 }


### PR DESCRIPTION
## Summary
- run clang-format across inc/ and src/
- update README I2C snippet and class list

## Testing
- `clang-format -n $(find inc src -name '*.h' -o -name '*.cpp')`
- `python3 docs/check_docs.py docs/index.md`


------
https://chatgpt.com/codex/tasks/task_e_685dfdf3107c83289f646bcdf3cb7bb6