### PR TITLE
Add RTOS mutex support

### DIFF
--- a/inc/mcu/McuCan.h
+++ b/inc/mcu/McuCan.h
@@ -13,9 +13,9 @@
 #ifndef MCU_CAN_H
 #define MCU_CAN_H
 
+#include "../utils/RtosMutex.h"
 #include "BaseCan.h"
 #include "McuTypes.h"
-#include <mutex>
 
 /**
  * @class McuCan
@@ -123,7 +123,7 @@ public:
 private:
   CanBusConfig config_;                 ///< CAN bus configuration
   CanReceiveCallback receive_callback_; ///< User receive callback
-  mutable std::mutex mutex_;            ///< Thread safety mutex
+  mutable RtosMutex mutex_;             ///< Thread safety mutex
 
   // Platform-specific implementation methods
   bool PlatformInitialize() noexcept;

--- a/inc/mcu/McuI2c.h
+++ b/inc/mcu/McuI2c.h
@@ -14,11 +14,11 @@
 #ifndef MCU_I2C_H
 #define MCU_I2C_H
 
+#include "../utils/RtosMutex.h"
 #include "BaseI2c.h"
 #include "McuTypes.h"
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -715,7 +715,7 @@ private:
   std::unordered_map<uint16_t, void *> device_handles_; ///< Device handles map
 
   // State management
-  mutable std::mutex mutex_;   ///< Thread synchronization mutex
+  mutable RtosMutex mutex_;    ///< Thread synchronization mutex
   HfI2cErr last_error_;        ///< Last error that occurred
   uint64_t transaction_count_; ///< Transaction counter
   bool bus_locked_;            ///< Bus lock status

--- a/inc/mcu/McuPio.h
+++ b/inc/mcu/McuPio.h
@@ -18,10 +18,10 @@
 #ifndef MCU_PIO_H
 #define MCU_PIO_H
 
+#include "../utils/RtosMutex.h"
 #include "BasePio.h"
 #include "McuTypes.h"
 #include <array>
-#include <mutex>
 
 // Forward declarations for ESP32 RMT types
 #ifdef HF_MCU_FAMILY_ESP32
@@ -252,7 +252,7 @@ private:
 
   bool initialized_;
   std::array<ChannelState, MAX_CHANNELS> channels_;
-  mutable std::mutex state_mutex_;
+  mutable RtosMutex state_mutex_;
 
   // Callbacks
   PioTransmitCallback transmit_callback_;

--- a/inc/mcu/McuPwm.h
+++ b/inc/mcu/McuPwm.h
@@ -18,10 +18,10 @@
 #ifndef MCU_PWM_H
 #define MCU_PWM_H
 
+#include "../utils/RtosMutex.h"
 #include "BasePwm.h"
 #include "McuTypes.h"
 #include <array>
-#include <mutex>
 
 /**
  * @class McuPwm
@@ -310,9 +310,9 @@ private:
   // MEMBER VARIABLES
   //==============================================================================
 
-  mutable std::mutex mutex_; ///< Thread safety mutex
-  bool initialized_;         ///< Initialization state
-  uint32_t base_clock_hz_;   ///< Base clock frequency
+  mutable RtosMutex mutex_; ///< Thread safety mutex
+  bool initialized_;        ///< Initialization state
+  uint32_t base_clock_hz_;  ///< Base clock frequency
 
   std::array<ChannelState, MAX_CHANNELS> channels_;                     ///< Channel states
   std::array<TimerState, MAX_TIMERS> timers_;                           ///< Timer states

--- a/inc/mcu/McuSelect.h
+++ b/inc/mcu/McuSelect.h
@@ -36,7 +36,12 @@
 // #define HF_TARGET_MCU_ESP32       // ESP32 Classic Xtensa MCU
 // #define HF_TARGET_MCU_STM32F4     // STM32F4 series ARM Cortex-M4
 // #define HF_TARGET_MCU_STM32H7     // STM32H7 series ARM Cortex-M7
+
 // #define HF_TARGET_MCU_RP2040      // Raspberry Pi Pico RP2040
+
+// Optional thread safety support using RTOS-based mutexes
+// Uncomment to enable mutex protection in MCU drivers
+// #define HF_THREAD_SAFE
 
 //==============================================================================
 // AUTOMATIC PLATFORM CONFIGURATION BASED ON SELECTION

--- a/inc/mcu/McuSpi.h
+++ b/inc/mcu/McuSpi.h
@@ -12,9 +12,9 @@
 #ifndef MCU_SPI_H
 #define MCU_SPI_H
 
+#include "../utils/RtosMutex.h"
 #include "BaseSpi.h"
 #include "McuTypes.h"
-#include <mutex>
 
 /**
  * @class McuSpi
@@ -242,7 +242,7 @@ private:
   // PRIVATE MEMBERS                              //
   //==============================================//
 
-  mutable std::mutex mutex_;        ///< Thread safety mutex
+  mutable RtosMutex mutex_;         ///< Thread safety mutex
   hf_spi_handle_t platform_handle_; ///< Platform-specific SPI handle
   HfSpiErr last_error_;             ///< Last error that occurred
   uint32_t transaction_count_;      ///< Number of transactions performed

--- a/inc/mcu/McuUart.h
+++ b/inc/mcu/McuUart.h
@@ -12,10 +12,10 @@
 #ifndef MCU_UART_H
 #define MCU_UART_H
 
+#include "../utils/RtosMutex.h"
 #include "BaseUart.h"
 #include "McuTypes.h"
 #include <cstdarg>
-#include <mutex>
 
 /**
  * @class McuUart
@@ -299,7 +299,7 @@ private:
   // PRIVATE MEMBERS                              //
   //==============================================//
 
-  mutable std::mutex mutex_;         ///< Thread safety mutex
+  mutable RtosMutex mutex_;          ///< Thread safety mutex
   hf_uart_handle_t platform_handle_; ///< Platform-specific UART handle
   HfUartErr last_error_;             ///< Last error that occurred
   uint32_t bytes_transmitted_;       ///< Total bytes transmitted

--- a/inc/thread_safe/SfAdc.h
+++ b/inc/thread_safe/SfAdc.h
@@ -22,13 +22,11 @@
 #ifndef HAL_INTERNAL_INTERFACE_DRIVERS_SFADC_H_
 #define HAL_INTERNAL_INTERFACE_DRIVERS_SFADC_H_
 
+#include "../utils/RtosMutex.h"
 #include "BaseAdc.h"
 #include "McuTypes.h"
 #include <atomic>
-#include <chrono>
 #include <memory>
-#include <mutex>
-#include <shared_mutex>
 #include <vector>
 
 /**
@@ -90,7 +88,7 @@ public:
    * @brief Set mutex acquisition timeout for all operations.
    * @param timeout Maximum time to wait for mutex acquisition
    */
-  void SetMutexTimeout(std::chrono::milliseconds timeout) noexcept;
+  void SetMutexTimeout(uint32_t timeout_ms) noexcept;
 
   /**
    * @brief Initialize ADC with thread safety.
@@ -282,11 +280,11 @@ private:
   // PRIVATE MEMBERS
   //==============================================================================
 
-  std::unique_ptr<BaseAdc> adc_impl_;       ///< Wrapped ADC implementation
-  mutable std::shared_mutex rw_mutex_;      ///< Reader-writer mutex
-  std::atomic<bool> initialized_;           ///< Atomic initialization flag
-  std::chrono::milliseconds mutex_timeout_; ///< Mutex acquisition timeout
-  mutable ThreadingStats stats_;            ///< Threading statistics
+  std::unique_ptr<BaseAdc> adc_impl_;  ///< Wrapped ADC implementation
+  mutable std::shared_mutex rw_mutex_; ///< Reader-writer mutex
+  std::atomic<bool> initialized_;      ///< Atomic initialization flag
+  uint32_t mutex_timeout_ms_;          ///< Mutex acquisition timeout in milliseconds
+  mutable ThreadingStats stats_;       ///< Threading statistics
 
   //==============================================================================
   // PRIVATE HELPER METHODS
@@ -305,12 +303,12 @@ private:
   /**
    * @brief Update lock timing statistics.
    */
-  void UpdateLockStats(const std::chrono::steady_clock::time_point &start_time) const noexcept;
+  void UpdateLockStats(uint64_t start_time_us) const noexcept;
 
   /**
    * @brief Default mutex timeout (5 seconds).
    */
-  static constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{5000};
+  static constexpr uint32_t DEFAULT_TIMEOUT_MS{5000};
 };
 
 #endif // HAL_INTERNAL_INTERFACE_DRIVERS_SFADC_H_

--- a/inc/thread_safe/SfCan.h
+++ b/inc/thread_safe/SfCan.h
@@ -22,13 +22,12 @@
 #ifndef HAL_INTERNAL_INTERFACE_DRIVERS_SFCAN_H_
 #define HAL_INTERNAL_INTERFACE_DRIVERS_SFCAN_H_
 
+#include "../utils/RtosMutex.h"
 #include "BaseCan.h"
 #include "McuTypes.h"
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <memory>
-#include <shared_mutex>
 #include <vector>
 
 /**
@@ -110,14 +109,14 @@ public:
    *
    * @param timeout Timeout duration for mutex operations
    */
-  void SetMutexTimeout(std::chrono::milliseconds timeout) noexcept;
+  void SetMutexTimeout(uint32_t timeout_ms) noexcept;
 
   /**
    * @brief Get the current mutex timeout.
    *
    * @return Current mutex timeout duration
    */
-  std::chrono::milliseconds GetMutexTimeout() const noexcept;
+  uint32_t GetMutexTimeout() const noexcept;
 
   //==============================================================================
   // INITIALIZATION AND CONTROL
@@ -335,11 +334,11 @@ public:
   const BaseCan *GetImplementation() const noexcept;
 
 private:
-  std::unique_ptr<BaseCan> can_impl_;       ///< Underlying CAN implementation
-  std::atomic<bool> initialized_;           ///< Lock-free initialization flag
-  mutable std::shared_mutex rw_mutex_;      ///< Reader-writer mutex for thread safety
-  std::chrono::milliseconds mutex_timeout_; ///< Timeout for mutex operations
-  mutable ThreadingStats stats_;            ///< Threading performance statistics
+  std::unique_ptr<BaseCan> can_impl_; ///< Underlying CAN implementation
+  std::atomic<bool> initialized_;     ///< Lock-free initialization flag
+  mutable RtosSharedMutex rw_mutex_;  ///< Reader-writer mutex for thread safety
+  uint32_t mutex_timeout_ms_;         ///< Timeout for mutex operations in milliseconds
+  mutable ThreadingStats stats_;      ///< Threading performance statistics
 
   /**
    * @brief Update threading statistics.

--- a/inc/thread_safe/SfPwm.h
+++ b/inc/thread_safe/SfPwm.h
@@ -15,9 +15,9 @@
 #include "../base/BasePwm.h"
 #include "../mcu/McuPwm.h"
 #include "../mcu/McuTypes.h"
+#include "../utils/RtosMutex.h"
 #include <cstdint>
 #include <memory>
-#include <mutex>
 
 /**
  * @class SfPwm
@@ -437,7 +437,7 @@ private:
   //==============================================================================
 
   std::unique_ptr<BasePwm> pwm_impl_; ///< Underlying PWM implementation
-  mutable std::timed_mutex mutex_;    ///< Thread safety mutex
+  mutable RtosMutex mutex_;           ///< Thread safety mutex
   Config config_;                     ///< Configuration
   bool initialized_;                  ///< Initialization state
 

--- a/inc/utils/RtosMutex.h
+++ b/inc/utils/RtosMutex.h
@@ -1,21 +1,50 @@
-#ifndef HF_RTOS_MUTEX_H
-#define HF_RTOS_MUTEX_H
+#pragma once
 
-#include "../mcu/McuTypes.h"
+#include "../mcu/McuSelect.h"
+
+#ifdef HF_MCU_FAMILY_ESP32
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "freertos/task.h"
+#elif defined(HF_MCU_FAMILY_STM32)
+#include "FreeRTOS.h"
+#include "cmsis_os.h"
+#include "semphr.h"
+#include "task.h"
+#elif defined(HF_MCU_FAMILY_RP2040)
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+#else
+#error                                                                                             \
+    "RTOS mutex implementation not available for this MCU platform. Please add support in RtosMutex.h"
+#endif
 
-/**
- * @brief RAII wrapper around a FreeRTOS mutex handle with scoped lock support.
- */
+#include <atomic>
+#include <cstdint>
+
+class RtosTime {
+public:
+  static uint64_t GetCurrentTimeUs() noexcept {
+    return static_cast<uint64_t>(xTaskGetTickCount()) * 1000 / configTICK_RATE_HZ * 1000;
+  }
+
+  static TickType_t MsToTicks(uint32_t ms) noexcept {
+    if (ms == 0) {
+      return 0;
+    }
+    const TickType_t ticks = pdMS_TO_TICKS(ms);
+    return (ticks > 0) ? ticks : 1;
+  }
+};
+
 class RtosMutex {
 public:
   RtosMutex() noexcept : handle_(xSemaphoreCreateMutex()) {}
 
   ~RtosMutex() noexcept {
-    if (handle_ != nullptr) {
+    if (handle_) {
       vSemaphoreDelete(handle_);
-      handle_ = nullptr;
     }
   }
 
@@ -28,71 +57,320 @@ public:
 
   RtosMutex &operator=(RtosMutex &&other) noexcept {
     if (this != &other) {
-      if (handle_ != nullptr)
+      if (handle_) {
         vSemaphoreDelete(handle_);
+      }
       handle_ = other.handle_;
       other.handle_ = nullptr;
     }
     return *this;
   }
 
-  [[nodiscard]] hf_mutex_handle_t GetHandle() const noexcept {
-    return handle_;
+  bool lock() noexcept {
+    if (!handle_)
+      return false;
+    return xSemaphoreTake(handle_, portMAX_DELAY) == pdTRUE;
   }
 
-  bool Take(hf_timeout_ms_t timeout_ms = HF_TIMEOUT_DEFAULT) noexcept {
-    if (handle_ == nullptr)
+  bool try_lock() noexcept {
+    if (!handle_)
       return false;
-    TickType_t ticks = (timeout_ms == HF_TIMEOUT_NEVER) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
+    return xSemaphoreTake(handle_, 0) == pdTRUE;
+  }
+
+  bool try_lock_for(uint32_t timeout_ms) noexcept {
+    if (!handle_)
+      return false;
+    const TickType_t ticks = RtosTime::MsToTicks(timeout_ms);
     return xSemaphoreTake(handle_, ticks) == pdTRUE;
   }
 
-  void Give() noexcept {
-    if (handle_ != nullptr)
+  void unlock() noexcept {
+    if (handle_) {
       xSemaphoreGive(handle_);
+    }
   }
 
-  /**
-   * @brief Scoped lock guard using RAII to automatically release the mutex.
-   */
-  class LockGuard {
-  public:
-    explicit LockGuard(RtosMutex &m, hf_timeout_ms_t timeout_ms = HF_TIMEOUT_DEFAULT) noexcept
-        : mutex_(m), locked_(m.Take(timeout_ms)) {}
-
-    ~LockGuard() noexcept {
-      if (locked_)
-        mutex_.Give();
-    }
-
-    LockGuard(const LockGuard &) = delete;
-    LockGuard &operator=(const LockGuard &) = delete;
-
-    LockGuard(LockGuard &&other) noexcept : mutex_(other.mutex_), locked_(other.locked_) {
-      other.locked_ = false;
-    }
-    LockGuard &operator=(LockGuard &&other) noexcept {
-      if (this != &other) {
-        if (locked_)
-          mutex_.Give();
-        mutex_ = other.mutex_;
-        locked_ = other.locked_;
-        other.locked_ = false;
-      }
-      return *this;
-    }
-
-    [[nodiscard]] bool IsLocked() const noexcept {
-      return locked_;
-    }
-
-  private:
-    RtosMutex &mutex_;
-    bool locked_;
-  };
+  SemaphoreHandle_t native_handle() const noexcept {
+    return handle_;
+  }
 
 private:
-  hf_mutex_handle_t handle_;
+  SemaphoreHandle_t handle_;
 };
 
-#endif // HF_RTOS_MUTEX_H
+class RtosSharedMutex {
+public:
+  RtosSharedMutex() noexcept : readers_(0), writer_active_(false) {
+    writer_mutex_ = xSemaphoreCreateMutex();
+    reader_mutex_ = xSemaphoreCreateMutex();
+  }
+
+  ~RtosSharedMutex() noexcept {
+    if (writer_mutex_ != nullptr) {
+      vSemaphoreDelete(writer_mutex_);
+    }
+    if (reader_mutex_ != nullptr) {
+      vSemaphoreDelete(reader_mutex_);
+    }
+  }
+
+  RtosSharedMutex(const RtosSharedMutex &) = delete;
+  RtosSharedMutex &operator=(const RtosSharedMutex &) = delete;
+
+  RtosSharedMutex(RtosSharedMutex &&other) noexcept
+      : writer_mutex_(other.writer_mutex_), reader_mutex_(other.reader_mutex_),
+        readers_(other.readers_.load()), writer_active_(other.writer_active_.load()) {
+    other.writer_mutex_ = nullptr;
+    other.reader_mutex_ = nullptr;
+    other.readers_.store(0);
+    other.writer_active_.store(false);
+  }
+
+  RtosSharedMutex &operator=(RtosSharedMutex &&other) noexcept {
+    if (this != &other) {
+      if (writer_mutex_ != nullptr) {
+        vSemaphoreDelete(writer_mutex_);
+      }
+      if (reader_mutex_ != nullptr) {
+        vSemaphoreDelete(reader_mutex_);
+      }
+      writer_mutex_ = other.writer_mutex_;
+      reader_mutex_ = other.reader_mutex_;
+      readers_.store(other.readers_.load());
+      writer_active_.store(other.writer_active_.load());
+      other.writer_mutex_ = nullptr;
+      other.reader_mutex_ = nullptr;
+      other.readers_.store(0);
+      other.writer_active_.store(false);
+    }
+    return *this;
+  }
+
+  bool lock() noexcept {
+    if (xSemaphoreTake(writer_mutex_, portMAX_DELAY) != pdTRUE) {
+      return false;
+    }
+    writer_active_.store(true);
+    while (readers_.load() > 0) {
+      taskYIELD();
+    }
+    return true;
+  }
+
+  bool try_lock() noexcept {
+    if (xSemaphoreTake(writer_mutex_, 0) != pdTRUE) {
+      return false;
+    }
+    writer_active_.store(true);
+    if (readers_.load() > 0) {
+      writer_active_.store(false);
+      xSemaphoreGive(writer_mutex_);
+      return false;
+    }
+    return true;
+  }
+
+  bool try_lock_for(uint32_t timeout_ms) noexcept {
+    const TickType_t ticks = RtosTime::MsToTicks(timeout_ms);
+    const TickType_t start_time = xTaskGetTickCount();
+    if (xSemaphoreTake(writer_mutex_, ticks) != pdTRUE) {
+      return false;
+    }
+    writer_active_.store(true);
+    const TickType_t elapsed = xTaskGetTickCount() - start_time;
+    const TickType_t remaining = (elapsed < ticks) ? ticks - elapsed : 0;
+    const TickType_t reader_wait_end = xTaskGetTickCount() + remaining;
+    while (readers_.load() > 0) {
+      if (xTaskGetTickCount() >= reader_wait_end) {
+        writer_active_.store(false);
+        xSemaphoreGive(writer_mutex_);
+        return false;
+      }
+      taskYIELD();
+    }
+    return true;
+  }
+
+  void unlock() noexcept {
+    writer_active_.store(false);
+    xSemaphoreGive(writer_mutex_);
+  }
+
+  bool lock_shared() noexcept {
+    while (true) {
+      if (xSemaphoreTake(reader_mutex_, portMAX_DELAY) != pdTRUE) {
+        return false;
+      }
+      if (!writer_active_.load()) {
+        readers_++;
+        xSemaphoreGive(reader_mutex_);
+        return true;
+      }
+      xSemaphoreGive(reader_mutex_);
+      taskYIELD();
+    }
+  }
+
+  bool try_lock_shared() noexcept {
+    if (xSemaphoreTake(reader_mutex_, 0) != pdTRUE) {
+      return false;
+    }
+    if (!writer_active_.load()) {
+      readers_++;
+      xSemaphoreGive(reader_mutex_);
+      return true;
+    }
+    xSemaphoreGive(reader_mutex_);
+    return false;
+  }
+
+  bool try_lock_shared_for(uint32_t timeout_ms) noexcept {
+    const TickType_t ticks = RtosTime::MsToTicks(timeout_ms);
+    const TickType_t start_time = xTaskGetTickCount();
+    while (true) {
+      const TickType_t elapsed = xTaskGetTickCount() - start_time;
+      if (elapsed >= ticks) {
+        return false;
+      }
+      const TickType_t remaining = ticks - elapsed;
+      if (xSemaphoreTake(reader_mutex_, remaining) != pdTRUE) {
+        return false;
+      }
+      if (!writer_active_.load()) {
+        readers_++;
+        xSemaphoreGive(reader_mutex_);
+        return true;
+      }
+      xSemaphoreGive(reader_mutex_);
+      const TickType_t new_elapsed = xTaskGetTickCount() - start_time;
+      if (new_elapsed >= ticks) {
+        return false;
+      }
+      taskYIELD();
+    }
+  }
+
+  void unlock_shared() noexcept {
+    if (xSemaphoreTake(reader_mutex_, portMAX_DELAY) == pdTRUE) {
+      if (readers_.load() > 0) {
+        readers_--;
+      }
+      xSemaphoreGive(reader_mutex_);
+    }
+  }
+
+private:
+  SemaphoreHandle_t writer_mutex_;
+  SemaphoreHandle_t reader_mutex_;
+  std::atomic<int> readers_;
+  std::atomic<bool> writer_active_;
+};
+
+template <typename Mutex> class RtosUniqueLock {
+public:
+  explicit RtosUniqueLock(Mutex &mutex, uint32_t timeout_ms = 0) noexcept
+      : mutex_(&mutex), locked_(false) {
+    if (timeout_ms > 0) {
+      locked_ = mutex_->try_lock_for(timeout_ms);
+    } else {
+      locked_ = mutex_->lock();
+    }
+  }
+
+  ~RtosUniqueLock() noexcept {
+    if (locked_ && mutex_) {
+      mutex_->unlock();
+    }
+  }
+
+  RtosUniqueLock(const RtosUniqueLock &) = delete;
+  RtosUniqueLock &operator=(const RtosUniqueLock &) = delete;
+
+  RtosUniqueLock(RtosUniqueLock &&other) noexcept : mutex_(other.mutex_), locked_(other.locked_) {
+    other.mutex_ = nullptr;
+    other.locked_ = false;
+  }
+
+  RtosUniqueLock &operator=(RtosUniqueLock &&other) noexcept {
+    if (this != &other) {
+      if (locked_ && mutex_) {
+        mutex_->unlock();
+      }
+      mutex_ = other.mutex_;
+      locked_ = other.locked_;
+      other.mutex_ = nullptr;
+      other.locked_ = false;
+    }
+    return *this;
+  }
+
+  [[nodiscard]] bool IsLocked() const noexcept {
+    return locked_;
+  }
+
+  void Unlock() noexcept {
+    if (locked_ && mutex_) {
+      mutex_->unlock();
+      locked_ = false;
+    }
+  }
+
+private:
+  Mutex *mutex_;
+  bool locked_;
+};
+
+template <typename SharedMutex> class RtosSharedLock {
+public:
+  explicit RtosSharedLock(SharedMutex &mutex, uint32_t timeout_ms = 0) noexcept
+      : mutex_(&mutex), locked_(false) {
+    if (timeout_ms > 0) {
+      locked_ = mutex_->try_lock_shared_for(timeout_ms);
+    } else {
+      locked_ = mutex_->lock_shared();
+    }
+  }
+
+  ~RtosSharedLock() noexcept {
+    if (locked_ && mutex_) {
+      mutex_->unlock_shared();
+    }
+  }
+
+  RtosSharedLock(const RtosSharedLock &) = delete;
+  RtosSharedLock &operator=(const RtosSharedLock &) = delete;
+
+  RtosSharedLock(RtosSharedLock &&other) noexcept : mutex_(other.mutex_), locked_(other.locked_) {
+    other.mutex_ = nullptr;
+    other.locked_ = false;
+  }
+
+  RtosSharedLock &operator=(RtosSharedLock &&other) noexcept {
+    if (this != &other) {
+      if (locked_ && mutex_) {
+        mutex_->unlock_shared();
+      }
+      mutex_ = other.mutex_;
+      locked_ = other.locked_;
+      other.mutex_ = nullptr;
+      other.locked_ = false;
+    }
+    return *this;
+  }
+
+  [[nodiscard]] bool IsLocked() const noexcept {
+    return locked_;
+  }
+
+  void Unlock() noexcept {
+    if (locked_ && mutex_) {
+      mutex_->unlock_shared();
+      locked_ = false;
+    }
+  }
+
+private:
+  SharedMutex *mutex_;
+  bool locked_;
+};

--- a/src/mcu/McuCan.cpp
+++ b/src/mcu/McuCan.cpp
@@ -70,7 +70,7 @@ bool McuCan::Stop() noexcept {
 //==============================================================================
 
 bool McuCan::SendMessage(const CanMessage &message, uint32_t timeout_ms) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;
@@ -80,7 +80,7 @@ bool McuCan::SendMessage(const CanMessage &message, uint32_t timeout_ms) noexcep
 }
 
 bool McuCan::ReceiveMessage(CanMessage &message, uint32_t timeout_ms) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;
@@ -94,7 +94,7 @@ bool McuCan::ReceiveMessage(CanMessage &message, uint32_t timeout_ms) noexcept {
 //==============================================================================
 
 bool McuCan::SetReceiveCallback(CanReceiveCallback callback) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;
@@ -105,7 +105,7 @@ bool McuCan::SetReceiveCallback(CanReceiveCallback callback) noexcept {
 }
 
 void McuCan::ClearReceiveCallback() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
   receive_callback_ = nullptr;
 }
 
@@ -114,7 +114,7 @@ void McuCan::ClearReceiveCallback() noexcept {
 //==============================================================================
 
 bool McuCan::GetStatus(CanBusStatus &status) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;
@@ -124,7 +124,7 @@ bool McuCan::GetStatus(CanBusStatus &status) noexcept {
 }
 
 bool McuCan::Reset() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;
@@ -134,7 +134,7 @@ bool McuCan::Reset() noexcept {
 }
 
 bool McuCan::IsTransmitQueueFull() const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return true;
@@ -144,7 +144,7 @@ bool McuCan::IsTransmitQueueFull() const noexcept {
 }
 
 bool McuCan::IsReceiveQueueEmpty() const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return true;
@@ -154,7 +154,7 @@ bool McuCan::IsReceiveQueueEmpty() const noexcept {
 }
 
 uint32_t McuCan::GetTransmitErrorCount() const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return 0;
@@ -164,7 +164,7 @@ uint32_t McuCan::GetTransmitErrorCount() const noexcept {
 }
 
 uint32_t McuCan::GetReceiveErrorCount() const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return 0;
@@ -178,7 +178,7 @@ uint32_t McuCan::GetReceiveErrorCount() const noexcept {
 //==============================================================================
 
 bool McuCan::SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;
@@ -188,7 +188,7 @@ bool McuCan::SetAcceptanceFilter(uint32_t id, uint32_t mask, bool extended) noex
 }
 
 bool McuCan::ClearAcceptanceFilter() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return false;

--- a/src/mcu/McuI2c.cpp
+++ b/src/mcu/McuI2c.cpp
@@ -35,7 +35,7 @@ bool McuI2c::Initialize() noexcept {
     return true;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   // Validate configuration
   if (config_.sda_pin == HF_GPIO_INVALID || config_.scl_pin == HF_GPIO_INVALID) {
@@ -62,7 +62,7 @@ bool McuI2c::Deinitialize() noexcept {
     return true;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   bool result = PlatformDeinitialize();
   if (result) {
@@ -86,7 +86,7 @@ HfI2cErr McuI2c::Write(uint8_t device_addr, const uint8_t *data, uint16_t length
     return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   esp_err_t err;
@@ -143,7 +143,7 @@ HfI2cErr McuI2c::Read(uint8_t device_addr, uint8_t *data, uint16_t length,
     return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   esp_err_t err;
@@ -201,7 +201,7 @@ HfI2cErr McuI2c::WriteRead(uint8_t device_addr, const uint8_t *tx_data, uint16_t
     return HfI2cErr::I2C_ERR_INVALID_ADDRESS;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   esp_err_t err;
@@ -283,7 +283,7 @@ bool McuI2c::ResetBus() noexcept {
     return false;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   // Reset I2C bus by deinitializing and reinitializing

--- a/src/mcu/McuPio.cpp
+++ b/src/mcu/McuPio.cpp
@@ -53,7 +53,7 @@ McuPio::~McuPio() noexcept {
 //==============================================================================
 
 HfPioErr McuPio::Initialize() noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (initialized_) {
     ESP_LOGW(TAG, "Already initialized");
@@ -76,7 +76,7 @@ HfPioErr McuPio::Initialize() noexcept {
 }
 
 HfPioErr McuPio::Deinitialize() noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -101,7 +101,7 @@ HfPioErr McuPio::Deinitialize() noexcept {
 }
 
 bool McuPio::IsInitialized() const noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
   return initialized_;
 }
 
@@ -110,7 +110,7 @@ bool McuPio::IsInitialized() const noexcept {
 //==============================================================================
 
 HfPioErr McuPio::ConfigureChannel(uint8_t channel_id, const PioChannelConfig &config) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -154,7 +154,7 @@ HfPioErr McuPio::ConfigureChannel(uint8_t channel_id, const PioChannelConfig &co
 
 HfPioErr McuPio::Transmit(uint8_t channel_id, const PioSymbol *symbols, size_t symbol_count,
                           bool wait_completion) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -266,7 +266,7 @@ HfPioErr McuPio::Transmit(uint8_t channel_id, const PioSymbol *symbols, size_t s
 
 HfPioErr McuPio::StartReceive(uint8_t channel_id, PioSymbol *buffer, size_t buffer_size,
                               uint32_t timeout_us) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -348,7 +348,7 @@ HfPioErr McuPio::StartReceive(uint8_t channel_id, PioSymbol *buffer, size_t buff
 }
 
 HfPioErr McuPio::StopReceive(uint8_t channel_id, size_t &symbols_received) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -385,7 +385,7 @@ HfPioErr McuPio::StopReceive(uint8_t channel_id, size_t &symbols_received) noexc
 //==============================================================================
 
 bool McuPio::IsChannelBusy(uint8_t channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return false;
@@ -395,7 +395,7 @@ bool McuPio::IsChannelBusy(uint8_t channel_id) const noexcept {
 }
 
 HfPioErr McuPio::GetChannelStatus(uint8_t channel_id, PioChannelStatus &status) const noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return HfPioErr::PIO_ERR_INVALID_CHANNEL;
@@ -426,25 +426,25 @@ HfPioErr McuPio::GetCapabilities(PioCapabilities &capabilities) const noexcept {
 //==============================================================================
 
 void McuPio::SetTransmitCallback(PioTransmitCallback callback, void *user_data) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
   transmit_callback_ = callback;
   callback_user_data_ = user_data;
 }
 
 void McuPio::SetReceiveCallback(PioReceiveCallback callback, void *user_data) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
   receive_callback_ = callback;
   callback_user_data_ = user_data;
 }
 
 void McuPio::SetErrorCallback(PioErrorCallback callback, void *user_data) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
   error_callback_ = callback;
   callback_user_data_ = user_data;
 }
 
 void McuPio::ClearCallbacks() noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
   transmit_callback_ = nullptr;
   receive_callback_ = nullptr;
   error_callback_ = nullptr;
@@ -457,7 +457,7 @@ void McuPio::ClearCallbacks() noexcept {
 
 HfPioErr McuPio::ConfigureCarrier(uint8_t channel_id, uint32_t carrier_freq_hz,
                                   float duty_cycle) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return HfPioErr::PIO_ERR_INVALID_CHANNEL;
@@ -500,7 +500,7 @@ HfPioErr McuPio::ConfigureCarrier(uint8_t channel_id, uint32_t carrier_freq_hz,
 }
 
 HfPioErr McuPio::EnableLoopback(uint8_t channel_id, bool enable) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return HfPioErr::PIO_ERR_INVALID_CHANNEL;
@@ -525,7 +525,7 @@ size_t McuPio::GetMaxSymbolCount() const noexcept {
 
 HfPioErr McuPio::TransmitRawRmtSymbols(uint8_t channel_id, const rmt_symbol_word_t *rmt_symbols,
                                        size_t symbol_count, bool wait_completion) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -599,7 +599,7 @@ HfPioErr McuPio::TransmitRawRmtSymbols(uint8_t channel_id, const rmt_symbol_word
 HfPioErr McuPio::ReceiveRawRmtSymbols(uint8_t channel_id, rmt_symbol_word_t *rmt_buffer,
                                       size_t buffer_size, size_t &symbols_received,
                                       uint32_t timeout_us) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -664,7 +664,7 @@ HfPioErr McuPio::ReceiveRawRmtSymbols(uint8_t channel_id, rmt_symbol_word_t *rmt
 
 HfPioErr McuPio::CreateWS2812Encoder(uint8_t channel_id, uint32_t resolution_hz, uint32_t t0h_ns,
                                      uint32_t t0l_ns, uint32_t t1h_ns, uint32_t t1l_ns) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return HfPioErr::PIO_ERR_INVALID_CHANNEL;
@@ -712,7 +712,7 @@ HfPioErr McuPio::CreateWS2812Encoder(uint8_t channel_id, uint32_t resolution_hz,
 
 HfPioErr McuPio::TransmitWS2812(uint8_t channel_id, const uint8_t *grb_data, size_t length,
                                 bool wait_completion) noexcept {
-  std::lock_guard<std::mutex> lock(state_mutex_);
+  RtosUniqueLock<RtosMutex> lock(state_mutex_);
 
   if (!initialized_) {
     return HfPioErr::PIO_ERR_NOT_INITIALIZED;
@@ -855,7 +855,7 @@ bool McuPio::OnTransmitComplete(rmt_channel_handle_t *channel,
   // Find the channel ID by comparing channel handles
   for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
     if (instance->channels_[i].tx_channel == channel) {
-      std::lock_guard<std::mutex> lock(instance->state_mutex_);
+      RtosUniqueLock<RtosMutex> lock(instance->state_mutex_);
 
       auto &ch = instance->channels_[i];
       ch.busy = false;
@@ -885,7 +885,7 @@ bool McuPio::OnReceiveComplete(rmt_channel_handle_t *channel, const rmt_rx_done_
   // Find the channel ID by comparing channel handles
   for (uint8_t i = 0; i < MAX_CHANNELS; ++i) {
     if (instance->channels_[i].rx_channel == channel) {
-      std::lock_guard<std::mutex> lock(instance->state_mutex_);
+      RtosUniqueLock<RtosMutex> lock(instance->state_mutex_);
 
       auto &ch = instance->channels_[i];
 

--- a/src/mcu/McuPwm.cpp
+++ b/src/mcu/McuPwm.cpp
@@ -8,7 +8,6 @@
  */
 #include "McuPwm.h"
 #include <algorithm>
-#include <chrono>
 
 // Platform-specific includes and definitions
 #ifdef HF_MCU_FAMILY_ESP32
@@ -36,7 +35,7 @@ McuPwm::McuPwm(uint32_t base_clock_hz) noexcept
 }
 
 McuPwm::~McuPwm() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
   if (initialized_) {
     ESP_LOGI(TAG, "McuPwm destructor - cleaning up");
     Deinitialize();
@@ -48,7 +47,7 @@ McuPwm::~McuPwm() noexcept {
 //==============================================================================
 
 HfPwmErr McuPwm::Initialize() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (initialized_) {
     ESP_LOGW(TAG, "PWM already initialized");
@@ -86,7 +85,7 @@ HfPwmErr McuPwm::Initialize() noexcept {
 }
 
 HfPwmErr McuPwm::Deinitialize() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -119,7 +118,7 @@ HfPwmErr McuPwm::Deinitialize() noexcept {
 }
 
 bool McuPwm::IsInitialized() const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
   return initialized_;
 }
 
@@ -128,7 +127,7 @@ bool McuPwm::IsInitialized() const noexcept {
 //==============================================================================
 
 HfPwmErr McuPwm::ConfigureChannel(HfChannelId channel_id, const PwmChannelConfig &config) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -191,7 +190,7 @@ HfPwmErr McuPwm::ConfigureChannel(HfChannelId channel_id, const PwmChannelConfig
 }
 
 HfPwmErr McuPwm::EnableChannel(HfChannelId channel_id) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -228,7 +227,7 @@ HfPwmErr McuPwm::EnableChannel(HfChannelId channel_id) noexcept {
 }
 
 HfPwmErr McuPwm::DisableChannel(HfChannelId channel_id) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -260,7 +259,7 @@ HfPwmErr McuPwm::DisableChannel(HfChannelId channel_id) noexcept {
 }
 
 bool McuPwm::IsChannelEnabled(HfChannelId channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
     return false;
@@ -316,7 +315,7 @@ return HfPwmErr::PWM_SUCCESS;
 }
 
 HfPwmErr McuPwm::EnableChannel(uint8_t channel_id) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -359,7 +358,7 @@ HfPwmErr McuPwm::EnableChannel(uint8_t channel_id) noexcept {
 }
 
 HfPwmErr McuPwm::DisableChannel(uint8_t channel_id) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -399,7 +398,7 @@ HfPwmErr McuPwm::DisableChannel(uint8_t channel_id) noexcept {
 }
 
 bool McuPwm::IsChannelEnabled(uint8_t channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
     return false;
@@ -413,7 +412,7 @@ bool McuPwm::IsChannelEnabled(uint8_t channel_id) const noexcept {
 //==============================================================================
 
 HfPwmErr McuPwm::SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -439,7 +438,7 @@ HfPwmErr McuPwm::SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept
 }
 
 HfPwmErr McuPwm::SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -476,7 +475,7 @@ HfPwmErr McuPwm::SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noe
 }
 
 HfPwmErr McuPwm::SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -531,7 +530,7 @@ HfPwmErr McuPwm::SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz
 }
 
 HfPwmErr McuPwm::SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -553,7 +552,7 @@ HfPwmErr McuPwm::SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees
 //==============================================================================
 
 HfPwmErr McuPwm::StartAll() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -574,7 +573,7 @@ HfPwmErr McuPwm::StartAll() noexcept {
 }
 
 HfPwmErr McuPwm::StopAll() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -595,7 +594,7 @@ HfPwmErr McuPwm::StopAll() noexcept {
 }
 
 HfPwmErr McuPwm::UpdateAll() noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -624,7 +623,7 @@ HfPwmErr McuPwm::UpdateAll() noexcept {
 HfPwmErr McuPwm::SetComplementaryOutput(HfChannelId primary_channel,
                                         HfChannelId complementary_channel,
                                         uint32_t deadtime_ns) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -664,7 +663,7 @@ HfPwmErr McuPwm::SetComplementaryOutput(HfChannelId primary_channel,
 //==============================================================================
 
 float McuPwm::GetDutyCycle(HfChannelId channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
     return -1.0f;
@@ -675,7 +674,7 @@ float McuPwm::GetDutyCycle(HfChannelId channel_id) const noexcept {
 }
 
 HfFrequencyHz McuPwm::GetFrequency(HfChannelId channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
     return 0;
@@ -685,7 +684,7 @@ HfFrequencyHz McuPwm::GetFrequency(HfChannelId channel_id) const noexcept {
 }
 
 HfPwmErr McuPwm::GetChannelStatus(HfChannelId channel_id, PwmChannelStatus &status) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
@@ -723,7 +722,7 @@ HfPwmErr McuPwm::GetCapabilities(PwmCapabilities &capabilities) const noexcept {
 }
 
 HfPwmErr McuPwm::GetLastError(HfChannelId channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id)) {
     return HfPwmErr::PWM_ERR_INVALID_CHANNEL;
@@ -737,13 +736,13 @@ HfPwmErr McuPwm::GetLastError(HfChannelId channel_id) const noexcept {
 //==============================================================================
 
 void McuPwm::SetPeriodCallback(PwmPeriodCallback callback, void *user_data) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
   period_callback_ = callback;
   period_callback_user_data_ = user_data;
 }
 
 void McuPwm::SetFaultCallback(PwmFaultCallback callback, void *user_data) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
   fault_callback_ = callback;
   fault_callback_user_data_ = user_data;
 }
@@ -754,7 +753,7 @@ void McuPwm::SetFaultCallback(PwmFaultCallback callback, void *user_data) noexce
 
 HfPwmErr McuPwm::SetHardwareFade(HfChannelId channel_id, float target_duty_cycle,
                                  uint32_t fade_time_ms) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -812,7 +811,7 @@ HfPwmErr McuPwm::SetHardwareFade(HfChannelId channel_id, float target_duty_cycle
 }
 
 HfPwmErr McuPwm::StopHardwareFade(HfChannelId channel_id) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -845,7 +844,7 @@ HfPwmErr McuPwm::StopHardwareFade(HfChannelId channel_id) noexcept {
 }
 
 bool McuPwm::IsFadeActive(HfChannelId channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
     return false;
@@ -855,7 +854,7 @@ bool McuPwm::IsFadeActive(HfChannelId channel_id) const noexcept {
 }
 
 HfPwmErr McuPwm::SetIdleLevel(HfChannelId channel_id, uint8_t idle_level) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;
@@ -892,7 +891,7 @@ HfPwmErr McuPwm::SetIdleLevel(HfChannelId channel_id, uint8_t idle_level) noexce
 }
 
 int8_t McuPwm::GetTimerAssignment(HfChannelId channel_id) const noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!IsValidChannelId(channel_id) || !channels_[channel_id].configured) {
     return -1;
@@ -902,7 +901,7 @@ int8_t McuPwm::GetTimerAssignment(HfChannelId channel_id) const noexcept {
 }
 
 HfPwmErr McuPwm::ForceTimerAssignment(HfChannelId channel_id, uint8_t timer_id) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   if (!initialized_) {
     return HfPwmErr::PWM_ERR_NOT_INITIALIZED;

--- a/src/mcu/McuSpi.cpp
+++ b/src/mcu/McuSpi.cpp
@@ -39,7 +39,7 @@ bool McuSpi::Initialize() noexcept {
     return true;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   // Validate configuration
   if (config_.mosi_pin == HF_GPIO_INVALID && config_.miso_pin == HF_GPIO_INVALID) {
@@ -76,7 +76,7 @@ bool McuSpi::Deinitialize() noexcept {
     return true;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   bool result = PlatformDeinitialize();
   if (result) {
@@ -108,7 +108,7 @@ HfSpiErr McuSpi::SetChipSelect(bool active) noexcept {
     return HfSpiErr::SPI_ERR_NOT_INITIALIZED;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   if (config_.cs_pin != HF_GPIO_INVALID) {
@@ -392,7 +392,7 @@ bool McuSpi::PlatformDeinitialize() noexcept {
 
 HfSpiErr McuSpi::InternalTransfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
                                   uint32_t timeout_ms, bool manage_cs) noexcept {
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   // Configure device for this transfer

--- a/src/mcu/McuUart.cpp
+++ b/src/mcu/McuUart.cpp
@@ -41,7 +41,7 @@ bool McuUart::Initialize() noexcept {
     return true;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   // Validate configuration
   if (!IsValidBaudRate(config_.baud_rate)) {
@@ -83,7 +83,7 @@ bool McuUart::Deinitialize() noexcept {
     return true;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
   bool result = PlatformDeinitialize();
   if (result) {
@@ -106,7 +106,7 @@ HfUartErr McuUart::Write(const uint8_t *data, uint16_t length, uint32_t timeout_
     return HfUartErr::UART_SUCCESS;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   uint32_t timeout = GetTimeoutMs(timeout_ms);
@@ -151,7 +151,7 @@ HfUartErr McuUart::Read(uint8_t *data, uint16_t length, uint32_t timeout_ms) noe
     return HfUartErr::UART_ERR_INVALID_PARAMETER;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  RtosUniqueLock<RtosMutex> lock(mutex_);
 
 #ifdef HF_MCU_FAMILY_ESP32
   uint32_t timeout = GetTimeoutMs(timeout_ms);


### PR DESCRIPTION
## Summary
- implement RTOS-based mutex/lock utilities
- enable optional thread-safety flag in `McuSelect`
- replace use of `std::mutex` across MCU and thread-safe drivers
- update mutex logic in SfCan, SfPwm and SfAdc

## Testing
- `clang-format -i inc/mcu/McuCan.h inc/mcu/McuI2c.h inc/mcu/McuPio.h inc/mcu/McuPwm.h inc/mcu/McuSelect.h inc/mcu/McuSpi.h inc/mcu/McuUart.h inc/thread_safe/SfAdc.h inc/thread_safe/SfCan.h inc/thread_safe/SfPwm.h inc/utils/RtosMutex.h src/mcu/McuCan.cpp src/mcu/McuI2c.cpp src/mcu/McuPio.cpp src/mcu/McuPwm.cpp src/mcu/McuSpi.cpp src/mcu/McuUart.cpp src/thread_safe/SfAdc.cpp src/thread_safe/SfCan.cpp src/thread_safe/SfPwm.cpp`