### PR TITLE
Add RAII mutex usage for SfGpio

### DIFF
--- a/inc/thread_safe/SfGpio.h
+++ b/inc/thread_safe/SfGpio.h
@@ -12,8 +12,7 @@
 
 #include "../base/BaseGpio.h"
 #include "../mcu/McuTypes.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/semphr.h"
+#include "../utils/RtosMutex.h"
 #include <memory>
 
 namespace HardFOC {
@@ -180,32 +179,10 @@ public:
 
 private:
   std::shared_ptr<BaseGpio> gpio_impl_; ///< Wrapped GPIO implementation
-  hf_mutex_handle_t mutex_;             ///< Mutex for thread safety
+  mutable RtosMutex mutex_;             ///< Mutex for thread safety
+  bool initialized_;                    ///< Initialization state
 
-  /**
-   * @brief Initialize mutex.
-   *
-   * @return bool true on success, false on failure
-   */
-  bool initializeMutex();
-
-  /**
-   * @brief Cleanup mutex.
-   */
-  void cleanupMutex();
-
-  /**
-   * @brief Lock mutex with timeout.
-   *
-   * @param timeout_ms Timeout in milliseconds
-   * @return bool true if locked, false on timeout
-   */
-  bool lockMutex(hf_timeout_ms_t timeout_ms = HF_TIMEOUT_DEFAULT);
-
-  /**
-   * @brief Unlock mutex.
-   */
-  void unlockMutex();
+  // No explicit lock/unlock helpers needed with RtosMutex
 };
 
 } // namespace ThreadSafe

--- a/inc/utils/RtosMutex.h
+++ b/inc/utils/RtosMutex.h
@@ -95,6 +95,20 @@ public:
     return handle_;
   }
 
+  // Convenience FreeRTOS-style API -------------------------------------------------
+  using LockGuard = RtosUniqueLock<RtosMutex>;
+
+  bool Take(uint32_t timeout_ms = 0) noexcept {
+    if (timeout_ms > 0) {
+      return try_lock_for(timeout_ms);
+    }
+    return lock();
+  }
+
+  void Give() noexcept {
+    unlock();
+  }
+
 private:
   SemaphoreHandle_t handle_;
 };


### PR DESCRIPTION
## Summary
- refactor `SfGpio` to use `RtosMutex` and LockGuard RAII helpers
- update `SfGpio` header to hold `RtosMutex`