### PR TITLE
Replace std mutex usage

### DIFF
--- a/inc/mcu/McuAdc.h
+++ b/inc/mcu/McuAdc.h
@@ -13,6 +13,7 @@
 #ifndef MCU_ADC_H_
 #define MCU_ADC_H_
 
+#include "../utils/RtosMutex.h"
 #include "BaseAdc.h"
 #include "McuTypes.h"
 #include <cstdint>
@@ -655,7 +656,7 @@ private:
   AdcCalibrationConfig calibration_config_;       ///< Calibration configuration
 
   // State management
-  mutable std::mutex mutex_;        ///< Thread synchronization mutex
+  mutable RtosMutex mutex_;         ///< Thread synchronization mutex
   bool continuous_running_;         ///< Continuous mode status
   bool triggered_sampling_;         ///< Triggered sampling status
   AdcPowerMode current_power_mode_; ///< Current power mode

--- a/inc/thread_safe/SfAdc.h
+++ b/inc/thread_safe/SfAdc.h
@@ -280,11 +280,11 @@ private:
   // PRIVATE MEMBERS
   //==============================================================================
 
-  std::unique_ptr<BaseAdc> adc_impl_;  ///< Wrapped ADC implementation
-  mutable std::shared_mutex rw_mutex_; ///< Reader-writer mutex
-  std::atomic<bool> initialized_;      ///< Atomic initialization flag
-  uint32_t mutex_timeout_ms_;          ///< Mutex acquisition timeout in milliseconds
-  mutable ThreadingStats stats_;       ///< Threading statistics
+  std::unique_ptr<BaseAdc> adc_impl_; ///< Wrapped ADC implementation
+  mutable RtosSharedMutex rw_mutex_;  ///< Reader-writer mutex
+  std::atomic<bool> initialized_;     ///< Atomic initialization flag
+  uint32_t mutex_timeout_ms_;         ///< Mutex acquisition timeout in milliseconds
+  mutable ThreadingStats stats_;      ///< Threading statistics
 
   //==============================================================================
   // PRIVATE HELPER METHODS

--- a/src/mcu/McuCan.cpp
+++ b/src/mcu/McuCan.cpp
@@ -9,7 +9,6 @@
  */
 #include "McuCan.h"
 #include <algorithm>
-#include <mutex>
 
 //==============================================================================
 // CONSTRUCTOR AND DESTRUCTOR

--- a/src/thread_safe/SfAdc.cpp
+++ b/src/thread_safe/SfAdc.cpp
@@ -44,7 +44,7 @@ SfAdc::~SfAdc() noexcept {
 //==============================================================================
 
 HfAdcErr SfAdc::Initialize() noexcept {
-  RtosUniqueLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosUniqueLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked()) {
     stats_.timeout_count_.fetch_add(1);
     return HfAdcErr::ADC_ERR_TIMEOUT;
@@ -68,7 +68,7 @@ HfAdcErr SfAdc::Initialize() noexcept {
 }
 
 HfAdcErr SfAdc::Deinitialize() noexcept {
-  RtosUniqueLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosUniqueLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked()) {
     stats_.timeout_count_.fetch_add(1);
     return HfAdcErr::ADC_ERR_TIMEOUT;
@@ -97,7 +97,7 @@ HfAdcErr SfAdc::Deinitialize() noexcept {
 
 HfAdcErr SfAdc::ConfigureChannel(hf_adc_channel_t channel,
                                  const AdcChannelConfig &config) noexcept {
-  RtosUniqueLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosUniqueLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked()) {
     stats_.timeout_count_.fetch_add(1);
     return HfAdcErr::ADC_ERR_TIMEOUT;
@@ -116,7 +116,7 @@ HfAdcErr SfAdc::ConfigureChannel(hf_adc_channel_t channel,
 }
 
 HfAdcErr SfAdc::ReadChannel(hf_adc_channel_t channel, uint32_t &raw_value) noexcept {
-  RtosSharedLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosSharedLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked()) {
     stats_.timeout_count_.fetch_add(1);
     return HfAdcErr::ADC_ERR_TIMEOUT;
@@ -135,7 +135,7 @@ HfAdcErr SfAdc::ReadChannel(hf_adc_channel_t channel, uint32_t &raw_value) noexc
 }
 
 HfAdcErr SfAdc::ReadChannelVoltage(hf_adc_channel_t channel, float &voltage_v) noexcept {
-  RtosSharedLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosSharedLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked()) {
     stats_.timeout_count_.fetch_add(1);
     return HfAdcErr::ADC_ERR_TIMEOUT;
@@ -186,7 +186,7 @@ HfAdcErr SfAdc::ReadMultipleChannels(const hf_adc_channel_t *channels, uint32_t 
     return HfAdcErr::ADC_ERR_INVALID_PARAMETER;
   }
 
-  RtosSharedLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosSharedLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked()) {
     stats_.timeout_count_.fetch_add(1);
     return HfAdcErr::ADC_ERR_TIMEOUT;
@@ -228,7 +228,7 @@ const char *SfAdc::GetErrorString(HfAdcErr error) const noexcept {
 }
 
 uint8_t SfAdc::GetMaxChannels() const noexcept {
-  RtosSharedLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosSharedLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked() || !adc_impl_) {
     return 0;
   }
@@ -237,7 +237,7 @@ uint8_t SfAdc::GetMaxChannels() const noexcept {
 }
 
 bool SfAdc::IsChannelConfigured(hf_adc_channel_t channel) const noexcept {
-  RtosSharedLock<RtosSharedMutex> lock(mutex_, mutex_timeout_ms_);
+  RtosSharedLock<RtosSharedMutex> lock(rw_mutex_, mutex_timeout_ms_);
   if (!lock.IsLocked() || !adc_impl_) {
     return false;
   }


### PR DESCRIPTION
## Summary
- remove unused `<mutex>` include from `McuCan.cpp`
- use `RtosMutex` in `McuAdc`
- switch `SfAdc` to `RtosSharedMutex` and update implementation
