### PR TITLE
Fix docs to reflect RtosMutex usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This component provides a truly platform-agnostic hardware abstraction layer. Al
 - **No Conditional Compilation**: Interface classes are clean and portable
 - **Layered CAN Stack**: CanBus → FlexCan → SfCan with proper abstraction
 - **Legacy Compatibility**: Preserved useful utility functions like `IsActiveHigh()`
-- **Thread-Safe Variants**: Built-in thread safety. Most wrappers use `std::mutex`, while `SfGpio` manages its own FreeRTOS semaphore internally.
+- **Thread-Safe Variants**: Built-in thread safety using `RtosMutex`. `SfGpio` manages its own FreeRTOS semaphore internally.
 
 Each abstraction is intentionally compact and header-focused where possible. Create an object, call `Open()` or `Start()` and off you go. All the platform-specific ceremony is performed behind the scenes so your code stays compact and portable between MCU families.
 
@@ -27,7 +27,7 @@ Each abstraction is intentionally compact and header-focused where possible. Cre
 - **CAN Stack**: `CanBus` (platform-agnostic) → `FlexCan` (compatibility) → `SfCan` (thread-safe)
 - **ADC**: `McuAdc` with legacy functions like `ReadVoltage()`, `ReadAveraged()`
 - **PWM**: `PwmOutput` with utilities like `SetDutyPercent()`, `GenerateSquareWave()`
-- **Thread-Safe Variants**: `SfI2cBus`, `SfSpiBus`, `SfUartDriver`, `SfCan` use `std::mutex`; `SfGpio` uses an internal FreeRTOS semaphore
+- **Thread-Safe Variants**: `SfI2cBus`, `SfSpiBus`, `SfUartDriver`, `SfCan` use `RtosMutex`; `SfGpio` uses an internal FreeRTOS semaphore
 - **Timers**: `PeriodicTimer` with platform-agnostic callback support
 - **Storage**: `NvsStorage` for non-volatile key-value storage
 

--- a/docs/examples/sensor-hub.md
+++ b/docs/examples/sensor-hub.md
@@ -10,10 +10,10 @@ Collect data from multiple sensors using thread-safe wrappers.
 ```cpp
 #include "SfI2cBus.h"
 #include "SfUartDriver.h"
-#include <mutex>
+#include "RtosMutex.h"
 
-std::mutex i2c_mutex;
-std::mutex uart_mutex;
+RtosMutex i2c_mutex;
+RtosMutex uart_mutex;
 SfI2cBus i2c(0, 400000, i2c_mutex);
 SfUartDriver uart(1, {115200, HF_UART_DATA_8_BITS, HF_UART_PARITY_DISABLE, HF_UART_STOP_BITS_1, HF_UART_HW_FLOWCTRL_DISABLE}, HF_GPIO_NUM_1, HF_GPIO_NUM_3, uart_mutex);
 

--- a/docs/guides/DeveloperGuide.md
+++ b/docs/guides/DeveloperGuide.md
@@ -428,12 +428,12 @@ public:
 // Good: Explicit thread safety where needed
 class ThreadSafeHardwareManager {
 private:
-    mutable std::mutex hardware_mutex_;
+    mutable RtosMutex hardware_mutex_;
     std::map<int, std::shared_ptr<SfGpio>> gpio_map_;
     
 public:
     std::shared_ptr<SfGpio> GetGpio(int pin) {
-        std::lock_guard<std::mutex> lock(hardware_mutex_);
+        RtosMutex::LockGuard lock(hardware_mutex_);
         
         auto it = gpio_map_.find(pin);
         if (it != gpio_map_.end()) {

--- a/docs/guides/thread-safety.md
+++ b/docs/guides/thread-safety.md
@@ -26,8 +26,8 @@ Classes like `DigitalOutputGuard` temporarily change pin state and restore it wh
 Refer to the [Developer Guide](DeveloperGuide.md) for more advanced multi-threading patterns.
 
 ## 🧰 Choosing a Mutex Type
-- Use `std::mutex` for standard use cases
-- `std::recursive_mutex` may be necessary for nested locking
+- Use `RtosMutex` for standard mutex protection
+- `RtosSharedMutex` allows shared reader access when needed
 
 ## 🛠️ Troubleshooting
 - Deadlocks often indicate inconsistent lock order


### PR DESCRIPTION
## Summary
- update README and docs to describe RtosMutex usage instead of std::mutex
- update thread safety guide and developer guide examples
- adjust sensor hub example to include RtosMutex

## Testing
- `python3 docs/check_docs.py README.md docs/guides/DeveloperGuide.md docs/guides/thread-safety.md docs/examples/sensor-hub.md`

------
https://chatgpt.com/codex/tasks/task_e_685f64569f64832880c216509c103cfc