### PR TITLE
Apply clang-format to McuTypes

### DIFF
--- a/inc/mcu/McuTypes.h
+++ b/inc/mcu/McuTypes.h
@@ -193,14 +193,14 @@ using hf_can_message_id_t = uint32_t; ///< CAN message ID
 using hf_i2c_address_t = uint8_t;     ///< I2C device address
 
 // Low-level driver configuration structures
-using hf_i2c_config_t = i2c_config_t;                       ///< I2C config
-using hf_spi_bus_config_t = spi_bus_config_t;               ///< SPI bus config
+using hf_i2c_config_t = i2c_config_t;                         ///< I2C config
+using hf_spi_bus_config_t = spi_bus_config_t;                 ///< SPI bus config
 using hf_spi_device_config_t = spi_device_interface_config_t; ///< SPI device config
-using hf_uart_config_t = uart_config_t;                     ///< UART config
+using hf_uart_config_t = uart_config_t;                       ///< UART config
 
 // Platform-specific handles
-using hf_timer_handle_t = void *; ///< Timer handle (platform-specific)
-using hf_mutex_handle_t = SemaphoreHandle_t;   ///< RTOS mutex handle
+using hf_timer_handle_t = void *;                ///< Timer handle (platform-specific)
+using hf_mutex_handle_t = SemaphoreHandle_t;     ///< RTOS mutex handle
 using hf_semaphore_handle_t = SemaphoreHandle_t; ///< Generic semaphore handle
 
 //==============================================================================


### PR DESCRIPTION
## Summary
- run clang-format over sources
- clean up formatting in McuTypes.h

## Testing
- `python3 docs/check_docs.py docs/index.md`
- `git ls-files | grep -E '\.(c|cpp|h|hpp)$' | xargs clang-format -n --Werror`

