### PR TITLE
Align SPI types with hf_* naming

### DIFF
--- a/inc/base/BaseSpi.h
+++ b/inc/base/BaseSpi.h
@@ -105,16 +105,16 @@ constexpr std::string_view hf_spi_err_to_string(hf_spi_err_t err) noexcept {
  *          supporting various platforms and SPI modes without MCU-specific types.
  */
 struct hf_spi_bus_config_t {
-  HfHostId host;                ///< SPI host/controller
-  HfPinNumber mosi_pin;         ///< MOSI (Master Out Slave In) pin
-  HfPinNumber miso_pin;         ///< MISO (Master In Slave Out) pin
-  HfPinNumber sclk_pin;         ///< SCLK (Serial Clock) pin
-  HfPinNumber cs_pin;           ///< CS (Chip Select) pin
-  HfFrequencyHz clock_speed_hz; ///< Clock speed in Hz
-  uint8_t mode;                 ///< SPI mode (0-3: CPOL/CPHA combinations)
-  uint8_t bits_per_word;        ///< Bits per transfer (typically 8 or 16)
-  bool cs_active_low;           ///< True if CS is active low, false if active high
-  HfTimeoutMs timeout_ms;       ///< Default timeout for operations in milliseconds
+  hf_host_id_t host;                ///< SPI host/controller
+  hf_pin_num_t mosi_pin;            ///< MOSI (Master Out Slave In) pin
+  hf_pin_num_t miso_pin;            ///< MISO (Master In Slave Out) pin
+  hf_pin_num_t sclk_pin;            ///< SCLK (Serial Clock) pin
+  hf_pin_num_t cs_pin;              ///< CS (Chip Select) pin
+  hf_frequency_hz_t clock_speed_hz; ///< Clock speed in Hz
+  uint8_t mode;                     ///< SPI mode (0-3: CPOL/CPHA combinations)
+  uint8_t bits_per_word;            ///< Bits per transfer (typically 8 or 16)
+  bool cs_active_low;               ///< True if CS is active low, false if active high
+  hf_timeout_ms_t timeout_ms;       ///< Default timeout for operations in milliseconds
 
   /**
    * @brief Default constructor with sensible defaults.
@@ -161,7 +161,8 @@ public:
    * @brief Constructor with configuration.
    * @param config SPI bus configuration parameters
    */
-  explicit BaseSpi(const hf_spi_bus_config_t &config) noexcept : config_(config), initialized_(false) {}
+  explicit BaseSpi(const hf_spi_bus_config_t &config) noexcept
+      : config_(config), initialized_(false) {}
 
   /**
    * @brief Virtual destructor ensures proper cleanup in derived classes.
@@ -229,7 +230,7 @@ public:
    * @note Must be implemented by concrete classes.
    */
   virtual hf_spi_err_t Transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                            uint32_t timeout_ms = 0) noexcept = 0;
+                                uint32_t timeout_ms = 0) noexcept = 0;
 
   /**
    * @brief Assert/deassert the chip select signal.
@@ -284,7 +285,8 @@ public:
    * @param timeout_ms Timeout in milliseconds (0 = use default)
    * @return hf_spi_err_t result code
    */
-  virtual hf_spi_err_t Write(const uint8_t *data, uint16_t length, uint32_t timeout_ms = 0) noexcept {
+  virtual hf_spi_err_t Write(const uint8_t *data, uint16_t length,
+                             uint32_t timeout_ms = 0) noexcept {
     return Transfer(data, nullptr, length, timeout_ms);
   }
 
@@ -329,7 +331,7 @@ public:
    * @brief Get the configured clock speed.
    * @return Clock speed in Hz
    */
-  [[nodiscard]] virtual uint32_t GetClockHz() const noexcept {
+  [[nodiscard]] virtual hf_frequency_hz_t GetClockHz() const noexcept {
     return config_.clock_speed_hz;
   }
 
@@ -353,7 +355,7 @@ public:
    * @brief Get the SPI host/controller.
    * @return SPI host number
    */
-  [[nodiscard]] virtual HfHostId GetHost() const noexcept {
+  [[nodiscard]] virtual hf_host_id_t GetHost() const noexcept {
     return config_.host;
   }
 
@@ -387,5 +389,5 @@ public:
 
 protected:
   hf_spi_bus_config_t config_; ///< Bus configuration
-  bool initialized_;    ///< Initialization state
+  bool initialized_;           ///< Initialization state
 };

--- a/inc/base/HardwareTypes.h
+++ b/inc/base/HardwareTypes.h
@@ -73,9 +73,12 @@ constexpr hf_host_id_t HF_INVALID_HOST = std::numeric_limits<hf_host_id_t>::max(
 //==============================================================================
 
 /**
- * @brief Platform-agnostic frequency type.
+ * @brief Platform-agnostic frequency type (in Hz).
  */
-using hf_frequency_t = uint32_t;
+using hf_frequency_hz_t = uint32_t;
+
+///@brief Backward compatibility alias
+using hf_frequency_t = hf_frequency_hz_t;
 
 /**
  * @brief Platform-agnostic baud rate type.
@@ -101,6 +104,11 @@ constexpr hf_channel_id_t HF_INVALID_CHANNEL = std::numeric_limits<hf_channel_id
  * @brief Platform-agnostic time type in milliseconds.
  */
 using hf_time_t = uint32_t;
+
+/**
+ * @brief Timeout value in milliseconds.
+ */
+using hf_timeout_ms_t = hf_time_t;
 
 //==============================================================================
 // TIMEOUT CONSTANTS

--- a/inc/mcu/esp32/EspSpi.h
+++ b/inc/mcu/esp32/EspSpi.h
@@ -18,17 +18,17 @@
 
 #pragma once
 
-#include "RtosMutex.h"
 #include "BaseSpi.h"
-#include "McuTypes.h"
+#include "EspTypes.h"
+#include "RtosMutex.h"
 #include <functional>
 #include <memory>
 #include <vector>
 
 #ifdef ESP_PLATFORM
+#include "driver/spi_common.h"
 #include "driver/spi_master.h"
 #include "driver/spi_slave.h"
-#include "driver/spi_common.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
@@ -36,83 +36,77 @@
 #include "hal/spi_types.h"
 #endif
 
-// Type aliases to centralized types in McuTypes.h (following naming convention)
-using hf_spi_bus_config_alias_t = hf_spi_bus_config_t;
-using hf_spi_device_config_alias_t = hf_spi_device_interface_config_t;
-using hf_spi_transaction_alias_t = hf_spi_transaction_t;
-using hf_spi_device_handle_alias_t = hf_spi_device_handle_t;
-using hf_spi_host_device_alias_t = hf_spi_host_device_t;
+// No aliases - use types directly
 
 //--------------------------------------
 //  Advanced SPI Configuration
 //--------------------------------------
 
-// Type aliases for centralized types from McuTypes.h (following naming convention)
-using hf_spi_transfer_mode_alias_t = hf_spi_transfer_mode_t;
-using hf_spi_clock_source_alias_t = hf_spi_clock_source_t;
+// Use direct types for advanced configuration
 
 /**
  * @brief Advanced SPI configuration for ESP32C6/ESP-IDF v5.5+.
  */
 struct hf_spi_advanced_config_t {
   // Basic configuration
-  hf_spi_bus_config_alias_t base_config;         ///< Base SPI bus configuration
-  hf_spi_host_device_alias_t host_device;       ///< SPI host device (SPI2 for ESP32C6)
-  hf_spi_device_config_alias_t device_config;   ///< Device-specific configuration
-  
+  hf_spi_bus_config_t base_config;                ///< Base SPI bus configuration
+  hf_spi_host_device_t host_device;               ///< SPI host device (SPI2 for ESP32C6)
+  hf_spi_device_interface_config_t device_config; ///< Device-specific configuration
+
   // Advanced ESP32C6 features
-  hf_spi_transfer_mode_alias_t transfer_mode;  ///< Transfer mode (single/dual/quad/octal)
-  hf_spi_clock_source_alias_t clock_source;    ///< Clock source selection
-  bool dma_enabled;                 ///< Enable DMA acceleration
-  uint32_t dma_channel;             ///< DMA channel selection (auto if 0)
-  uint32_t max_transfer_size;       ///< Maximum transfer size in bytes
-  
+  hf_spi_transfer_mode_t transfer_mode; ///< Transfer mode (single/dual/quad/octal)
+  hf_spi_clock_source_t clock_source;   ///< Clock source selection
+  bool dma_enabled;                     ///< Enable DMA acceleration
+  uint32_t dma_channel;                 ///< DMA channel selection (auto if 0)
+  uint32_t max_transfer_size;           ///< Maximum transfer size in bytes
+
   // Performance and timing
-  bool use_iomux;                   ///< Use IOMUX for better performance
-  uint8_t input_delay_ns;           ///< Input delay compensation
-  uint8_t cs_setup_time;            ///< CS setup time (clock cycles)
-  uint8_t cs_hold_time;             ///< CS hold time (clock cycles)
-  
+  bool use_iomux;         ///< Use IOMUX for better performance
+  uint8_t input_delay_ns; ///< Input delay compensation
+  uint8_t cs_setup_time;  ///< CS setup time (clock cycles)
+  uint8_t cs_hold_time;   ///< CS hold time (clock cycles)
+
   // Power management
-  bool auto_suspend_enabled;        ///< Auto-suspend when idle
-  uint32_t suspend_delay_ms;        ///< Delay before auto-suspend
-  bool clock_gating_enabled;        ///< Enable clock gating for power saving
-  
+  bool auto_suspend_enabled; ///< Auto-suspend when idle
+  uint32_t suspend_delay_ms; ///< Delay before auto-suspend
+  bool clock_gating_enabled; ///< Enable clock gating for power saving
+
   // Queue and buffering
-  uint8_t transaction_queue_size;   ///< Transaction queue depth
-  bool polling_mode;                ///< Use polling instead of interrupts
-  uint32_t timeout_ms;              ///< Default operation timeout
-  
+  uint8_t transaction_queue_size; ///< Transaction queue depth
+  bool polling_mode;              ///< Use polling instead of interrupts
+  uint32_t timeout_ms;            ///< Default operation timeout
+
   // Diagnostics and monitoring
-  bool statistics_enabled;          ///< Enable operation statistics
-  bool error_recovery_enabled;      ///< Enable automatic error recovery
-  
+  bool statistics_enabled;     ///< Enable operation statistics
+  bool error_recovery_enabled; ///< Enable automatic error recovery
+
   // Default constructor
   hf_spi_advanced_config_t()
-      : host_device(hf_spi_host_device_alias_t::HF_SPI2_HOST), transfer_mode(hf_spi_transfer_mode_alias_t::HF_SPI_TRANSFER_MODE_SINGLE),
-        clock_source(hf_spi_clock_source_alias_t::HF_SPI_CLK_SRC_DEFAULT), dma_enabled(true), dma_channel(0),
-        max_transfer_size(4092), use_iomux(true), input_delay_ns(0), cs_setup_time(0), cs_hold_time(0),
-        auto_suspend_enabled(false), suspend_delay_ms(5000), clock_gating_enabled(false),
-        transaction_queue_size(7), polling_mode(false), timeout_ms(1000),
-        statistics_enabled(false), error_recovery_enabled(true) {}
+      : host_device(hf_spi_host_device_t::HF_SPI2_HOST),
+        transfer_mode(hf_spi_transfer_mode_t::HF_SPI_TRANSFER_MODE_SINGLE),
+        clock_source(hf_spi_clock_source_t::HF_SPI_CLK_SRC_DEFAULT), dma_enabled(true),
+        dma_channel(0), max_transfer_size(4092), use_iomux(true), input_delay_ns(0),
+        cs_setup_time(0), cs_hold_time(0), auto_suspend_enabled(false), suspend_delay_ms(5000),
+        clock_gating_enabled(false), transaction_queue_size(7), polling_mode(false),
+        timeout_ms(1000), statistics_enabled(false), error_recovery_enabled(true) {}
 };
 
 /**
  * @brief SPI operation statistics for performance monitoring.
  */
 struct hf_spi_statistics_t {
-  uint64_t total_transactions;      ///< Total transactions performed
-  uint64_t successful_transactions; ///< Successful transactions
-  uint64_t failed_transactions;     ///< Failed transactions
-  uint64_t timeout_transactions;    ///< Timed-out transactions
-  uint64_t bytes_transmitted;       ///< Total bytes transmitted
-  uint64_t bytes_received;          ///< Total bytes received
-  uint64_t average_transfer_time_us;///< Average transfer time (microseconds)
-  uint64_t max_transfer_time_us;    ///< Maximum transfer time
-  uint64_t min_transfer_time_us;    ///< Minimum transfer time
-  uint32_t dma_transfers;           ///< DMA-accelerated transfers
-  uint32_t polling_transfers;       ///< Polling-mode transfers
-  
+  uint64_t total_transactions;       ///< Total transactions performed
+  uint64_t successful_transactions;  ///< Successful transactions
+  uint64_t failed_transactions;      ///< Failed transactions
+  uint64_t timeout_transactions;     ///< Timed-out transactions
+  uint64_t bytes_transmitted;        ///< Total bytes transmitted
+  uint64_t bytes_received;           ///< Total bytes received
+  uint64_t average_transfer_time_us; ///< Average transfer time (microseconds)
+  uint64_t max_transfer_time_us;     ///< Maximum transfer time
+  uint64_t min_transfer_time_us;     ///< Minimum transfer time
+  uint32_t dma_transfers;            ///< DMA-accelerated transfers
+  uint32_t polling_transfers;        ///< Polling-mode transfers
+
   hf_spi_statistics_t()
       : total_transactions(0), successful_transactions(0), failed_transactions(0),
         timeout_transactions(0), bytes_transmitted(0), bytes_received(0),
@@ -124,25 +118,22 @@ struct hf_spi_statistics_t {
  * @brief SPI transfer descriptor for batch operations.
  */
 struct hf_spi_transfer_descriptor_t {
-  const uint8_t *tx_data;      ///< Transmit data (nullptr for read-only)
-  uint8_t *rx_data;            ///< Receive data (nullptr for write-only)
-  uint16_t length;             ///< Transfer length in bytes
-  uint32_t timeout_ms;         ///< Transfer timeout (0 = use default)
-  bool manage_cs;              ///< Manage CS for this transfer
-  uint32_t flags;              ///< Transfer-specific flags
-  
-  hf_spi_transfer_descriptor_t(const uint8_t *tx = nullptr, uint8_t *rx = nullptr,
-                       uint16_t len = 0, uint32_t timeout = 0, bool cs = true)
-      : tx_data(tx), rx_data(rx), length(len), timeout_ms(timeout),
-        manage_cs(cs), flags(0) {}
+  const uint8_t *tx_data; ///< Transmit data (nullptr for read-only)
+  uint8_t *rx_data;       ///< Receive data (nullptr for write-only)
+  uint16_t length;        ///< Transfer length in bytes
+  uint32_t timeout_ms;    ///< Transfer timeout (0 = use default)
+  bool manage_cs;         ///< Manage CS for this transfer
+  uint32_t flags;         ///< Transfer-specific flags
+
+  hf_spi_transfer_descriptor_t(const uint8_t *tx = nullptr, uint8_t *rx = nullptr, uint16_t len = 0,
+                               uint32_t timeout = 0, bool cs = true)
+      : tx_data(tx), rx_data(rx), length(len), timeout_ms(timeout), manage_cs(cs), flags(0) {}
 };
 
 // Callback function types (following naming convention)
-using hf_spi_async_callback_t = std::function<void(hf_spi_err_t result, size_t bytesTransferred, void *userData)>;
+using hf_spi_async_callback_t =
+    std::function<void(hf_spi_err_t result, size_t bytesTransferred, void *userData)>;
 using hf_spi_event_callback_t = std::function<void(int eventType, void *eventData, void *userData)>;
-
-// Type alias for centralized event type (following naming convention)
-using hf_spi_event_type_alias_t = hf_spi_event_type_t;
 
 /**
  * @class EspSpi
@@ -180,7 +171,7 @@ public:
    * @brief Constructor with basic configuration.
    * @param config SPI bus configuration parameters
    */
-  explicit EspSpi(const hf_spi_bus_config_alias_t &config) noexcept;
+  explicit EspSpi(const hf_spi_bus_config_t &config) noexcept;
 
   /**
    * @brief Constructor with advanced configuration.
@@ -217,7 +208,7 @@ public:
    * @return hf_spi_err_t result code
    */
   hf_spi_err_t Transfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                    uint32_t timeout_ms = 0) noexcept override;
+                        uint32_t timeout_ms = 0) noexcept override;
 
   /**
    * @brief Assert/deassert the chip select signal.
@@ -248,7 +239,7 @@ public:
    * @brief Get current SPI configuration.
    * @return Current SPI bus configuration
    */
-  const hf_spi_bus_config_alias_t& GetConfig() const noexcept {
+  const hf_spi_bus_config_t &GetConfig() const noexcept {
     return use_advanced_config_ ? advanced_config_.base_config : config_;
   }
 
@@ -262,7 +253,7 @@ public:
    * @brief Get current transfer mode.
    * @return Current transfer mode
    */
-  hf_spi_transfer_mode_alias_t GetTransferMode() const noexcept;
+  hf_spi_transfer_mode_t GetTransferMode() const noexcept;
 
   /**
    * @brief Reset the SPI bus and recover from errors.
@@ -279,21 +270,21 @@ public:
    * @param device_config Device configuration
    * @return Device handle or nullptr on failure
    */
-  hf_spi_device_handle_alias_t addDevice(const hf_spi_device_config_alias_t &device_config) noexcept;
+  hf_spi_device_handle_t addDevice(const hf_spi_device_interface_config_t &device_config) noexcept;
 
   /**
    * @brief Remove a device from the SPI bus.
    * @param device_handle Device handle to remove
    * @return hf_spi_err_t result code
    */
-  hf_spi_err_t removeDevice(hf_spi_device_handle_alias_t device_handle) noexcept;
+  hf_spi_err_t removeDevice(hf_spi_device_handle_t device_handle) noexcept;
 
   /**
    * @brief Switch to a specific device.
    * @param device_handle Device handle to switch to
    * @return hf_spi_err_t result code
    */
-  hf_spi_err_t selectDevice(hf_spi_device_handle_alias_t device_handle) noexcept;
+  hf_spi_err_t selectDevice(hf_spi_device_handle_t device_handle) noexcept;
 
   //==============================================//
   // ADVANCED TRANSFER OPERATIONS                //
@@ -308,7 +299,7 @@ public:
    * @return hf_spi_err_t result code
    */
   hf_spi_err_t transferQuad(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                        uint32_t timeout_ms = 0) noexcept;
+                            uint32_t timeout_ms = 0) noexcept;
 
   /**
    * @brief Perform transfer using octal SPI mode (ESP32C6 specific).
@@ -319,7 +310,7 @@ public:
    * @return hf_spi_err_t result code
    */
   hf_spi_err_t transferOctal(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                         uint32_t timeout_ms = 0) noexcept;
+                             uint32_t timeout_ms = 0) noexcept;
 
   /**
    * @brief Perform DMA-accelerated transfer.
@@ -330,7 +321,7 @@ public:
    * @return hf_spi_err_t result code
    */
   hf_spi_err_t transferDma(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                       uint32_t timeout_ms = 0) noexcept;
+                           uint32_t timeout_ms = 0) noexcept;
 
   /**
    * @brief Perform batch transfers with single CS assertion.
@@ -354,7 +345,7 @@ public:
    * @return hf_spi_err_t result code
    */
   hf_spi_err_t transferAsync(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                         hf_spi_async_callback_t callback, void *userData = nullptr) noexcept;
+                             hf_spi_async_callback_t callback, void *userData = nullptr) noexcept;
 
   /**
    * @brief Cancel pending asynchronous operation.
@@ -397,7 +388,8 @@ public:
    * @param count Number of registers to write
    * @return hf_spi_err_t result code
    */
-  hf_spi_err_t writeMultipleRegisters(uint8_t start_reg_addr, const uint8_t *data, uint8_t count) noexcept;
+  hf_spi_err_t writeMultipleRegisters(uint8_t start_reg_addr, const uint8_t *data,
+                                      uint8_t count) noexcept;
 
   /**
    * @brief Read multiple registers sequentially.
@@ -436,9 +428,10 @@ public:
    * @param clock_source Clock source to use
    * @return hf_spi_err_t result code
    */
-  hf_spi_err_t setClockSource(hf_spi_clock_source_alias_t clock_source) noexcept;
+  hf_spi_err_t setClockSource(hf_spi_clock_source_t clock_source) noexcept;
 
-  //==============================================//  //==============================================//
+  //==============================================//
+  ////==============================================//
   // STATISTICS AND DIAGNOSTICS                  //
   //==============================================//
 
@@ -446,7 +439,7 @@ public:
    * @brief Get operation statistics.
    * @return Current statistics reference
    */
-  const hf_spi_statistics_t& getStatistics() const noexcept;
+  const hf_spi_statistics_t &getStatistics() const noexcept;
 
   /**
    * @brief Reset operation statistics.
@@ -457,7 +450,7 @@ public:
    * @brief Get comprehensive diagnostics information.
    * @return Diagnostics structure with current state
    */
-  hf_spi_diagnostics_alias_t getDiagnostics() const noexcept;
+  hf_spi_diagnostics_t getDiagnostics() const noexcept;
 
   /**
    * @brief Check if SPI bus is healthy.
@@ -522,7 +515,7 @@ public:
    * @brief Get current transfer mode.
    * @return Current transfer mode
    */
-  hf_spi_transfer_mode_alias_t GetTransferMode() const noexcept;
+  hf_spi_transfer_mode_t GetTransferMode() const noexcept;
 
 private:
   //==============================================//
@@ -542,7 +535,7 @@ private:
    * @return true if valid, false otherwise
    */
   bool IsValidMode(uint8_t mode) const noexcept {
-  return HF_SPI_IS_VALID_MODE(mode);
+    return HF_SPI_IS_VALID_MODE(mode);
   }
 
   /**
@@ -598,9 +591,9 @@ private:
    * @return hf_spi_err_t result code
    */
   hf_spi_err_t InternalTransfer(const uint8_t *tx_data, uint8_t *rx_data, uint16_t length,
-                            uint32_t timeout_ms, hf_spi_transfer_mode_alias_t transfer_mode, 
-                            bool manage_cs) noexcept;
-                            
+                                uint32_t timeout_ms, hf_spi_transfer_mode_t transfer_mode,
+                                bool manage_cs) noexcept;
+
   /**
    * @brief Update operation statistics.
    * @param success Operation success status
@@ -608,8 +601,8 @@ private:
    * @param transferTimeUs Transfer time in microseconds
    * @param usedDma Whether DMA was used
    */
-  void UpdateStatistics(bool success, size_t bytesTransferred, 
-                       uint64_t transferTimeUs, bool usedDma) noexcept;
+  void UpdateStatistics(bool success, size_t bytesTransferred, uint64_t transferTimeUs,
+                        bool usedDma) noexcept;
 
   /**
    * @brief Handle platform-specific error.
@@ -622,33 +615,33 @@ private:
   //==============================================//
 
   // Platform-specific handles
-  hf_spi_device_handle_alias_t platform_handle_;                         ///< Primary device handle
-  hf_spi_device_handle_alias_t current_device_;                          ///< Currently selected device
-  std::vector<hf_spi_device_handle_alias_t> device_handles_;             ///< All registered devices
+  hf_spi_device_handle_t platform_handle_;             ///< Primary device handle
+  hf_spi_device_handle_t current_device_;              ///< Currently selected device
+  std::vector<hf_spi_device_handle_t> device_handles_; ///< All registered devices
 
   // Configuration storage
-  hf_spi_advanced_config_t advanced_config_;                       ///< Advanced configuration
-  bool use_advanced_config_;                                ///< Flag indicating advanced config usage
+  hf_spi_advanced_config_t advanced_config_; ///< Advanced configuration
+  bool use_advanced_config_;                 ///< Flag indicating advanced config usage
 
   // State management
-  mutable RtosMutex mutex_;            ///< Thread safety mutex
-  hf_spi_err_t last_error_;                ///< Last error that occurred
-  uint32_t transaction_count_;         ///< Number of transactions performed
-  bool cs_active_;                     ///< Current CS state
-  bool dma_enabled_;                   ///< DMA enable state
-  bool bus_suspended_;                 ///< Bus suspension state
-  hf_spi_transfer_mode_alias_t current_transfer_mode_; ///< Current transfer mode
-  uint16_t max_transfer_size_;         ///< Maximum transfer size in bytes
+  mutable RtosMutex mutex_;                      ///< Thread safety mutex
+  hf_spi_err_t last_error_;                      ///< Last error that occurred
+  uint32_t transaction_count_;                   ///< Number of transactions performed
+  bool cs_active_;                               ///< Current CS state
+  bool dma_enabled_;                             ///< DMA enable state
+  bool bus_suspended_;                           ///< Bus suspension state
+  hf_spi_transfer_mode_t current_transfer_mode_; ///< Current transfer mode
+  uint16_t max_transfer_size_;                   ///< Maximum transfer size in bytes
 
   // Asynchronous operation support
-  std::vector<uint32_t> async_operations_;  ///< Active async operations
-  uint32_t next_operation_id_;              ///< Next operation ID
-  hf_spi_event_callback_t event_callback_;         ///< Event callback function
-  void *event_user_data_;                   ///< Event callback user data
+  std::vector<uint32_t> async_operations_; ///< Active async operations
+  uint32_t next_operation_id_;             ///< Next operation ID
+  hf_spi_event_callback_t event_callback_; ///< Event callback function
+  void *event_user_data_;                  ///< Event callback user data
 
   // Statistics and diagnostics
-  mutable hf_spi_statistics_t statistics_;   ///< Operation statistics
-  uint64_t last_transfer_time_;        ///< Last transfer timestamp
+  mutable hf_spi_statistics_t statistics_; ///< Operation statistics
+  uint64_t last_transfer_time_;            ///< Last transfer timestamp
 
   // Platform-specific constants
   static constexpr uint32_t DEFAULT_TIMEOUT_MS = 1000;

--- a/inc/mcu/esp32/utils/EspTypes_Base.h
+++ b/inc/mcu/esp32/utils/EspTypes_Base.h
@@ -29,7 +29,7 @@
 using hf_timeout_ms_t = uint32_t;
 
 /// @brief Pin number type (hardware agnostic)
-using hf_pin_number_t = uint32_t;
+using hf_pin_num_t = uint32_t;
 
 //==============================================================================
 // MCU-SPECIFIC CONSTANTS

--- a/inc/mcu/esp32/utils/EspTypes_SPI.h
+++ b/inc/mcu/esp32/utils/EspTypes_SPI.h
@@ -12,10 +12,10 @@
 
 #pragma once
 
+#include "BaseSpi.h"       // For hf_spi_err_t
 #include "HardwareTypes.h" // For basic hardware types
-#include "McuSelect.h"    // Central MCU platform selection (includes all ESP-IDF)
+#include "McuSelect.h"     // Central MCU platform selection (includes all ESP-IDF)
 #include "McuTypes_Base.h"
-#include "BaseSpi.h" // For hf_spi_err_t
 
 //==============================================================================
 // PLATFORM-SPECIFIC SPI TYPE MAPPINGS
@@ -43,28 +43,26 @@ using hf_spi_transaction_native_t = struct {
 using hf_spi_device_handle_native_t = void *;
 #endif
 
-
 /**
  * @brief SPI bus configuration for ESP32C6/ESP-IDF v5.5+.
  */
 struct hf_spi_bus_config_t {
-  int mosi_io_num;        ///< MOSI GPIO pin
-  int miso_io_num;        ///< MISO GPIO pin
-  int sclk_io_num;        ///< SCLK GPIO pin
-  int quadwp_io_num;      ///< WP pin for quad/octal mode
-  int quadhd_io_num;      ///< HD pin for quad/octal mode
-  int data4_io_num;       ///< DATA4 pin for octal mode
-  int data5_io_num;       ///< DATA5 pin for octal mode
-  int data6_io_num;       ///< DATA6 pin for octal mode
-  int data7_io_num;       ///< DATA7 pin for octal mode
-  int max_transfer_sz;    ///< Maximum transfer size
-  uint32_t flags;         ///< Bus configuration flags
-  uint32_t intr_flags;    ///< Interrupt allocation flags
-  
+  hf_pin_num_t mosi_io_num;   ///< MOSI GPIO pin
+  hf_pin_num_t miso_io_num;   ///< MISO GPIO pin
+  hf_pin_num_t sclk_io_num;   ///< SCLK GPIO pin
+  hf_pin_num_t quadwp_io_num; ///< WP pin for quad/octal mode
+  hf_pin_num_t quadhd_io_num; ///< HD pin for quad/octal mode
+  hf_pin_num_t data4_io_num;  ///< DATA4 pin for octal mode
+  hf_pin_num_t data5_io_num;  ///< DATA5 pin for octal mode
+  hf_pin_num_t data6_io_num;  ///< DATA6 pin for octal mode
+  hf_pin_num_t data7_io_num;  ///< DATA7 pin for octal mode
+  int max_transfer_sz;        ///< Maximum transfer size
+  uint32_t flags;             ///< Bus configuration flags
+  uint32_t intr_flags;        ///< Interrupt allocation flags
+
   hf_spi_bus_config_t() noexcept
-      : mosi_io_num(-1), miso_io_num(-1), sclk_io_num(-1),
-        quadwp_io_num(-1), quadhd_io_num(-1), data4_io_num(-1),
-        data5_io_num(-1), data6_io_num(-1), data7_io_num(-1),
+      : mosi_io_num(-1), miso_io_num(-1), sclk_io_num(-1), quadwp_io_num(-1), quadhd_io_num(-1),
+        data4_io_num(-1), data5_io_num(-1), data6_io_num(-1), data7_io_num(-1),
         max_transfer_sz(4092), flags(0), intr_flags(0) {}
 };
 
@@ -72,71 +70,70 @@ struct hf_spi_bus_config_t {
  * @brief SPI device configuration for ESP32C6/ESP-IDF v5.5+.
  */
 struct hf_spi_device_interface_config_t {
-  uint8_t command_bits;        ///< Command phase bit length (0-16)
-  uint8_t address_bits;        ///< Address phase bit length (0-64)
-  uint8_t dummy_bits;          ///< Dummy phase bit length
-  uint8_t mode;                ///< SPI mode (0-3)
-  uint8_t duty_cycle_pos;      ///< Duty cycle of positive clock
-  uint8_t cs_ena_pretrans;     ///< CS setup time
-  uint8_t cs_ena_posttrans;    ///< CS hold time
-  int clock_speed_hz;          ///< Clock speed in Hz
-  int input_delay_ns;          ///< Input delay in nanoseconds
-  int spics_io_num;            ///< CS GPIO pin (-1 = not used)
-  uint32_t flags;              ///< Device configuration flags
-  int queue_size;              ///< Transaction queue size
-  void (*pre_cb)(void *trans); ///< Pre-transaction callback
-  void (*post_cb)(void *trans);///< Post-transaction callback
-  
+  uint8_t command_bits;         ///< Command phase bit length (0-16)
+  uint8_t address_bits;         ///< Address phase bit length (0-64)
+  uint8_t dummy_bits;           ///< Dummy phase bit length
+  uint8_t mode;                 ///< SPI mode (0-3)
+  uint8_t duty_cycle_pos;       ///< Duty cycle of positive clock
+  uint8_t cs_ena_pretrans;      ///< CS setup time
+  uint8_t cs_ena_posttrans;     ///< CS hold time
+  int clock_speed_hz;           ///< Clock speed in Hz
+  int input_delay_ns;           ///< Input delay in nanoseconds
+  hf_pin_num_t spics_io_num;    ///< CS GPIO pin (-1 = not used)
+  uint32_t flags;               ///< Device configuration flags
+  int queue_size;               ///< Transaction queue size
+  void (*pre_cb)(void *trans);  ///< Pre-transaction callback
+  void (*post_cb)(void *trans); ///< Post-transaction callback
+
   hf_spi_device_interface_config_t() noexcept
-      : command_bits(0), address_bits(0), dummy_bits(0), mode(0),
-        duty_cycle_pos(128), cs_ena_pretrans(0), cs_ena_posttrans(0),
-        clock_speed_hz(1000000), input_delay_ns(0), spics_io_num(-1),
-        flags(0), queue_size(7), pre_cb(nullptr), post_cb(nullptr) {}
+      : command_bits(0), address_bits(0), dummy_bits(0), mode(0), duty_cycle_pos(128),
+        cs_ena_pretrans(0), cs_ena_posttrans(0), clock_speed_hz(1000000), input_delay_ns(0),
+        spics_io_num(-1), flags(0), queue_size(7), pre_cb(nullptr), post_cb(nullptr) {}
 };
 
 /**
  * @brief SPI transaction structure for ESP32C6/ESP-IDF v5.5+.
  */
 struct hf_spi_transaction_t {
-  uint32_t flags;              ///< Transaction flags
-  uint16_t cmd;                ///< Command data
-  uint64_t addr;               ///< Address data
-  size_t length;               ///< Data length in bits
-  size_t rxlength;             ///< RX data length in bits
-  void *user;                  ///< User data pointer
+  uint32_t flags;  ///< Transaction flags
+  uint16_t cmd;    ///< Command data
+  uint64_t addr;   ///< Address data
+  size_t length;   ///< Data length in bits
+  size_t rxlength; ///< RX data length in bits
+  void *user;      ///< User data pointer
   union {
-    const void *tx_buffer;     ///< TX data buffer
-    uint8_t tx_data[4];        ///< TX data for ≤32 bits
+    const void *tx_buffer; ///< TX data buffer
+    uint8_t tx_data[4];    ///< TX data for ≤32 bits
   };
   union {
-    void *rx_buffer;           ///< RX data buffer
-    uint8_t rx_data[4];        ///< RX data for ≤32 bits
+    void *rx_buffer;    ///< RX data buffer
+    uint8_t rx_data[4]; ///< RX data for ≤32 bits
   };
-  
+
   hf_spi_transaction_t() noexcept
-      : flags(0), cmd(0), addr(0), length(0), rxlength(0),
-        user(nullptr), tx_buffer(nullptr), rx_buffer(nullptr) {}
+      : flags(0), cmd(0), addr(0), length(0), rxlength(0), user(nullptr), tx_buffer(nullptr),
+        rx_buffer(nullptr) {}
 };
 
 /**
  * @brief SPI diagnostics information structure.
  */
 struct hf_spi_diagnostics_t {
-  bool is_initialized;        ///< Initialization state
-  bool is_bus_suspended;      ///< Bus suspension state
-  bool dma_enabled;           ///< DMA enabled state
+  bool is_initialized;          ///< Initialization state
+  bool is_bus_suspended;        ///< Bus suspension state
+  bool dma_enabled;             ///< DMA enabled state
   uint32_t current_clock_speed; ///< Current clock speed in Hz
-  uint8_t current_mode;       ///< Current SPI mode
-  uint16_t max_transfer_size; ///< Maximum transfer size
-  uint8_t device_count;       ///< Number of registered devices
-  uint32_t last_error;        ///< Last error code
-  uint64_t total_transactions; ///< Total transactions performed
+  uint8_t current_mode;         ///< Current SPI mode
+  uint16_t max_transfer_size;   ///< Maximum transfer size
+  uint8_t device_count;         ///< Number of registered devices
+  uint32_t last_error;          ///< Last error code
+  uint64_t total_transactions;  ///< Total transactions performed
   uint64_t failed_transactions; ///< Failed transactions count
-  
+
   hf_spi_diagnostics_t() noexcept
-      : is_initialized(false), is_bus_suspended(false), dma_enabled(false),
-        current_clock_speed(0), current_mode(0), max_transfer_size(0),
-        device_count(0), last_error(0), total_transactions(0), failed_transactions(0) {}
+      : is_initialized(false), is_bus_suspended(false), dma_enabled(false), current_clock_speed(0),
+        current_mode(0), max_transfer_size(0), device_count(0), last_error(0),
+        total_transactions(0), failed_transactions(0) {}
 };
 
 // Type alias for SPI diagnostics (following naming convention)
@@ -147,7 +144,6 @@ using hf_spi_diagnostics_alias_t = hf_spi_diagnostics_t;
  */
 using hf_spi_device_handle_t = hf_spi_device_handle_native_t;
 using hf_spi_host_device_id_t = hf_spi_host_native_t;
-
 
 //==============================================================================
 // MCU-SPECIFIC SPI TYPES
@@ -169,9 +165,9 @@ enum class hf_spi_mode_t : uint8_t {
  *          SPI1 is reserved for flash and not exposed to users.
  */
 enum class hf_spi_host_device_t : uint8_t {
-  HF_SPI2_HOST = 1,      ///< SPI2 host (general purpose) - ESP-IDF SPI2_HOST
-  HF_SPI3_HOST = 2,      ///< SPI3 host (general purpose) - ESP-IDF SPI3_HOST  
-  HF_SPI_HOST_MAX = 3,   ///< Maximum number of SPI hosts
+  HF_SPI2_HOST = 1,    ///< SPI2 host (general purpose) - ESP-IDF SPI2_HOST
+  HF_SPI3_HOST = 2,    ///< SPI3 host (general purpose) - ESP-IDF SPI3_HOST
+  HF_SPI_HOST_MAX = 3, ///< Maximum number of SPI hosts
 };
 
 /**
@@ -221,22 +217,22 @@ using hf_spi_handle_t = void *;
  * @details Performance monitoring and error tracking for SPI operations.
  */
 struct hf_spi_transaction_diagnostics_t {
-  uint32_t total_transactions;     ///< Total number of transactions
-  uint32_t successful_transactions; ///< Number of successful transactions
-  uint32_t failed_transactions;    ///< Number of failed transactions
-  uint32_t timeout_transactions;   ///< Number of timed-out transactions
-  uint32_t total_bytes_sent;       ///< Total bytes transmitted
-  uint32_t total_bytes_received;   ///< Total bytes received
-  uint32_t max_transaction_time_us; ///< Maximum transaction time (microseconds)
-  uint32_t min_transaction_time_us; ///< Minimum transaction time (microseconds)
-  uint64_t last_activity_timestamp; ///< Last activity timestamp
+  uint32_t total_transactions;       ///< Total number of transactions
+  uint32_t successful_transactions;  ///< Number of successful transactions
+  uint32_t failed_transactions;      ///< Number of failed transactions
+  uint32_t timeout_transactions;     ///< Number of timed-out transactions
+  uint32_t total_bytes_sent;         ///< Total bytes transmitted
+  uint32_t total_bytes_received;     ///< Total bytes received
+  uint32_t max_transaction_time_us;  ///< Maximum transaction time (microseconds)
+  uint32_t min_transaction_time_us;  ///< Minimum transaction time (microseconds)
+  uint64_t last_activity_timestamp;  ///< Last activity timestamp
   uint64_t initialization_timestamp; ///< Initialization timestamp
 
   hf_spi_transaction_diagnostics_t() noexcept
       : total_transactions(0), successful_transactions(0), failed_transactions(0),
         timeout_transactions(0), total_bytes_sent(0), total_bytes_received(0),
-        max_transaction_time_us(0), min_transaction_time_us(0xFFFFFFFF),
-        last_activity_timestamp(0), initialization_timestamp(0) {}
+        max_transaction_time_us(0), min_transaction_time_us(0xFFFFFFFF), last_activity_timestamp(0),
+        initialization_timestamp(0) {}
 };
 
 //==============================================================================
@@ -244,13 +240,14 @@ struct hf_spi_transaction_diagnostics_t {
 //==============================================================================
 
 #ifdef HF_TARGET_MCU_ESP32C6
-static constexpr uint32_t HF_SPI_MIN_CLOCK_SPEED = 1000;      ///< Minimum SPI clock speed (Hz)
-static constexpr uint32_t HF_SPI_MAX_CLOCK_SPEED = 80000000;  ///< Maximum SPI clock speed (Hz)
-static constexpr uint32_t HF_SPI_MAX_TRANSFER_SIZE = 4092;    ///< Maximum transfer size (bytes)
+static constexpr uint32_t HF_SPI_MIN_CLOCK_SPEED = 1000;     ///< Minimum SPI clock speed (Hz)
+static constexpr uint32_t HF_SPI_MAX_CLOCK_SPEED = 80000000; ///< Maximum SPI clock speed (Hz)
+static constexpr uint32_t HF_SPI_MAX_TRANSFER_SIZE = 4092;   ///< Maximum transfer size (bytes)
 static constexpr uint8_t HF_SPI_MAX_HOSTS = 3;               ///< Maximum SPI hosts
 
-#define HF_SPI_IS_VALID_HOST(host) ((host) < static_cast<uint8_t>(hf_spi_host_device_t::HF_SPI_HOST_MAX))
-#define HF_SPI_IS_VALID_CLOCK_SPEED(speed) \
+#define HF_SPI_IS_VALID_HOST(host)                                                                 \
+  ((host) < static_cast<uint8_t>(hf_spi_host_device_t::HF_SPI_HOST_MAX))
+#define HF_SPI_IS_VALID_CLOCK_SPEED(speed)                                                         \
   ((speed) >= HF_SPI_MIN_CLOCK_SPEED && (speed) <= HF_SPI_MAX_CLOCK_SPEED)
 #define HF_SPI_IS_VALID_MODE(mode) ((mode) >= 0 && (mode) <= 3)
 #define HF_SPI_IS_VALID_TRANSFER_SIZE(size) ((size) > 0 && (size) <= HF_SPI_MAX_TRANSFER_SIZE)
@@ -262,11 +259,8 @@ static constexpr uint32_t HF_SPI_MAX_TRANSFER_SIZE = 4096;
 static constexpr uint8_t HF_SPI_MAX_HOSTS = 2;
 
 #define HF_SPI_IS_VALID_HOST(host) ((host) < HF_SPI_MAX_HOSTS)
-#define HF_SPI_IS_VALID_CLOCK_SPEED(speed) \
+#define HF_SPI_IS_VALID_CLOCK_SPEED(speed)                                                         \
   ((speed) >= HF_SPI_MIN_CLOCK_SPEED && (speed) <= HF_SPI_MAX_CLOCK_SPEED)
 #define HF_SPI_IS_VALID_MODE(mode) ((mode) >= 0 && (mode) <= 3)
 #define HF_SPI_IS_VALID_TRANSFER_SIZE(size) ((size) > 0 && (size) <= HF_SPI_MAX_TRANSFER_SIZE)
 #endif
-
-// SPI diagnostics alias for convenience (following naming convention)
-using hf_spi_diagnostics_alias_t = hf_spi_diagnostics_t;


### PR DESCRIPTION
## Summary
- adopt `hf_*` conventions across SPI interfaces
- remove outdated type aliases in EspSpi
- use pin-number types in SPI bus config
- extend base hardware types with frequency and timeout aliases