### PR TITLE
Align remaining PWM type names

### DIFF
--- a/docs/api/BasePwm.md
+++ b/docs/api/BasePwm.md
@@ -43,11 +43,11 @@ BasePwm (Abstract Base Class)
 
 ## 🏗️ Data Structures
 
-### PwmChannelConfig
+### hf_pwm_channel_config_t
 Configuration structure for PWM channel setup:
 
 ```cpp
-struct PwmChannelConfig {
+struct hf_pwm_channel_config_t {
     hf_gpio_num_t output_pin;           // GPIO pin for PWM output
     uint32_t frequency_hz;              // PWM frequency in Hz
     uint8_t resolution_bits;            // PWM resolution (8-16 bits)
@@ -81,25 +81,25 @@ enum class PwmAlignment : uint8_t {
 };
 ```
 
-### PwmChannelStatus
+### hf_pwm_channel_status_t
 Real-time channel status information:
 
 ```cpp
-struct PwmChannelStatus {
+struct hf_pwm_channel_status_t {
     bool is_enabled;                    // Channel is enabled
     bool is_running;                    // Channel is actively generating PWM
     uint32_t current_frequency_hz;      // Current frequency
     float current_duty_cycle;           // Current duty cycle (0.0-1.0)
     uint32_t raw_duty_value;            // Raw duty register value
-    HfPwmErr last_error;                // Last error encountered
+    hf_pwm_err_t last_error;                // Last error encountered
 };
 ```
 
-### PwmCapabilities
+### hf_pwm_capabilities_t
 Hardware capability information:
 
 ```cpp
-struct PwmCapabilities {
+struct hf_pwm_capabilities_t {
     uint8_t max_channels;               // Maximum number of channels
     uint8_t max_timers;                 // Maximum number of timers
     uint32_t min_frequency_hz;          // Minimum supported frequency
@@ -137,139 +137,139 @@ bool IsInitialized() const noexcept
 
 #### `ConfigureChannel()`
 ```cpp
-virtual HfPwmErr ConfigureChannel(uint8_t channel, const PwmChannelConfig& config) noexcept = 0
+virtual hf_pwm_err_t ConfigureChannel(uint8_t channel, const hf_pwm_channel_config_t& config) noexcept = 0
 ```
 **Description**: Configure a PWM channel with specified settings  
 **Parameters**:
 - `channel`: Channel number (0-based)
 - `config`: Channel configuration structure
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 #### `EnableChannel()`
 ```cpp
-virtual HfPwmErr EnableChannel(uint8_t channel) noexcept = 0
+virtual hf_pwm_err_t EnableChannel(uint8_t channel) noexcept = 0
 ```
 **Description**: Enable PWM output on specified channel  
 **Parameters**:
 - `channel`: Channel number to enable
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 #### `DisableChannel()`
 ```cpp
-virtual HfPwmErr DisableChannel(uint8_t channel) noexcept = 0
+virtual hf_pwm_err_t DisableChannel(uint8_t channel) noexcept = 0
 ```
 **Description**: Disable PWM output on specified channel  
 **Parameters**:
 - `channel`: Channel number to disable
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 ### Duty Cycle Control
 
 #### `SetDutyCycle()`
 ```cpp
-virtual HfPwmErr SetDutyCycle(uint8_t channel, float duty_cycle) noexcept = 0
+virtual hf_pwm_err_t SetDutyCycle(uint8_t channel, float duty_cycle) noexcept = 0
 ```
 **Description**: Set duty cycle for a PWM channel  
 **Parameters**:
 - `channel`: Channel number
 - `duty_cycle`: Duty cycle (0.0 = 0%, 1.0 = 100%)
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 #### `SetDutyCycleRaw()`
 ```cpp
-virtual HfPwmErr SetDutyCycleRaw(uint8_t channel, uint32_t raw_value) noexcept = 0
+virtual hf_pwm_err_t SetDutyCycleRaw(uint8_t channel, uint32_t raw_value) noexcept = 0
 ```
 **Description**: Set duty cycle using raw timer value  
 **Parameters**:
 - `channel`: Channel number
 - `raw_value`: Raw duty cycle value (0 to max resolution)
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 #### `GetDutyCycle()`
 ```cpp
-virtual HfPwmErr GetDutyCycle(uint8_t channel, float& duty_cycle) noexcept = 0
+virtual hf_pwm_err_t GetDutyCycle(uint8_t channel, float& duty_cycle) noexcept = 0
 ```
 **Description**: Get current duty cycle for a channel  
 **Parameters**:
 - `channel`: Channel number
 - `duty_cycle`: Reference to store duty cycle value
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Yes  
 
 ### Frequency Control
 
 #### `SetFrequency()`
 ```cpp
-virtual HfPwmErr SetFrequency(uint8_t channel, uint32_t frequency_hz) noexcept = 0
+virtual hf_pwm_err_t SetFrequency(uint8_t channel, uint32_t frequency_hz) noexcept = 0
 ```
 **Description**: Set PWM frequency for a channel  
 **Parameters**:
 - `channel`: Channel number
 - `frequency_hz`: Frequency in Hz
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 #### `GetFrequency()`
 ```cpp
-virtual HfPwmErr GetFrequency(uint8_t channel, uint32_t& frequency_hz) noexcept = 0
+virtual hf_pwm_err_t GetFrequency(uint8_t channel, uint32_t& frequency_hz) noexcept = 0
 ```
 **Description**: Get current frequency for a channel  
 **Parameters**:
 - `channel`: Channel number
 - `frequency_hz`: Reference to store frequency value
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Yes  
 
 ### Status and Information
 
 #### `GetChannelStatus()`
 ```cpp
-virtual HfPwmErr GetChannelStatus(uint8_t channel, PwmChannelStatus& status) noexcept = 0
+virtual hf_pwm_err_t GetChannelStatus(uint8_t channel, hf_pwm_channel_status_t& status) noexcept = 0
 ```
 **Description**: Get comprehensive channel status information  
 **Parameters**:
 - `channel`: Channel number
 - `status`: Reference to store status information
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Yes  
 
 #### `GetCapabilities()`
 ```cpp
-virtual HfPwmErr GetCapabilities(PwmCapabilities& capabilities) noexcept = 0
+virtual hf_pwm_err_t GetCapabilities(hf_pwm_capabilities_t& capabilities) noexcept = 0
 ```
 **Description**: Get hardware capability information  
 **Parameters**:
 - `capabilities`: Reference to store capability information
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Yes  
 
 ### Callback Management
 
 #### `SetPeriodCallback()`
 ```cpp
-virtual HfPwmErr SetPeriodCallback(uint8_t channel, PwmPeriodCallback callback) noexcept = 0
+virtual hf_pwm_err_t SetPeriodCallback(uint8_t channel, hf_pwm_period_callback_t callback) noexcept = 0
 ```
 **Description**: Set callback for PWM period complete events  
 **Parameters**:
 - `channel`: Channel number
 - `callback`: Function to call on period complete
 
-**Returns**: `HfPwmErr` result code  
+**Returns**: `hf_pwm_err_t` result code  
 **Thread-Safe**: Implementation dependent  
 
 ## 💡 Usage Examples
@@ -282,7 +282,7 @@ virtual HfPwmErr SetPeriodCallback(uint8_t channel, PwmPeriodCallback callback) 
 auto pwm = McuPwm::Create();
 
 // Configure channel for LED brightness control
-PwmChannelConfig config;
+hf_pwm_channel_config_t config;
 config.output_pin = 18;          // GPIO 18
 config.frequency_hz = 1000;      // 1kHz
 config.resolution_bits = 12;     // 12-bit resolution (0-4095)
@@ -290,8 +290,8 @@ config.initial_duty_cycle = 0.5f; // 50% brightness
 
 // Initialize and configure
 if (pwm->EnsureInitialized()) {
-    HfPwmErr result = pwm->ConfigureChannel(0, config);
-    if (result == HfPwmErr::PWM_SUCCESS) {
+    hf_pwm_err_t result = pwm->ConfigureChannel(0, config);
+    if (result == hf_pwm_err_t::PWM_SUCCESS) {
         pwm->EnableChannel(0);
         printf("PWM channel 0 configured successfully\n");
     }
@@ -301,7 +301,7 @@ if (pwm->EnsureInitialized()) {
 ### Motor Control with Complementary Outputs
 ```cpp
 // Configure for 3-phase motor control
-PwmChannelConfig motor_config;
+hf_pwm_channel_config_t motor_config;
 motor_config.frequency_hz = 20000;           // 20kHz for motor control
 motor_config.resolution_bits = 14;           // 14-bit for precise control
 motor_config.alignment = PwmAlignment::CenterAligned;
@@ -323,7 +323,7 @@ pwm->SetDutyCycle(2, 0.1f);  // Phase C: 10%
 ### Servo Control
 ```cpp
 // Configure for servo control (50Hz, 1-2ms pulse width)
-PwmChannelConfig servo_config;
+hf_pwm_channel_config_t servo_config;
 servo_config.output_pin = 21;
 servo_config.frequency_hz = 50;              // 50Hz (20ms period)
 servo_config.resolution_bits = 16;           // High resolution for precise timing
@@ -349,8 +349,8 @@ for (uint32_t freq = 1000; freq <= 10000; freq += 1000) {
         vTaskDelay(pdMS_TO_TICKS(100));
         
         // Monitor status
-        PwmChannelStatus status;
-        if (pwm->GetChannelStatus(0, status) == HfPwmErr::PWM_SUCCESS) {
+        hf_pwm_channel_status_t status;
+        if (pwm->GetChannelStatus(0, status) == hf_pwm_err_t::PWM_SUCCESS) {
             printf("Freq: %u Hz, Duty: %.1f%%, Raw: %u\n", 
                    status.current_frequency_hz, 
                    status.current_duty_cycle * 100.0f,
@@ -390,8 +390,8 @@ pwm->SetPeriodCallback(0, [](uint8_t channel, uint32_t period_count) {
 ### Hardware Capability Discovery
 ```cpp
 // Discover what the PWM implementation supports
-PwmCapabilities caps;
-if (pwm->GetCapabilities(caps) == HfPwmErr::PWM_SUCCESS) {
+hf_pwm_capabilities_t caps;
+if (pwm->GetCapabilities(caps) == hf_pwm_err_t::PWM_SUCCESS) {
     printf("PWM Capabilities:\n");
     printf("  Max Channels: %d\n", caps.max_channels);
     printf("  Max Timers: %d\n", caps.max_timers);
@@ -406,18 +406,18 @@ if (pwm->GetCapabilities(caps) == HfPwmErr::PWM_SUCCESS) {
 ### Error Handling
 ```cpp
 // Comprehensive error handling
-HfPwmErr result = pwm->SetDutyCycle(0, 1.5f);  // Invalid duty cycle
-if (result != HfPwmErr::PWM_SUCCESS) {
+hf_pwm_err_t result = pwm->SetDutyCycle(0, 1.5f);  // Invalid duty cycle
+if (result != hf_pwm_err_t::PWM_SUCCESS) {
     printf("Error setting duty cycle: %s\n", PwmErrorToString(result));
     
     switch (result) {
-        case HfPwmErr::PWM_ERR_INVALID_CHANNEL:
+        case hf_pwm_err_t::PWM_ERR_INVALID_CHANNEL:
             printf("Channel does not exist\n");
             break;
-        case HfPwmErr::PWM_ERR_DUTY_OUT_OF_RANGE:
+        case hf_pwm_err_t::PWM_ERR_DUTY_OUT_OF_RANGE:
             printf("Duty cycle must be between 0.0 and 1.0\n");
             break;
-        case HfPwmErr::PWM_ERR_NOT_INITIALIZED:
+        case hf_pwm_err_t::PWM_ERR_NOT_INITIALIZED:
             printf("PWM not initialized - calling EnsureInitialized()\n");
             pwm->EnsureInitialized();
             break;

--- a/docs/examples/PracticalExamples.md
+++ b/docs/examples/PracticalExamples.md
@@ -991,10 +991,10 @@ public:
         
         // Register message handlers
         can_system_.RegisterMessageHandler(0x200 + node_id_, 
-            [this](const hf_can_message_t& msg) { HandleControlMessage(msg); });
+            `this`(const hf_can_message_t& msg) { HandleControlMessage(msg); });
             
         can_system_.RegisterMessageHandler(0x600 + node_id_, 
-            [this](const hf_can_message_t& msg) { HandleStatusRequest(msg); });
+            `this`(const hf_can_message_t& msg) { HandleStatusRequest(msg); });
         
         can_system_.StartReceiving();
         

--- a/inc/base/BasePwm.h
+++ b/inc/base/BasePwm.h
@@ -64,7 +64,7 @@
   X(PWM_ERR_INVALID_DEVICE_ID, 23, "Invalid device ID")
 
 // Generate enum class
-enum class HfPwmErr : uint32_t {
+enum class hf_pwm_err_t : uint32_t {
 #define X(name, value, description) name = value,
   HF_PWM_ERR_LIST(X)
 #undef X
@@ -72,10 +72,10 @@ enum class HfPwmErr : uint32_t {
 };
 
 // Generate error message function
-constexpr const char *PwmErrorToString(HfPwmErr error) noexcept {
+constexpr const char *hf_pwm_err_tToString(hf_pwm_err_t error) noexcept {
   switch (error) {
 #define X(name, value, description)                                                                \
-  case HfPwmErr::name:                                                                             \
+  case hf_pwm_err_t::name:                                                                             \
     return description;
     HF_PWM_ERR_LIST(X)
 #undef X
@@ -117,18 +117,18 @@ enum class hf_pwm_idle_state_t : uint8_t {
 /**
  * @brief PWM channel configuration structure
  */
-struct PwmChannelConfig {
-  HfPinNumber output_pin;    ///< GPIO pin for PWM output
-  uint32_t frequency_hz;     ///< PWM frequency in Hz
-  uint8_t resolution_bits;   ///< PWM resolution (8-16 bits typical)
-  PwmOutputMode output_mode; ///< Output mode configuration
-  PwmAlignment alignment;    ///< PWM alignment mode
-  PwmIdleState idle_state;   ///< Idle state configuration
-  float initial_duty_cycle;  ///< Initial duty cycle (0.0 - 1.0)
-  bool invert_output;        ///< Invert the output signal
+struct hf_pwm_channel_config_t {
+  hf_pin_num_t output_pin;        ///< GPIO pin for PWM output
+  uint32_t frequency_hz;         ///< PWM frequency in Hz
+  uint8_t resolution_bits;       ///< PWM resolution (8-16 bits typical)
+  hf_pwm_output_mode_t output_mode; ///< Output mode configuration
+  hf_pwm_alignment_t alignment;     ///< PWM alignment mode
+  hf_pwm_idle_state_t idle_state;   ///< Idle state configuration
+  float initial_duty_cycle;      ///< Initial duty cycle (0.0 - 1.0)
+  bool invert_output;            ///< Invert the output signal
 
   // Default constructor with sensible defaults
-  PwmChannelConfig() noexcept
+  hf_pwm_channel_config_t() noexcept
       : output_pin(-1), frequency_hz(1000), resolution_bits(12), output_mode(hf_pwm_output_mode_t::Normal),
         alignment(hf_pwm_alignment_t::EdgeAligned), idle_state(hf_pwm_idle_state_t::Low),
         initial_duty_cycle(0.0f), invert_output(false) {}
@@ -137,15 +137,15 @@ struct PwmChannelConfig {
 /**
  * @brief PWM timer configuration (for MCU implementations)
  */
-struct PwmTimerConfig {
-  uint8_t timer_number;       ///< Timer/group number
-  uint32_t base_frequency_hz; ///< Base timer frequency
-  uint8_t resolution_bits;    ///< Timer resolution
-  PwmAlignment alignment;     ///< Timer alignment mode
+struct hf_pwm_timer_config_t {
+  uint8_t timer_number;          ///< Timer/group number
+  uint32_t base_frequency_hz;    ///< Base timer frequency
+  uint8_t resolution_bits;       ///< Timer resolution
+  hf_pwm_alignment_t alignment;  ///< Timer alignment mode
 
-  PwmTimerConfig() noexcept
+  hf_pwm_timer_config_t() noexcept
       : timer_number(0), base_frequency_hz(80000000),
-        resolution_bits(12), alignment(PwmAlignment::EdgeAligned) {}
+        resolution_bits(12), alignment(hf_pwm_alignment_t::EdgeAligned) {}
 };
 
 //--------------------------------------
@@ -155,23 +155,23 @@ struct PwmTimerConfig {
 /**
  * @brief PWM channel status information
  */
-struct PwmChannelStatus {
+struct hf_pwm_channel_status_t {
   bool is_enabled;               ///< Channel is enabled
   bool is_running;               ///< Channel is actively generating PWM
   uint32_t current_frequency_hz; ///< Current frequency
   float current_duty_cycle;      ///< Current duty cycle (0.0 - 1.0)
   uint32_t raw_duty_value;       ///< Raw duty register value
-  HfPwmErr last_error;           ///< Last error encountered
+  hf_pwm_err_t last_error;           ///< Last error encountered
 
-  PwmChannelStatus() noexcept
+  hf_pwm_channel_status_t() noexcept
       : is_enabled(false), is_running(false), current_frequency_hz(0), current_duty_cycle(0.0f),
-        raw_duty_value(0), last_error(HfPwmErr::PWM_SUCCESS) {}
+        raw_duty_value(0), last_error(hf_pwm_err_t::PWM_SUCCESS) {}
 };
 
 /**
  * @brief PWM capability information (what the implementation supports)
  */
-struct PwmCapabilities {
+struct hf_pwm_capabilities_t {
   uint8_t max_channels;         ///< Maximum number of channels
   uint8_t max_timers;           ///< Maximum number of timers
   uint32_t min_frequency_hz;    ///< Minimum supported frequency
@@ -193,7 +193,7 @@ struct PwmCapabilities {
  * @param channel_id Channel that completed a period
  * @param user_data User-provided data
  */
-using PwmPeriodCallback = std::function<void(HfChannelId channel_id, void *user_data)>;
+using hf_pwm_period_callback_t = std::function<void(hf_channel_id_t channel_id, void *user_data)>;
 
 /**
  * @brief Callback for PWM fault/error events
@@ -201,8 +201,8 @@ using PwmPeriodCallback = std::function<void(HfChannelId channel_id, void *user_
  * @param error Error that occurred
  * @param user_data User-provided data
  */
-using PwmFaultCallback =
-    std::function<void(HfChannelId channel_id, HfPwmErr error, void *user_data)>;
+using hf_pwm_fault_callback_t =
+    std::function<void(hf_channel_id_t channel_id, hf_pwm_err_t error, void *user_data)>;
 
 //--------------------------------------
 //  Abstract Base Class
@@ -238,13 +238,13 @@ public:
    * @brief Initialize the PWM system
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr Initialize() noexcept = 0;
+  virtual hf_pwm_err_t Initialize() noexcept = 0;
 
   /**
    * @brief Deinitialize the PWM system
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr Deinitialize() noexcept = 0;
+  virtual hf_pwm_err_t Deinitialize() noexcept = 0;
 
   /**
    * @brief Check if PWM system is initialized
@@ -262,29 +262,29 @@ public:
    * @param config Channel configuration
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr ConfigureChannel(HfChannelId channel_id,
-                                    const PwmChannelConfig &config) noexcept = 0;
+  virtual hf_pwm_err_t ConfigureChannel(hf_channel_id_t channel_id,
+                                    const hf_pwm_channel_config_t &config) noexcept = 0;
 
   /**
    * @brief Enable a PWM channel
    * @param channel_id Channel to enable
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr EnableChannel(HfChannelId channel_id) noexcept = 0;
+  virtual hf_pwm_err_t EnableChannel(hf_channel_id_t channel_id) noexcept = 0;
 
   /**
    * @brief Disable a PWM channel
    * @param channel_id Channel to disable
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr DisableChannel(HfChannelId channel_id) noexcept = 0;
+  virtual hf_pwm_err_t DisableChannel(hf_channel_id_t channel_id) noexcept = 0;
 
   /**
    * @brief Check if a channel is enabled
    * @param channel_id Channel to check
    * @return true if enabled, false otherwise
    */
-  virtual bool IsChannelEnabled(HfChannelId channel_id) const noexcept = 0;
+  virtual bool IsChannelEnabled(hf_channel_id_t channel_id) const noexcept = 0;
 
   //==============================================================================
   // PWM CONTROL
@@ -296,7 +296,7 @@ public:
    * @param duty_cycle Duty cycle (0.0 - 1.0)
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept = 0;
+  virtual hf_pwm_err_t SetDutyCycle(hf_channel_id_t channel_id, float duty_cycle) noexcept = 0;
 
   /**
    * @brief Set raw duty value for a channel
@@ -304,7 +304,7 @@ public:
    * @param raw_value Raw duty register value
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept = 0;
+  virtual hf_pwm_err_t SetDutyCycleRaw(hf_channel_id_t channel_id, uint32_t raw_value) noexcept = 0;
 
   /**
    * @brief Set frequency for a channel
@@ -312,7 +312,7 @@ public:
    * @param frequency_hz Frequency in Hz
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept = 0;
+  virtual hf_pwm_err_t SetFrequency(hf_channel_id_t channel_id, hf_frequency_hz_t frequency_hz) noexcept = 0;
 
   /**
    * @brief Set phase shift for a channel (if supported)
@@ -320,7 +320,7 @@ public:
    * @param phase_shift_degrees Phase shift in degrees (0-360)
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept = 0;
+  virtual hf_pwm_err_t SetPhaseShift(hf_channel_id_t channel_id, float phase_shift_degrees) noexcept = 0;
 
   //==============================================================================
   // ADVANCED FEATURES
@@ -330,19 +330,19 @@ public:
    * @brief Start all enabled channels simultaneously
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr StartAll() noexcept = 0;
+  virtual hf_pwm_err_t StartAll() noexcept = 0;
 
   /**
    * @brief Stop all channels
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr StopAll() noexcept = 0;
+  virtual hf_pwm_err_t StopAll() noexcept = 0;
 
   /**
    * @brief Update all channel outputs simultaneously (for synchronized updates)
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr UpdateAll() noexcept = 0;
+  virtual hf_pwm_err_t UpdateAll() noexcept = 0;
 
   /**
    * @brief Set complementary output configuration (for motor control)
@@ -351,8 +351,8 @@ public:
    * @param deadtime_ns Deadtime in nanoseconds
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr SetComplementaryOutput(HfChannelId primary_channel,
-                                          HfChannelId complementary_channel,
+  virtual hf_pwm_err_t SetComplementaryOutput(hf_channel_id_t primary_channel,
+                                          hf_channel_id_t complementary_channel,
                                           uint32_t deadtime_ns) noexcept = 0;
 
   //==============================================================================
@@ -364,14 +364,14 @@ public:
    * @param channel_id Channel identifier
    * @return Current duty cycle (0.0 - 1.0), or -1.0 on error
    */
-  virtual float GetDutyCycle(HfChannelId channel_id) const noexcept = 0;
+  virtual float GetDutyCycle(hf_channel_id_t channel_id) const noexcept = 0;
 
   /**
    * @brief Get current frequency for a channel
    * @param channel_id Channel identifier
    * @return Current frequency in Hz, or 0 on error
    */
-  virtual HfFrequencyHz GetFrequency(HfChannelId channel_id) const noexcept = 0;
+  virtual hf_frequency_hz_t GetFrequency(hf_channel_id_t channel_id) const noexcept = 0;
 
   /**
    * @brief Get channel status
@@ -379,22 +379,22 @@ public:
    * @param status Status structure to fill
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr GetChannelStatus(HfChannelId channel_id,
-                                    PwmChannelStatus &status) const noexcept = 0;
+  virtual hf_pwm_err_t GetChannelStatus(hf_channel_id_t channel_id,
+                                    hf_pwm_channel_status_t &status) const noexcept = 0;
 
   /**
    * @brief Get PWM implementation capabilities
    * @param capabilities Capabilities structure to fill
    * @return PWM_SUCCESS on success, error code on failure
    */
-  virtual HfPwmErr GetCapabilities(PwmCapabilities &capabilities) const noexcept = 0;
+  virtual hf_pwm_err_t GetCapabilities(hf_pwm_capabilities_t &capabilities) const noexcept = 0;
 
   /**
    * @brief Get last error for a specific channel
    * @param channel_id Channel identifier
    * @return Last error code for the channel
    */
-  virtual HfPwmErr GetLastError(HfChannelId channel_id) const noexcept = 0;
+  virtual hf_pwm_err_t GetLastError(hf_channel_id_t channel_id) const noexcept = 0;
 
   //==============================================================================
   // CALLBACKS
@@ -405,7 +405,7 @@ public:
    * @param callback Callback function
    * @param user_data User data passed to callback
    */
-  virtual void SetPeriodCallback(PwmPeriodCallback callback,
+  virtual void SetPeriodCallback(hf_pwm_period_callback_t callback,
                                  void *user_data = nullptr) noexcept = 0;
 
   /**
@@ -413,7 +413,7 @@ public:
    * @param callback Callback function
    * @param user_data User data passed to callback
    */
-  virtual void SetFaultCallback(PwmFaultCallback callback, void *user_data = nullptr) noexcept = 0;
+  virtual void SetFaultCallback(hf_pwm_fault_callback_t callback, void *user_data = nullptr) noexcept = 0;
 
   //==============================================================================
   // UTILITY FUNCTIONS

--- a/inc/mcu/esp32/EspPwm.h
+++ b/inc/mcu/esp32/EspPwm.h
@@ -25,21 +25,6 @@
 #include "McuTypes.h"
 #include <array>
 
-// Type aliases to centralized types in McuTypes.h (no duplicate type declarations)
-using PwmChannelNative = hf_pwm_channel_native_t;
-using PwmTimerNative = hf_pwm_timer_native_t;
-using PwmModeNative = hf_pwm_mode_native_t;
-using PwmClockSource = hf_pwm_clock_source_t;
-using PwmResolution = hf_pwm_resolution_t;
-using PwmFadeMode = hf_pwm_fade_mode_t;
-using PwmIntrType = hf_pwm_intr_type_t;
-using PwmTimingConfig = hf_pwm_timing_config_t;
-using PwmChannelConfigNative = hf_pwm_channel_config_native_t;
-using PwmTimerConfigNative = hf_pwm_timer_config_native_t;
-using PwmFadeConfig = hf_pwm_fade_config_t;
-using PwmCapabilities = hf_pwm_capabilities_t;
-using PwmStatistics = hf_pwm_statistics_t;
-
 /**
  * @class McuPwm
  * @brief PWM implementation for microcontrollers with integrated PWM peripherals.
@@ -101,56 +86,56 @@ public:
   // LIFECYCLE (BasePwm Interface)
   //==============================================================================
 
-  HfPwmErr Initialize() noexcept override;
-  HfPwmErr Deinitialize() noexcept override;
+  hf_pwm_err_t Initialize() noexcept override;
+  hf_pwm_err_t Deinitialize() noexcept override;
   bool IsInitialized() const noexcept override;
 
   //==============================================================================
   // CHANNEL MANAGEMENT (BasePwm Interface)
   //==============================================================================
 
-  HfPwmErr ConfigureChannel(HfChannelId channel_id,
-                            const PwmChannelConfig &config) noexcept override;
-  HfPwmErr EnableChannel(HfChannelId channel_id) noexcept override;
-  HfPwmErr DisableChannel(HfChannelId channel_id) noexcept override;
-  bool IsChannelEnabled(HfChannelId channel_id) const noexcept override;
+  hf_pwm_err_t ConfigureChannel(hf_channel_id_t channel_id,
+                            const hf_pwm_channel_config_t &config) noexcept override;
+  hf_pwm_err_t EnableChannel(hf_channel_id_t channel_id) noexcept override;
+  hf_pwm_err_t DisableChannel(hf_channel_id_t channel_id) noexcept override;
+  bool IsChannelEnabled(hf_channel_id_t channel_id) const noexcept override;
 
   //==============================================================================
   // PWM CONTROL (BasePwm Interface)
   //==============================================================================
 
-  HfPwmErr SetDutyCycle(HfChannelId channel_id, float duty_cycle) noexcept override;
-  HfPwmErr SetDutyCycleRaw(HfChannelId channel_id, uint32_t raw_value) noexcept override;
-  HfPwmErr SetFrequency(HfChannelId channel_id, HfFrequencyHz frequency_hz) noexcept override;
-  HfPwmErr SetPhaseShift(HfChannelId channel_id, float phase_shift_degrees) noexcept override;
+  hf_pwm_err_t SetDutyCycle(hf_channel_id_t channel_id, float duty_cycle) noexcept override;
+  hf_pwm_err_t SetDutyCycleRaw(hf_channel_id_t channel_id, uint32_t raw_value) noexcept override;
+  hf_pwm_err_t SetFrequency(hf_channel_id_t channel_id, hf_frequency_hz_t frequency_hz) noexcept override;
+  hf_pwm_err_t SetPhaseShift(hf_channel_id_t channel_id, float phase_shift_degrees) noexcept override;
 
   //==============================================================================
   // ADVANCED FEATURES (BasePwm Interface)
   //==============================================================================
 
-  HfPwmErr StartAll() noexcept override;
-  HfPwmErr StopAll() noexcept override;
-  HfPwmErr UpdateAll() noexcept override;
-  HfPwmErr SetComplementaryOutput(HfChannelId primary_channel, HfChannelId complementary_channel,
+  hf_pwm_err_t StartAll() noexcept override;
+  hf_pwm_err_t StopAll() noexcept override;
+  hf_pwm_err_t UpdateAll() noexcept override;
+  hf_pwm_err_t SetComplementaryOutput(hf_channel_id_t primary_channel, hf_channel_id_t complementary_channel,
                                   uint32_t deadtime_ns) noexcept override;
 
   //==============================================================================
   // STATUS AND INFORMATION (BasePwm Interface)
   //==============================================================================
 
-  float GetDutyCycle(HfChannelId channel_id) const noexcept override;
-  HfFrequencyHz GetFrequency(HfChannelId channel_id) const noexcept override;
-  HfPwmErr GetChannelStatus(HfChannelId channel_id,
-                            PwmChannelStatus &status) const noexcept override;
-  HfPwmErr GetCapabilities(PwmCapabilities &capabilities) const noexcept override;
-  HfPwmErr GetLastError(HfChannelId channel_id) const noexcept override;
+  float GetDutyCycle(hf_channel_id_t channel_id) const noexcept override;
+  hf_frequency_hz_t GetFrequency(hf_channel_id_t channel_id) const noexcept override;
+  hf_pwm_err_t GetChannelStatus(hf_channel_id_t channel_id,
+                            hf_pwm_channel_status_t &status) const noexcept override;
+  hf_pwm_err_t GetCapabilities(hf_pwm_capabilities_t &capabilities) const noexcept override;
+  hf_pwm_err_t GetLastError(hf_channel_id_t channel_id) const noexcept override;
 
   //==============================================================================
   // CALLBACKS (BasePwm Interface)
   //==============================================================================
 
-  void SetPeriodCallback(PwmPeriodCallback callback, void *user_data = nullptr) noexcept override;
-  void SetFaultCallback(PwmFaultCallback callback, void *user_data = nullptr) noexcept override;
+  void SetPeriodCallback(hf_pwm_period_callback_t callback, void *user_data = nullptr) noexcept override;
+  void SetFaultCallback(hf_pwm_fault_callback_t callback, void *user_data = nullptr) noexcept override;
 
   //==============================================================================
   // ESP32C6-SPECIFIC FEATURES
@@ -163,7 +148,7 @@ public:
    * @param fade_time_ms Fade duration in milliseconds
    * @return PWM_SUCCESS on success, error code on failure
    */
-  HfPwmErr SetHardwareFade(HfChannelId channel_id, float target_duty_cycle,
+  hf_pwm_err_t SetHardwareFade(hf_channel_id_t channel_id, float target_duty_cycle,
                            uint32_t fade_time_ms) noexcept;
 
   /**
@@ -171,14 +156,14 @@ public:
    * @param channel_id Channel identifier
    * @return PWM_SUCCESS on success, error code on failure
    */
-  HfPwmErr StopHardwareFade(HfChannelId channel_id) noexcept;
+  hf_pwm_err_t StopHardwareFade(hf_channel_id_t channel_id) noexcept;
 
   /**
    * @brief Check if hardware fade is active on a channel
    * @param channel_id Channel identifier
    * @return true if fade is active, false otherwise
    */
-  bool IsFadeActive(HfChannelId channel_id) const noexcept;
+  bool IsFadeActive(hf_channel_id_t channel_id) const noexcept;
 
   /**
    * @brief Set idle output level for a channel
@@ -186,14 +171,14 @@ public:
    * @param idle_level Idle level (0 or 1)
    * @return PWM_SUCCESS on success, error code on failure
    */
-  HfPwmErr SetIdleLevel(HfChannelId channel_id, uint8_t idle_level) noexcept;
+  hf_pwm_err_t SetIdleLevel(hf_channel_id_t channel_id, uint8_t idle_level) noexcept;
 
   /**
    * @brief Get current timer assignment for a channel
    * @param channel_id Channel identifier
    * @return Timer number (0-3), or -1 if channel not configured
    */
-  int8_t GetTimerAssignment(HfChannelId channel_id) const noexcept;
+  int8_t GetTimerAssignment(hf_channel_id_t channel_id) const noexcept;
 
   /**
    * @brief Force a specific timer for a channel (advanced usage)
@@ -202,7 +187,7 @@ public:
    * @return PWM_SUCCESS on success, error code on failure
    * @note Use with caution - automatic timer allocation is usually better
    */
-  HfPwmErr ForceTimerAssignment(HfChannelId channel_id, uint8_t timer_id) noexcept;
+  hf_pwm_err_t ForceTimerAssignment(hf_channel_id_t channel_id, uint8_t timer_id) noexcept;
 
 private:
   //==============================================================================
@@ -215,15 +200,15 @@ private:
   struct ChannelState {
     bool configured;         ///< Channel is configured
     bool enabled;            ///< Channel is enabled
-    PwmChannelConfig config; ///< Channel configuration
+    hf_pwm_channel_config_t config; ///< Channel configuration
     uint8_t assigned_timer;  ///< Assigned timer (0-3)
     uint32_t raw_duty_value; ///< Current raw duty value
-    HfPwmErr last_error;     ///< Last error for this channel
+    hf_pwm_err_t last_error;     ///< Last error for this channel
     bool fade_active;        ///< Hardware fade is active
 
     ChannelState() noexcept
         : configured(false), enabled(false), assigned_timer(0xFF), raw_duty_value(0),
-          last_error(HfPwmErr::PWM_SUCCESS), fade_active(false) {}
+          last_error(hf_pwm_err_t::PWM_SUCCESS), fade_active(false) {}
   };
 
   /**
@@ -260,7 +245,7 @@ private:
    * @param channel_id Channel to validate
    * @return true if valid, false otherwise
    */
-  bool IsValidChannelId(HfChannelId channel_id) const noexcept;
+  bool IsValidChannelId(hf_channel_id_t channel_id) const noexcept;
 
   /**
    * @brief Find or allocate a timer for the given frequency and resolution
@@ -283,7 +268,7 @@ private:
    * @param resolution_bits Timer resolution
    * @return PWM_SUCCESS on success, error code on failure
    */
-  HfPwmErr ConfigurePlatformTimer(uint8_t timer_id, uint32_t frequency_hz,
+  hf_pwm_err_t ConfigurePlatformTimer(uint8_t timer_id, uint32_t frequency_hz,
                                   uint8_t resolution_bits) noexcept;
 
   /**
@@ -293,7 +278,7 @@ private:
    * @param timer_id Assigned timer
    * @return PWM_SUCCESS on success, error code on failure
    */
-  HfPwmErr ConfigurePlatformChannel(HfChannelId channel_id, const PwmChannelConfig &config,
+  hf_pwm_err_t ConfigurePlatformChannel(hf_channel_id_t channel_id, const hf_pwm_channel_config_t &config,
                                     uint8_t timer_id) noexcept;
 
   /**
@@ -302,26 +287,26 @@ private:
    * @param raw_duty_value Raw duty value
    * @return PWM_SUCCESS on success, error code on failure
    */
-  HfPwmErr UpdatePlatformDuty(HfChannelId channel_id, uint32_t raw_duty_value) noexcept;
+  hf_pwm_err_t UpdatePlatformDuty(hf_channel_id_t channel_id, uint32_t raw_duty_value) noexcept;
 
   /**
    * @brief Set error for a channel
    * @param channel_id Channel identifier
    * @param error Error to set
    */
-  void SetChannelError(HfChannelId channel_id, HfPwmErr error) noexcept;
+  void SetChannelError(hf_channel_id_t channel_id, hf_pwm_err_t error) noexcept;
 
   /**
    * @brief Platform-specific interrupt handler
    * @param channel_id Channel that generated interrupt
    */
-  static void IRAM_ATTR InterruptHandler(HfChannelId channel_id, void *user_data) noexcept;
+  static void IRAM_ATTR InterruptHandler(hf_channel_id_t channel_id, void *user_data) noexcept;
 
   /**
    * @brief Handle fade complete interrupt
    * @param channel_id Channel that completed fade
    */
-  void HandleFadeComplete(HfChannelId channel_id) noexcept;
+  void HandleFadeComplete(hf_channel_id_t channel_id) noexcept;
 
   //==============================================================================
   // MEMBER VARIABLES
@@ -335,10 +320,10 @@ private:
   std::array<TimerState, MAX_TIMERS> timers_;                           ///< Timer states
   std::array<ComplementaryPair, MAX_CHANNELS / 2> complementary_pairs_; ///< Complementary pairs
 
-  PwmPeriodCallback period_callback_; ///< Period complete callback
+  hf_pwm_period_callback_t period_callback_; ///< Period complete callback
   void *period_callback_user_data_;   ///< Period callback user data
-  PwmFaultCallback fault_callback_;   ///< Fault callback
+  hf_pwm_fault_callback_t fault_callback_;   ///< Fault callback
   void *fault_callback_user_data_;    ///< Fault callback user data
 
-  HfPwmErr last_global_error_; ///< Last global error
+  hf_pwm_err_t last_global_error_; ///< Last global error
 };

--- a/inc/mcu/esp32/utils/EspTypes_PWM.h
+++ b/inc/mcu/esp32/utils/EspTypes_PWM.h
@@ -16,7 +16,7 @@
 #include "HardwareTypes.h" // For basic hardware types
 #include "McuSelect.h"    // Central MCU platform selection (includes all ESP-IDF)
 #include "McuTypes_Base.h"
-#include "BasePwm.h" // For HfPwmErr
+#include "BasePwm.h" // For hf_pwm_err_t
 
 //==============================================================================
 // ESP32C6 PWM/LEDC TYPES AND CONSTANTS (ESP-IDF v5.5+)


### PR DESCRIPTION
## Summary
- rename PWM error enumeration and related types to `hf_*` names
- update ESP32 PWM headers and implementation for new type names
- update documentation to reflect renamed types
- fix link detection issue in example docs

## Testing
- `python3 docs/check_docs.py docs` *(fails: found 10 broken links)*
