### PR TITLE
Remove HF_ prefix from GPIO error enums

### DIFF
--- a/docs/ESP32_GPIO_ALIGNMENT_SUMMARY.md
+++ b/docs/ESP32_GPIO_ALIGNMENT_SUMMARY.md
@@ -10,12 +10,12 @@ This document summarizes the comprehensive analysis and alignment of the GPIO sy
 
 **Before**: Mixed naming conventions with inconsistent patterns
 - `HfGpioErr` vs `hf_gpio_err_t`
-- `GPIO_SUCCESS` vs `HF_GPIO_SUCCESS`
+- `GPIO_SUCCESS` vs `GPIO_SUCCESS`
 - Inconsistent error code naming
 
 **After**: Consistent `hf_*` prefix naming throughout
 - All types use `hf_gpio_*` prefix (e.g., `hf_gpio_err_t`, `hf_gpio_mode_t`)
-- Consistent error code naming (`HF_GPIO_SUCCESS`, `HF_GPIO_ERR_*`)
+- Consistent error code naming (`GPIO_SUCCESS`, `GPIO_ERR_*`)
 - Aligned with ADC and CAN system naming conventions
 
 ### 2. ESP-IDF v5.4+ API Alignment
@@ -176,12 +176,12 @@ EspGpio::WriteDedicatedBundle(bundle_handle, 0x0F);
 **Comprehensive Error Codes**:
 ```cpp
 enum class hf_gpio_err_t : uint8_t {
-    HF_GPIO_SUCCESS = 0,
-    HF_GPIO_ERR_FAILURE = 1,
-    HF_GPIO_ERR_NOT_INITIALIZED = 2,
-    HF_GPIO_ERR_INVALID_PARAMETER = 4,
-    HF_GPIO_ERR_PIN_NOT_FOUND = 8,
-    HF_GPIO_ERR_HARDWARE_FAULT = 13,
+    GPIO_SUCCESS = 0,
+    GPIO_ERR_FAILURE = 1,
+    GPIO_ERR_NOT_INITIALIZED = 2,
+    GPIO_ERR_INVALID_PARAMETER = 4,
+    GPIO_ERR_PIN_NOT_FOUND = 8,
+    GPIO_ERR_HARDWARE_FAULT = 13,
     // ... 37 total error codes
 };
 ```

--- a/docs/GPIO_CAN_REFACTORING_COMPLETE.md
+++ b/docs/GPIO_CAN_REFACTORING_COMPLETE.md
@@ -134,7 +134,7 @@ All ESP32C6-specific code properly wrapped:
   }
 #else
   ESP_LOGW(TAG, "Glitch filter not supported on this platform");
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 ```
 
@@ -172,7 +172,7 @@ Enhanced documentation throughout:
 /**
  * @brief Configure flexible glitch filter with custom timing.
  * @param config Flexible glitch filter configuration
- * @return HfGpioErr::HF_GPIO_OK if successful, error code otherwise
+ * @return HfGpioErr::GPIO_OK if successful, error code otherwise
  * @details Flexible glitch filter allows precise control over filtering parameters.
  *          Pulses shorter than window_threshold_ns within window_width_ns are filtered.
  *          ESP32C6 provides 8 flexible glitch filters with configurable duration.

--- a/docs/REFACTORING_SUMMARY.md
+++ b/docs/REFACTORING_SUMMARY.md
@@ -97,7 +97,7 @@ McuGpio led_gpio(18);
 
 // First operation triggers hardware initialization
 auto result = led_gpio.SetMode(GpioMode::GPIO_MODE_OUTPUT);
-if (result != HfGpioErr::HF_GPIO_OK) {
+if (result != HfGpioErr::GPIO_OK) {
     // Handle initialization error
 }
 

--- a/inc/base/BaseGpio.h
+++ b/inc/base/BaseGpio.h
@@ -30,60 +30,60 @@
  */
 #define HF_GPIO_ERR_LIST(X)                                                                        \
   /* Success codes */                                                                              \
-  X(HF_GPIO_SUCCESS, 0, "Success")                                                                    \
+  X(GPIO_SUCCESS, 0, "Success")                                                                    \
                                                                                                    \
   /* General errors */                                                                             \
-  X(HF_GPIO_ERR_FAILURE, 1, "General failure")                                                        \
-  X(HF_GPIO_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                \
-  X(HF_GPIO_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                        \
-  X(HF_GPIO_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                            \
-  X(HF_GPIO_ERR_NULL_POINTER, 5, "Null pointer")                                                      \
-  X(HF_GPIO_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                    \
+  X(GPIO_ERR_FAILURE, 1, "General failure")                                                        \
+  X(GPIO_ERR_NOT_INITIALIZED, 2, "Not initialized")                                                \
+  X(GPIO_ERR_ALREADY_INITIALIZED, 3, "Already initialized")                                        \
+  X(GPIO_ERR_INVALID_PARAMETER, 4, "Invalid parameter")                                            \
+  X(GPIO_ERR_NULL_POINTER, 5, "Null pointer")                                                      \
+  X(GPIO_ERR_OUT_OF_MEMORY, 6, "Out of memory")                                                    \
                                                                                                    \
   /* Pin errors */                                                                                 \
-  X(HF_GPIO_ERR_INVALID_PIN, 7, "Invalid pin")                                                        \
-  X(HF_GPIO_ERR_PIN_NOT_FOUND, 8, "Pin not found")                                                    \
-  X(HF_GPIO_ERR_PIN_NOT_CONFIGURED, 9, "Pin not configured")                                          \
-  X(HF_GPIO_ERR_PIN_ALREADY_REGISTERED, 10, "Pin already registered")                                 \
-  X(HF_GPIO_ERR_PIN_ACCESS_DENIED, 11, "Pin access denied")                                           \
-  X(HF_GPIO_ERR_PIN_BUSY, 12, "Pin busy")                                                             \
+  X(GPIO_ERR_INVALID_PIN, 7, "Invalid pin")                                                        \
+  X(GPIO_ERR_PIN_NOT_FOUND, 8, "Pin not found")                                                    \
+  X(GPIO_ERR_PIN_NOT_CONFIGURED, 9, "Pin not configured")                                          \
+  X(GPIO_ERR_PIN_ALREADY_REGISTERED, 10, "Pin already registered")                                 \
+  X(GPIO_ERR_PIN_ACCESS_DENIED, 11, "Pin access denied")                                           \
+  X(GPIO_ERR_PIN_BUSY, 12, "Pin busy")                                                             \
                                                                                                    \
   /* Hardware errors */                                                                            \
-  X(HF_GPIO_ERR_HARDWARE_FAULT, 13, "Hardware fault")                                                 \
-  X(HF_GPIO_ERR_COMMUNICATION_FAILURE, 14, "Communication failure")                                   \
-  X(HF_GPIO_ERR_DEVICE_NOT_RESPONDING, 15, "Device not responding")                                   \
-  X(HF_GPIO_ERR_TIMEOUT, 16, "Timeout")                                                               \
-  X(HF_GPIO_ERR_VOLTAGE_OUT_OF_RANGE, 17, "Voltage out of range")                                     \
+  X(GPIO_ERR_HARDWARE_FAULT, 13, "Hardware fault")                                                 \
+  X(GPIO_ERR_COMMUNICATION_FAILURE, 14, "Communication failure")                                   \
+  X(GPIO_ERR_DEVICE_NOT_RESPONDING, 15, "Device not responding")                                   \
+  X(GPIO_ERR_TIMEOUT, 16, "Timeout")                                                               \
+  X(GPIO_ERR_VOLTAGE_OUT_OF_RANGE, 17, "Voltage out of range")                                     \
                                                                                                    \
   /* Configuration errors */                                                                       \
-  X(HF_GPIO_ERR_INVALID_CONFIGURATION, 18, "Invalid configuration")                                   \
-  X(HF_GPIO_ERR_UNSUPPORTED_OPERATION, 19, "Unsupported operation")                                   \
-  X(HF_GPIO_ERR_RESOURCE_BUSY, 20, "Resource busy")                                                   \
-  X(HF_GPIO_ERR_RESOURCE_UNAVAILABLE, 21, "Resource unavailable")                                     \
+  X(GPIO_ERR_INVALID_CONFIGURATION, 18, "Invalid configuration")                                   \
+  X(GPIO_ERR_UNSUPPORTED_OPERATION, 19, "Unsupported operation")                                   \
+  X(GPIO_ERR_RESOURCE_BUSY, 20, "Resource busy")                                                   \
+  X(GPIO_ERR_RESOURCE_UNAVAILABLE, 21, "Resource unavailable")                                     \
                                                                                                    \
   /* I/O errors */                                                                                 \
-  X(HF_GPIO_ERR_READ_FAILURE, 22, "Read failure")                                                     \
-  X(HF_GPIO_ERR_WRITE_FAILURE, 23, "Write failure")                                                   \
-  X(HF_GPIO_ERR_DIRECTION_MISMATCH, 24, "Direction mismatch")                                         \
-  X(HF_GPIO_ERR_PULL_RESISTOR_FAILURE, 25, "Pull resistor failure")                                   \
+  X(GPIO_ERR_READ_FAILURE, 22, "Read failure")                                                     \
+  X(GPIO_ERR_WRITE_FAILURE, 23, "Write failure")                                                   \
+  X(GPIO_ERR_DIRECTION_MISMATCH, 24, "Direction mismatch")                                         \
+  X(GPIO_ERR_PULL_RESISTOR_FAILURE, 25, "Pull resistor failure")                                   \
                                                                                                    \
   /* Interrupt errors */                                                                           \
-  X(HF_GPIO_ERR_INTERRUPT_NOT_SUPPORTED, 26, "Interrupt not supported")                               \
-  X(HF_GPIO_ERR_INTERRUPT_ALREADY_ENABLED, 27, "Interrupt already enabled")                           \
-  X(HF_GPIO_ERR_INTERRUPT_NOT_ENABLED, 28, "Interrupt not enabled")                                   \
-  X(HF_GPIO_ERR_INTERRUPT_HANDLER_FAILED, 29, "Interrupt handler failed")                             \
+  X(GPIO_ERR_INTERRUPT_NOT_SUPPORTED, 26, "Interrupt not supported")                               \
+  X(GPIO_ERR_INTERRUPT_ALREADY_ENABLED, 27, "Interrupt already enabled")                           \
+  X(GPIO_ERR_INTERRUPT_NOT_ENABLED, 28, "Interrupt not enabled")                                   \
+  X(GPIO_ERR_INTERRUPT_HANDLER_FAILED, 29, "Interrupt handler failed")                             \
                                                                                                    \
   /* System errors */                                                                              \
-  X(HF_GPIO_ERR_SYSTEM_ERROR, 30, "System error")                                                     \
-  X(HF_GPIO_ERR_PERMISSION_DENIED, 31, "Permission denied")                                           \
-  X(HF_GPIO_ERR_OPERATION_ABORTED, 32, "Operation aborted")                                           \
+  X(GPIO_ERR_SYSTEM_ERROR, 30, "System error")                                                     \
+  X(GPIO_ERR_PERMISSION_DENIED, 31, "Permission denied")                                           \
+  X(GPIO_ERR_OPERATION_ABORTED, 32, "Operation aborted")                                           \
                                                                                                    \
   /* Extended errors for McuGpio implementation */                                                 \
-  X(HF_GPIO_ERR_NOT_SUPPORTED, 33, "Operation not supported")                                         \
-  X(HF_GPIO_ERR_DRIVER_ERROR, 34, "Driver error")                                                     \
-  X(HF_GPIO_ERR_INVALID_STATE, 35, "Invalid state")                                                   \
-  X(HF_GPIO_ERR_INVALID_ARG, 36, "Invalid argument")                                                  \
-  X(HF_GPIO_ERR_CALIBRATION_FAILURE, 37, "Calibration failure")
+  X(GPIO_ERR_NOT_SUPPORTED, 33, "Operation not supported")                                         \
+  X(GPIO_ERR_DRIVER_ERROR, 34, "Driver error")                                                     \
+  X(GPIO_ERR_INVALID_STATE, 35, "Invalid state")                                                   \
+  X(GPIO_ERR_INVALID_ARG, 36, "Invalid argument")                                                  \
+  X(GPIO_ERR_CALIBRATION_FAILURE, 37, "Calibration failure")
 
 /**
  * @brief HardFOC GPIO error codes
@@ -93,7 +93,7 @@ enum class hf_gpio_err_t : uint8_t {
 #define X(NAME, VALUE, DESC) NAME = VALUE,
   HF_GPIO_ERR_LIST(X)
 #undef X
-      HF_GPIO_ERR_COUNT // Automatically calculated count
+      GPIO_ERR_COUNT // Automatically calculated count
 };
 
 /**
@@ -296,16 +296,16 @@ public:
   /**
    * @brief Set the pin direction (input or output).
    * @param direction New Direction setting (Input or Output)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = SetDirectionImpl(direction);
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       current_direction_ = direction;
     }
     return result;
@@ -338,16 +338,16 @@ public:
   /**
    * @brief Set the output drive mode.
    * @param mode New OutputMode setting (PushPull or OpenDrain)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t SetOutputMode(hf_gpio_output_mode_t mode) noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = SetOutputModeImpl(mode);
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       output_mode_ = mode;
     }
     return result;
@@ -368,16 +368,16 @@ public:
   /**
    * @brief Set the pull resistor mode.
    * @param mode New PullMode setting (Floating, PullUp, or PullDown)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t SetPullMode(hf_gpio_pull_mode_t mode) noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = SetPullModeImpl(mode);
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       pull_mode_ = mode;
     }
     return result;
@@ -417,16 +417,16 @@ public:
 
   /**
    * @brief Set the GPIO to active state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t SetActive() noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = SetActiveImpl();
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       current_state_ = hf_gpio_state_t::HF_GPIO_STATE_ACTIVE;
     }
     return result;
@@ -434,16 +434,16 @@ public:
 
   /**
    * @brief Set the GPIO to inactive state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t SetInactive() noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = SetInactiveImpl();
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       current_state_ = hf_gpio_state_t::HF_GPIO_STATE_INACTIVE;
     }
     return result;
@@ -451,16 +451,16 @@ public:
 
   /**
    * @brief Toggle the GPIO state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t Toggle() noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = ToggleImpl();
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       current_state_ = (current_state_ == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE) ? hf_gpio_state_t::HF_GPIO_STATE_INACTIVE : hf_gpio_state_t::HF_GPIO_STATE_ACTIVE;
     }
     return result;
@@ -469,16 +469,16 @@ public:
   /**
    * @brief Check if the GPIO is currently active.
    * @param is_active Reference to store the result
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t IsActive(bool &is_active) noexcept {
     hf_gpio_err_t validation = ValidateBasicOperation();
-    if (validation != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (validation != hf_gpio_err_t::GPIO_SUCCESS) {
       return validation;
     }
 
     hf_gpio_err_t result = IsActiveImpl(is_active);
-    if (result == hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       current_state_ = is_active ? hf_gpio_state_t::HF_GPIO_STATE_ACTIVE : hf_gpio_state_t::HF_GPIO_STATE_INACTIVE;
     }
     return result;
@@ -522,54 +522,54 @@ public:
    * @param trigger Interrupt trigger type
    * @param callback Callback function to invoke on interrupt (optional)
    * @param user_data User data passed to callback (optional)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   virtual hf_gpio_err_t ConfigureInterrupt(hf_gpio_interrupt_trigger_t trigger, 
                                            InterruptCallback callback = nullptr,
                                            void *user_data = nullptr) noexcept {
-    return hf_gpio_err_t::HF_GPIO_ERR_NOT_SUPPORTED;
+    return hf_gpio_err_t::GPIO_ERR_NOT_SUPPORTED;
   }
 
   /**
    * @brief Enable GPIO interrupt.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   virtual hf_gpio_err_t EnableInterrupt() noexcept {
-    return hf_gpio_err_t::HF_GPIO_ERR_NOT_SUPPORTED;
+    return hf_gpio_err_t::GPIO_ERR_NOT_SUPPORTED;
   }
 
   /**
    * @brief Disable GPIO interrupt.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   virtual hf_gpio_err_t DisableInterrupt() noexcept {
-    return hf_gpio_err_t::HF_GPIO_ERR_NOT_SUPPORTED;
+    return hf_gpio_err_t::GPIO_ERR_NOT_SUPPORTED;
   }
 
   /**
    * @brief Wait for GPIO interrupt to occur.
    * @param timeout_ms Timeout in milliseconds (0 = wait forever)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if interrupt occurred, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if interrupt occurred, error code otherwise
    */
   virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept {
-    return hf_gpio_err_t::HF_GPIO_ERR_NOT_SUPPORTED;
+    return hf_gpio_err_t::GPIO_ERR_NOT_SUPPORTED;
   }
 
   /**
    * @brief Get interrupt status information.
    * @param status Reference to store status information
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   virtual hf_gpio_err_t GetInterruptStatus(InterruptStatus &status) noexcept {
-    return hf_gpio_err_t::HF_GPIO_ERR_NOT_SUPPORTED;
+    return hf_gpio_err_t::GPIO_ERR_NOT_SUPPORTED;
   }
 
   /**
    * @brief Clear interrupt statistics.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   virtual hf_gpio_err_t ClearInterruptStats() noexcept {
-    return hf_gpio_err_t::HF_GPIO_ERR_NOT_SUPPORTED;
+    return hf_gpio_err_t::GPIO_ERR_NOT_SUPPORTED;
   }
 
   //==============================================================//
@@ -612,12 +612,12 @@ protected:
    */
   [[nodiscard]] hf_gpio_err_t ValidateBasicOperation() const noexcept {
     if (!initialized_) {
-      return hf_gpio_err_t::HF_GPIO_ERR_NOT_INITIALIZED;
+      return hf_gpio_err_t::GPIO_ERR_NOT_INITIALIZED;
     }
     if (!IsPinAvailable()) {
-      return hf_gpio_err_t::HF_GPIO_ERR_PIN_ACCESS_DENIED;
+      return hf_gpio_err_t::GPIO_ERR_PIN_ACCESS_DENIED;
     }
-    return hf_gpio_err_t::HF_GPIO_SUCCESS;
+    return hf_gpio_err_t::GPIO_SUCCESS;
   }
 
   /**

--- a/inc/mcu/esp32/EspGpio.h
+++ b/inc/mcu/esp32/EspGpio.h
@@ -137,40 +137,40 @@ public:
    * @param trigger Interrupt trigger type
    * @param callback Callback function to invoke on interrupt (optional)
    * @param user_data User data passed to callback (optional)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t ConfigureInterrupt(InterruptTrigger trigger, InterruptCallback callback = nullptr,
                                void *user_data = nullptr) noexcept override;
 
   /**
    * @brief Enable GPIO interrupt.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t EnableInterrupt() noexcept override;
 
   /**
    * @brief Disable GPIO interrupt.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t DisableInterrupt() noexcept override;
 
   /**
    * @brief Wait for GPIO interrupt with timeout.
    * @param timeout_ms Timeout in milliseconds (0 = no timeout)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if interrupt occurred, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if interrupt occurred, error code otherwise
    */
   hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept override;
 
   /**
    * @brief Get current interrupt status and statistics.
    * @param status Reference to store interrupt status
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t GetInterruptStatus(InterruptStatus &status) noexcept override;
 
   /**
    * @brief Clear interrupt statistics/counters.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t ClearInterruptStats() noexcept override;
 
@@ -201,7 +201,7 @@ protected:
   /**
    * @brief Platform-specific implementation for setting pin direction.
    * @param direction Desired pin direction (Input or Output)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Reconfigures the MCU pin as input or output with appropriate
    *          pull resistor and drive mode settings.
    */
@@ -210,28 +210,28 @@ protected:
   /**
    * @brief Platform-specific implementation for setting output mode.
    * @param mode Desired output mode (PushPull or OpenDrain)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Changes the output drive characteristics of the MCU pin.
    */
   hf_gpio_err_t SetOutputModeImpl(hf_gpio_output_mode_t mode) noexcept override;
 
   /**
    * @brief Platform-specific implementation for setting active state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Sets the MCU pin to the electrical level corresponding to logical active.
    */
   hf_gpio_err_t SetActiveImpl() noexcept override;
 
   /**
    * @brief Platform-specific implementation for setting inactive state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Sets the MCU pin to the electrical level corresponding to logical inactive.
    */
   hf_gpio_err_t SetInactiveImpl() noexcept override;
 
   /**
    * @brief Platform-specific implementation for toggling pin state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Toggles the MCU pin between active and inactive states.
    */
   hf_gpio_err_t ToggleImpl() noexcept override;
@@ -239,7 +239,7 @@ protected:
   /**
    * @brief Platform-specific implementation for reading pin active state.
    * @param is_active Output parameter: true if active, false if inactive
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Reads the current MCU pin electrical level and converts to logical state.
    */
   hf_gpio_err_t IsActiveImpl(bool &is_active) noexcept override;
@@ -247,7 +247,7 @@ protected:
   /**
    * @brief Platform-specific implementation for setting pull resistor mode.
    * @param mode Desired PullMode configuration (Floating, PullUp, or PullDown)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Configures the MCU's internal pull resistors.
    */
   hf_gpio_err_t SetPullModeImpl(hf_gpio_pull_mode_t mode) noexcept override;
@@ -274,7 +274,7 @@ protected:
   /**
    * @brief Set GPIO drive capability.
    * @param capability New drive capability level
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Controls the output drive strength from ~5mA (Weak) to ~40mA (Strongest).
    *          Higher drive capability allows for faster switching and driving larger loads
    *          but increases power consumption and EMI.
@@ -290,7 +290,7 @@ protected:
   /**
    * @brief Configure pin glitch filter (fixed 2 clock cycles).
    * @param enable Enable or disable the pin glitch filter
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Pin glitch filter removes pulses shorter than 2 IO_MUX clock cycles.
    *          This is a simple, low-overhead filter suitable for basic noise rejection.
    */
@@ -299,7 +299,7 @@ protected:
   /**
    * @brief Configure flexible glitch filter with custom timing.
    * @param config Flexible glitch filter configuration
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Flexible glitch filter allows precise control over filtering parameters.
    *          Pulses shorter than window_threshold_ns within window_width_ns are filtered.
    */
@@ -307,13 +307,13 @@ protected:
 
   /**
    * @brief Enable all configured glitch filters.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t EnableGlitchFilters() noexcept;
 
   /**
    * @brief Disable all glitch filters.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   hf_gpio_err_t DisableGlitchFilters() noexcept;
 
@@ -326,7 +326,7 @@ protected:
   /**
    * @brief Configure GPIO sleep behavior.
    * @param config Sleep configuration parameters
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Configures how the GPIO behaves during sleep modes.
    *          Essential for power-optimized applications.
    */
@@ -335,7 +335,7 @@ protected:
   /**
    * @brief Enable GPIO hold function.
    * @param enable Enable or disable hold function
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Hold function maintains GPIO state during sleep and reset.
    *          Useful for maintaining critical pin states during power transitions.
    */
@@ -344,7 +344,7 @@ protected:
   /**
    * @brief Configure GPIO as wake-up source.
    * @param config Wake-up configuration parameters
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Enables GPIO to wake the system from deep sleep.
    *          Essential for battery-powered applications.
    */
@@ -371,7 +371,7 @@ protected:
   /**
    * @brief Configure ETM (Event Task Matrix) for hardware-level GPIO operations.
    * @param etm_config ETM configuration including event and task setup
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details ETM enables zero-latency hardware-level GPIO operations triggered by events.
    *          Perfect for precise timing requirements in motor control and signal processing.
    */
@@ -379,14 +379,14 @@ protected:
 
   /**
    * @brief Enable ETM channel for this GPIO.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Enables the configured ETM channel to start responding to events.
    */
   hf_gpio_err_t EnableETM() noexcept;
 
   /**
    * @brief Disable ETM channel for this GPIO.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Disables the ETM channel while preserving configuration.
    */
   hf_gpio_err_t DisableETM() noexcept;
@@ -401,7 +401,7 @@ protected:
   /**
    * @brief Get ETM status and configuration information.
    * @param status Output structure to store ETM status
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Provides comprehensive ETM status for monitoring and debugging.
    */
   hf_gpio_err_t GetETMStatus(hf_gpio_etm_status_t &status) const noexcept;
@@ -423,7 +423,7 @@ protected:
   /**
    * @brief Dump complete ETM configuration to output stream.
    * @param output_stream Output stream for dump (default: stdout)
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Provides comprehensive ETM system dump for debugging and analysis.
    */
   static hf_gpio_err_t DumpETMConfiguration(FILE* output_stream = nullptr) noexcept;
@@ -435,7 +435,7 @@ protected:
   /**
    * @brief Get pin capabilities for comprehensive feature detection.
    * @param capabilities Output structure to store pin capabilities
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Provides comprehensive information about pin capabilities including
    *          ADC, RTC, touch, strapping, and special function support.
    */
@@ -444,7 +444,7 @@ protected:
   /**
    * @brief Get detailed status information for diagnostics.
    * @param status Output structure to store status information
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Provides comprehensive status information for debugging and monitoring.
    */
   hf_gpio_err_t GetStatusInfo(hf_gpio_status_info_t &status) const noexcept;
@@ -464,7 +464,7 @@ protected:
    * @brief Create a dedicated GPIO bundle for high-speed operations.
    * @param config Dedicated GPIO bundle configuration
    * @param bundle_handle Output handle for the created bundle
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Dedicated GPIO bundles enable high-speed bit-banging operations
    *          with minimal CPU overhead, perfect for custom protocols.
    */
@@ -474,7 +474,7 @@ protected:
   /**
    * @brief Delete a dedicated GPIO bundle.
    * @param bundle_handle Handle of the bundle to delete
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   static hf_gpio_err_t DeleteDedicatedBundle(hf_dedic_gpio_bundle_handle_t bundle_handle) noexcept;
 
@@ -482,7 +482,7 @@ protected:
    * @brief Read data from a dedicated GPIO bundle.
    * @param bundle_handle Handle of the bundle to read from
    * @param data Output data from the bundle
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   static hf_gpio_err_t ReadDedicatedBundle(hf_dedic_gpio_bundle_handle_t bundle_handle,
                                            hf_dedic_gpio_bundle_data_t &data) noexcept;
@@ -491,7 +491,7 @@ protected:
    * @brief Write data to a dedicated GPIO bundle.
    * @param bundle_handle Handle of the bundle to write to
    * @param data Data to write to the bundle
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    */
   static hf_gpio_err_t WriteDedicatedBundle(hf_dedic_gpio_bundle_handle_t bundle_handle,
                                             hf_dedic_gpio_bundle_data_t data) noexcept;

--- a/inc/mcu/esp32/utils/EspTypes_GPIO.h
+++ b/inc/mcu/esp32/utils/EspTypes_GPIO.h
@@ -790,15 +790,15 @@ uint8_t hf_gpio_get_optimal_etm_channel(uint8_t gpio_num, uint8_t priority);
  * @brief GPIO operation result codes.
  */
 enum class hf_gpio_result_t : uint8_t {
-  HF_GPIO_OK = 0,                     ///< Operation successful
-  HF_GPIO_ERR_INVALID_ARG = 1,        ///< Invalid argument
-  HF_GPIO_ERR_INVALID_STATE = 2,      ///< Invalid state for operation
-  HF_GPIO_ERR_NOT_SUPPORTED = 3,      ///< Operation not supported
-  HF_GPIO_ERR_NO_MEM = 4,             ///< Out of memory
-  HF_GPIO_ERR_TIMEOUT = 5,            ///< Operation timeout
-  HF_GPIO_ERR_HW_FAULT = 6,           ///< Hardware fault
-  HF_GPIO_ERR_BUSY = 7,               ///< Resource busy
-  HF_GPIO_ERR_NOT_FOUND = 8           ///< Resource not found
+  GPIO_OK = 0,                     ///< Operation successful
+  GPIO_ERR_INVALID_ARG = 1,        ///< Invalid argument
+  GPIO_ERR_INVALID_STATE = 2,      ///< Invalid state for operation
+  GPIO_ERR_NOT_SUPPORTED = 3,      ///< Operation not supported
+  GPIO_ERR_NO_MEM = 4,             ///< Out of memory
+  GPIO_ERR_TIMEOUT = 5,            ///< Operation timeout
+  GPIO_ERR_HW_FAULT = 6,           ///< Hardware fault
+  GPIO_ERR_BUSY = 7,               ///< Resource busy
+  GPIO_ERR_NOT_FOUND = 8           ///< Resource not found
 };
 
 /**
@@ -808,15 +808,15 @@ enum class hf_gpio_result_t : uint8_t {
  */
 constexpr const char* hf_gpio_result_to_string(hf_gpio_result_t result) {
   switch (result) {
-    case hf_gpio_result_t::HF_GPIO_OK: return "Success";
-    case hf_gpio_result_t::HF_GPIO_ERR_INVALID_ARG: return "Invalid argument";
-    case hf_gpio_result_t::HF_GPIO_ERR_INVALID_STATE: return "Invalid state";
-    case hf_gpio_result_t::HF_GPIO_ERR_NOT_SUPPORTED: return "Not supported";
-    case hf_gpio_result_t::HF_GPIO_ERR_NO_MEM: return "Out of memory";
-    case hf_gpio_result_t::HF_GPIO_ERR_TIMEOUT: return "Timeout";
-    case hf_gpio_result_t::HF_GPIO_ERR_HW_FAULT: return "Hardware fault";
-    case hf_gpio_result_t::HF_GPIO_ERR_BUSY: return "Resource busy";
-    case hf_gpio_result_t::HF_GPIO_ERR_NOT_FOUND: return "Resource not found";
+    case hf_gpio_result_t::GPIO_OK: return "Success";
+    case hf_gpio_result_t::GPIO_ERR_INVALID_ARG: return "Invalid argument";
+    case hf_gpio_result_t::GPIO_ERR_INVALID_STATE: return "Invalid state";
+    case hf_gpio_result_t::GPIO_ERR_NOT_SUPPORTED: return "Not supported";
+    case hf_gpio_result_t::GPIO_ERR_NO_MEM: return "Out of memory";
+    case hf_gpio_result_t::GPIO_ERR_TIMEOUT: return "Timeout";
+    case hf_gpio_result_t::GPIO_ERR_HW_FAULT: return "Hardware fault";
+    case hf_gpio_result_t::GPIO_ERR_BUSY: return "Resource busy";
+    case hf_gpio_result_t::GPIO_ERR_NOT_FOUND: return "Resource not found";
     default: return "Unknown error";
   }
 }

--- a/inc/utils/DigitalOutputGuard.h
+++ b/inc/utils/DigitalOutputGuard.h
@@ -93,7 +93,7 @@ public:
 
   /**
    * @brief Manually set the GPIO to active state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Allows manual control while the guard is active. The destructor
    *          will still set the pin inactive when the guard goes out of scope.
    */
@@ -101,7 +101,7 @@ public:
 
   /**
    * @brief Manually set the GPIO to inactive state.
-   * @return hf_gpio_err_t::HF_GPIO_SUCCESS if successful, error code otherwise
+   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
    * @details Allows manual control while the guard is active. The destructor
    *          will still attempt to set the pin inactive when the guard goes out of scope.
    */

--- a/src/mcu/esp32/EspGpio.cpp
+++ b/src/mcu/esp32/EspGpio.cpp
@@ -1120,13 +1120,13 @@ bool EspGpio::SupportsGlitchFilter() const noexcept {
 
 HfGpioErr EspGpio::ConfigurePinGlitchFilter(bool enable) noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
   if (!HF_GPIO_SUPPORTS_GLITCH_FILTER(pin_)) {
     ESP_LOGW(TAG, "GPIO%d does not support glitch filtering", static_cast<int>(pin_));
-    return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+    return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
   }
 
   if (enable) {
@@ -1140,7 +1140,7 @@ HfGpioErr EspGpio::ConfigurePinGlitchFilter(bool enable) noexcept {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to create pin glitch filter for GPIO%d: %s", 
                static_cast<int>(pin_), esp_err_to_name(err));
-      return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+      return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
     }
     
     err = gpio_glitch_filter_enable(reinterpret_cast<gpio_glitch_filter_handle_t>(glitch_filter_handle_));
@@ -1149,7 +1149,7 @@ HfGpioErr EspGpio::ConfigurePinGlitchFilter(bool enable) noexcept {
                static_cast<int>(pin_), esp_err_to_name(err));
       gpio_del_glitch_filter(reinterpret_cast<gpio_glitch_filter_handle_t>(glitch_filter_handle_));
       glitch_filter_handle_ = nullptr;
-      return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+      return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
     }
     
     pin_glitch_filter_enabled_ = true;
@@ -1172,22 +1172,22 @@ HfGpioErr EspGpio::ConfigurePinGlitchFilter(bool enable) noexcept {
     ESP_LOGI(TAG, "Pin glitch filter disabled for GPIO%d", static_cast<int>(pin_));
   }
   
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
   ESP_LOGW(TAG, "Glitch filter not supported on this platform");
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
 HfGpioErr EspGpio::ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig &config) noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
   if (!HF_GPIO_SUPPORTS_GLITCH_FILTER(pin_)) {
     ESP_LOGW(TAG, "GPIO%d does not support glitch filtering", static_cast<int>(pin_));
-    return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+    return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
   }
 
   // Configure flexible glitch filter with custom timing
@@ -1202,7 +1202,7 @@ HfGpioErr EspGpio::ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig &confi
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to create flex glitch filter for GPIO%d: %s", 
              static_cast<int>(pin_), esp_err_to_name(err));
-    return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+    return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
   }
   
   err = gpio_glitch_filter_enable(reinterpret_cast<gpio_glitch_filter_handle_t>(glitch_filter_handle_));
@@ -1211,7 +1211,7 @@ HfGpioErr EspGpio::ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig &confi
              static_cast<int>(pin_), esp_err_to_name(err));
     gpio_del_glitch_filter(reinterpret_cast<gpio_glitch_filter_handle_t>(glitch_filter_handle_));
     glitch_filter_handle_ = nullptr;
-    return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+    return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
   }
   
   flex_glitch_filter_enabled_ = true;
@@ -1221,60 +1221,60 @@ HfGpioErr EspGpio::ConfigureFlexGlitchFilter(const FlexGlitchFilterConfig &confi
   ESP_LOGI(TAG, "Flex glitch filter enabled for GPIO%d (window: %uns, threshold: %uns)", 
            static_cast<int>(pin_), config.window_width_ns, config.window_threshold_ns);
   
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
   ESP_LOGW(TAG, "Flexible glitch filter not supported on this platform");
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
 HfGpioErr EspGpio::EnableGlitchFilters() noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
   if (!glitch_filter_handle_) {
     ESP_LOGW(TAG, "No glitch filter configured for GPIO%d", static_cast<int>(pin_));
-    return HfGpioErr::HF_GPIO_ERR_INVALID_STATE;
+    return HfGpioErr::GPIO_ERR_INVALID_STATE;
   }
 
   esp_err_t err = gpio_glitch_filter_enable(reinterpret_cast<gpio_glitch_filter_handle_t>(glitch_filter_handle_));
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to enable glitch filters for GPIO%d: %s", 
              static_cast<int>(pin_), esp_err_to_name(err));
-    return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+    return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
   }
   
   ESP_LOGI(TAG, "Glitch filters enabled for GPIO%d", static_cast<int>(pin_));
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
 HfGpioErr EspGpio::DisableGlitchFilters() noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
   if (!glitch_filter_handle_) {
     ESP_LOGD(TAG, "No glitch filter to disable for GPIO%d", static_cast<int>(pin_));
-    return HfGpioErr::HF_GPIO_OK;
+    return HfGpioErr::GPIO_OK;
   }
 
   esp_err_t err = gpio_glitch_filter_disable(reinterpret_cast<gpio_glitch_filter_handle_t>(glitch_filter_handle_));
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to disable glitch filters for GPIO%d: %s", 
              static_cast<int>(pin_), esp_err_to_name(err));
-    return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+    return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
   }
   
   ESP_LOGI(TAG, "Glitch filters disabled for GPIO%d", static_cast<int>(pin_));
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
@@ -1288,13 +1288,13 @@ bool EspGpio::SupportsRtcGpio() const noexcept {
 
 HfGpioErr EspGpio::ConfigureSleep(const GpioSleepConfig &config) noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
   if (!HF_GPIO_IS_RTC_CAPABLE(pin_)) {
     ESP_LOGW(TAG, "GPIO%d does not support RTC functionality", static_cast<int>(pin_));
-    return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+    return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
   }
 
   esp_err_t err;
@@ -1305,7 +1305,7 @@ HfGpioErr EspGpio::ConfigureSleep(const GpioSleepConfig &config) noexcept {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to initialize RTC GPIO%d: %s", 
                static_cast<int>(pin_), esp_err_to_name(err));
-      return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+      return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
     }
 
     // Set sleep mode direction
@@ -1326,7 +1326,7 @@ HfGpioErr EspGpio::ConfigureSleep(const GpioSleepConfig &config) noexcept {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to set RTC direction for GPIO%d: %s", 
                static_cast<int>(pin_), esp_err_to_name(err));
-      return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+      return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
     }
 
     // Configure sleep pull mode
@@ -1356,7 +1356,7 @@ HfGpioErr EspGpio::ConfigureSleep(const GpioSleepConfig &config) noexcept {
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to configure RTC pull mode for GPIO%d: %s", 
                  static_cast<int>(pin_), esp_err_to_name(err));
-        return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+        return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
       }
     }
 
@@ -1373,16 +1373,16 @@ HfGpioErr EspGpio::ConfigureSleep(const GpioSleepConfig &config) noexcept {
   ESP_LOGI(TAG, "Sleep configuration updated for GPIO%d (RTC: %s)", 
            static_cast<int>(pin_), config.enable_sleep_retain ? "enabled" : "disabled");
   
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
   ESP_LOGW(TAG, "Sleep configuration not supported on this platform");
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
 HfGpioErr EspGpio::ConfigureHold(bool enable) noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
@@ -1409,28 +1409,28 @@ HfGpioErr EspGpio::ConfigureHold(bool enable) noexcept {
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to %s hold for GPIO%d: %s", 
              enable ? "enable" : "disable", static_cast<int>(pin_), esp_err_to_name(err));
-    return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+    return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
   }
   
   hold_enabled_ = enable;
   ESP_LOGI(TAG, "Hold %s for GPIO%d", enable ? "enabled" : "disabled", static_cast<int>(pin_));
   
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
   ESP_LOGW(TAG, "Hold configuration not supported on this platform");
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
 HfGpioErr EspGpio::ConfigureWakeUp(const GpioWakeUpConfig &config) noexcept {
   if (!EnsureInitialized()) {
-    return HfGpioErr::HF_GPIO_ERR_NOT_INITIALIZED;
+    return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
 
 #ifdef HF_MCU_ESP32C6
   if (!HF_GPIO_IS_RTC_CAPABLE(pin_)) {
     ESP_LOGW(TAG, "GPIO%d does not support wake-up functionality", static_cast<int>(pin_));
-    return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+    return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
   }
 
   esp_err_t err;
@@ -1446,14 +1446,14 @@ HfGpioErr EspGpio::ConfigureWakeUp(const GpioWakeUpConfig &config) noexcept {
         break;
       default:
         ESP_LOGE(TAG, "Invalid wake-up trigger for GPIO%d", static_cast<int>(pin_));
-        return HfGpioErr::HF_GPIO_ERR_INVALID_ARG;
+        return HfGpioErr::GPIO_ERR_INVALID_ARG;
     }
     
     err = rtc_gpio_wakeup_enable(static_cast<gpio_num_t>(pin_), wakeup_type);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to enable wake-up for GPIO%d: %s", 
                static_cast<int>(pin_), esp_err_to_name(err));
-      return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+      return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
     }
     
     ESP_LOGI(TAG, "Wake-up enabled for GPIO%d (trigger: %s)", 
@@ -1464,17 +1464,17 @@ HfGpioErr EspGpio::ConfigureWakeUp(const GpioWakeUpConfig &config) noexcept {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to disable wake-up for GPIO%d: %s", 
                static_cast<int>(pin_), esp_err_to_name(err));
-      return HfGpioErr::HF_GPIO_ERR_DRIVER_ERROR;
+      return HfGpioErr::GPIO_ERR_DRIVER_ERROR;
     }
     
     ESP_LOGI(TAG, "Wake-up disabled for GPIO%d", static_cast<int>(pin_));
   }
   
   wakeup_config_ = config;
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
   ESP_LOGW(TAG, "Wake-up configuration not supported on this platform");
-  return HfGpioErr::HF_GPIO_ERR_NOT_SUPPORTED;
+  return HfGpioErr::GPIO_ERR_NOT_SUPPORTED;
 #endif
 }
 
@@ -1516,7 +1516,7 @@ HfGpioErr EspGpio::GetPinCapabilities(hf_gpio_pin_capabilities_t &capabilities) 
   capabilities.is_spi_pin = HF_GPIO_IS_SPI_PIN(pin_);
   capabilities.is_usb_jtag_pin = HF_GPIO_IS_USB_JTAG_PIN(pin_);
   
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #else
   // Generic capabilities for non-ESP32C6 platforms
   capabilities.pin_number = pin_;
@@ -1531,7 +1531,7 @@ HfGpioErr EspGpio::GetPinCapabilities(hf_gpio_pin_capabilities_t &capabilities) 
   capabilities.is_spi_pin = false;
   capabilities.is_usb_jtag_pin = false;
   
-  return HfGpioErr::HF_GPIO_OK;
+  return HfGpioErr::GPIO_OK;
 #endif
 }
 

--- a/src/utils/DigitalOutputGuard.cpp
+++ b/src/utils/DigitalOutputGuard.cpp
@@ -20,16 +20,16 @@
 
 DigitalOutputGuard::DigitalOutputGuard(BaseGpio &gpio, bool ensure_output_mode) noexcept
     : gpio_(&gpio), was_output_mode_(false), is_valid_(false),
-      last_error_(hf_gpio_err_t::HF_GPIO_SUCCESS) {
+      last_error_(hf_gpio_err_t::GPIO_SUCCESS) {
 
   is_valid_ = InitializeGuard(ensure_output_mode);
 }
 
 DigitalOutputGuard::DigitalOutputGuard(BaseGpio *gpio, bool ensure_output_mode) noexcept
-    : gpio_(gpio), was_output_mode_(false), is_valid_(false), last_error_(hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    : gpio_(gpio), was_output_mode_(false), is_valid_(false), last_error_(hf_gpio_err_t::GPIO_SUCCESS) {
 
   if (gpio_ == nullptr) {
-    last_error_ = hf_gpio_err_t::HF_GPIO_ERR_NULL_POINTER;
+    last_error_ = hf_gpio_err_t::GPIO_ERR_NULL_POINTER;
     is_valid_ = false;
     return;
   }
@@ -46,7 +46,7 @@ DigitalOutputGuard::~DigitalOutputGuard() noexcept {
     // Set the GPIO to inactive state before destruction
     // Don't change the direction back - leave it as configured
     hf_gpio_err_t result = gpio_->SetInactive();
-    if (result != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result != hf_gpio_err_t::GPIO_SUCCESS) {
       // In destructor, we can't throw exceptions or report errors
       // Just attempt the operation and continue with destruction
       (void)result; // Suppress unused variable warning
@@ -60,14 +60,14 @@ DigitalOutputGuard::~DigitalOutputGuard() noexcept {
 
 hf_gpio_err_t DigitalOutputGuard::SetActive() noexcept {
   if (!is_valid_ || gpio_ == nullptr) {
-    return last_error_ != hf_gpio_err_t::HF_GPIO_SUCCESS ? last_error_
-                                                  : hf_gpio_err_t::HF_GPIO_ERR_NOT_INITIALIZED;
+    return last_error_ != hf_gpio_err_t::GPIO_SUCCESS ? last_error_
+                                                  : hf_gpio_err_t::GPIO_ERR_NOT_INITIALIZED;
   }
 
   // Ensure the GPIO is in output mode
   if (!gpio_->IsOutput()) {
     hf_gpio_err_t result = gpio_->SetDirection(hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT);
-    if (result != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result != hf_gpio_err_t::GPIO_SUCCESS) {
       last_error_ = result;
       return result;
     }
@@ -79,14 +79,14 @@ hf_gpio_err_t DigitalOutputGuard::SetActive() noexcept {
 
 hf_gpio_err_t DigitalOutputGuard::SetInactive() noexcept {
   if (!is_valid_ || gpio_ == nullptr) {
-    return last_error_ != hf_gpio_err_t::HF_GPIO_SUCCESS ? last_error_
-                                                  : hf_gpio_err_t::HF_GPIO_ERR_NOT_INITIALIZED;
+    return last_error_ != hf_gpio_err_t::GPIO_SUCCESS ? last_error_
+                                                  : hf_gpio_err_t::GPIO_ERR_NOT_INITIALIZED;
   }
 
   // Ensure the GPIO is in output mode
   if (!gpio_->IsOutput()) {
     hf_gpio_err_t result = gpio_->SetDirection(hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT);
-    if (result != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result != hf_gpio_err_t::GPIO_SUCCESS) {
       last_error_ = result;
       return result;
     }
@@ -111,7 +111,7 @@ BaseGpio::hf_gpio_state_t DigitalOutputGuard::GetCurrentState() const noexcept {
 bool DigitalOutputGuard::InitializeGuard(bool ensure_output_mode) noexcept {
   // Check if GPIO is initialized
   if (!gpio_->EnsureInitialized()) {
-    last_error_ = hf_gpio_err_t::HF_GPIO_ERR_NOT_INITIALIZED;
+    last_error_ = hf_gpio_err_t::GPIO_ERR_NOT_INITIALIZED;
     return false;
   }
 
@@ -121,7 +121,7 @@ bool DigitalOutputGuard::InitializeGuard(bool ensure_output_mode) noexcept {
   // Ensure output mode if requested
   if (ensure_output_mode && !was_output_mode_) {
     hf_gpio_err_t result = gpio_->SetDirection(hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT);
-    if (result != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+    if (result != hf_gpio_err_t::GPIO_SUCCESS) {
       last_error_ = result;
       return false;
     }
@@ -129,17 +129,17 @@ bool DigitalOutputGuard::InitializeGuard(bool ensure_output_mode) noexcept {
 
   // If not in output mode and we're not ensuring it, that's an error
   if (!gpio_->IsOutput()) {
-    last_error_ = hf_gpio_err_t::HF_GPIO_ERR_DIRECTION_MISMATCH;
+    last_error_ = hf_gpio_err_t::GPIO_ERR_DIRECTION_MISMATCH;
     return false;
   }
 
   // Set the GPIO to active state
   hf_gpio_err_t result = gpio_->SetActive();
-  if (result != hf_gpio_err_t::HF_GPIO_SUCCESS) {
+  if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     last_error_ = result;
     return false;
   }
 
-  last_error_ = hf_gpio_err_t::HF_GPIO_SUCCESS;
+  last_error_ = hf_gpio_err_t::GPIO_SUCCESS;
   return true;
 }


### PR DESCRIPTION
## Summary
- rename GPIO error enumerators so they no longer start with `HF_`
- adjust comments and docs to use the new names