### PR TITLE
Fix ESP32 CAN compliance with new base types

### DIFF
--- a/inc/mcu/esp32/EspCan.h
+++ b/inc/mcu/esp32/EspCan.h
@@ -257,7 +257,7 @@ private:
     mutable RtosMutex stats_mutex_;                 ///< Statistics mutex
 
     // ESP-IDF TWAI handle (native handle like EspAdc)
-    hf_can_handle_native_t twai_handle_;            ///< Native TWAI handle
+    twai_node_handle_t twai_handle_;                ///< Native TWAI handle
 
     // Callbacks (similar to EspAdc callback management)
     hf_can_receive_callback_t receive_callback_;    ///< Receive message callback

--- a/inc/utils/McuSelect.h
+++ b/inc/utils/McuSelect.h
@@ -140,7 +140,8 @@ extern "C" {
 #endif
 
 #include "driver/adc.h"
-#include "driver/can.h" // Note: Different from ESP32-C6 TWAI
+#include "driver/twai.h"      // Modern TWAI driver for all ESP32 variants
+#include "hal/twai_types.h"
 #include "driver/gpio.h"
 #include "driver/i2c.h"
 #include "driver/ledc.h"

--- a/src/mcu/esp32/EspCan.cpp
+++ b/src/mcu/esp32/EspCan.cpp
@@ -449,10 +449,25 @@ hf_can_err_t EspCan::ConvertToNativeMessage(const hf_can_message_t& message, twa
     if (message.is_extended) {
         native_message.flags |= TWAI_MSG_FLAG_EXTD;
     }
-    
+
     // Set remote frame flag
     if (message.is_rtr) {
         native_message.flags |= TWAI_MSG_FLAG_RTR;
+    }
+
+    // Set single shot flag
+    if (message.is_ss) {
+        native_message.flags |= TWAI_MSG_FLAG_SS;
+    }
+
+    // Set self reception flag
+    if (message.is_self) {
+        native_message.flags |= TWAI_MSG_FLAG_SELF;
+    }
+
+    // Set DLC non-compliant flag
+    if (message.dlc_non_comp) {
+        native_message.flags |= TWAI_MSG_FLAG_DLC_NON_COMP;
     }
     
     // Set data length
@@ -476,9 +491,18 @@ hf_can_err_t EspCan::ConvertFromNativeMessage(const twai_frame_t& native_message
     
     // Set frame format
     message.is_extended = (native_message.flags & TWAI_MSG_FLAG_EXTD) != 0;
-    
+
     // Set remote frame flag
     message.is_rtr = (native_message.flags & TWAI_MSG_FLAG_RTR) != 0;
+
+    // Set single shot flag
+    message.is_ss = (native_message.flags & TWAI_MSG_FLAG_SS) != 0;
+
+    // Set self reception flag
+    message.is_self = (native_message.flags & TWAI_MSG_FLAG_SELF) != 0;
+
+    // Set DLC non-compliant flag
+    message.dlc_non_comp = (native_message.flags & TWAI_MSG_FLAG_DLC_NON_COMP) != 0;
     
     // Set data length
     message.dlc = native_message.data_length_code;


### PR DESCRIPTION
## Summary
- align EspCan with simplified EspTypes cleanup
- use esp-idf `twai_node_handle_t` directly
- add handling for single-shot, self-reception, and DLC flags
- include modern TWAI driver for all ESP32 variants