### PR TITLE
Fix esp32 GPIO header to use new types

### DIFF
--- a/inc/mcu/esp32/EspGpio.h
+++ b/inc/mcu/esp32/EspGpio.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "BaseGpio.h"
-#include "McuTypes.h"
+#include "EspTypes_GPIO.h"
 
 
 
@@ -69,7 +69,7 @@ public:
                    hf_gpio_active_state_t active_state = hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
                    hf_gpio_output_mode_t output_mode = hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
                    hf_gpio_pull_mode_t pull_mode = hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_FLOATING,
-                   hf_gpio_drive_strength_t drive_capability = hf_gpio_drive_strength_t::HF_GPIO_DRIVE_STRENGTH_MEDIUM) noexcept;
+                   hf_gpio_drive_cap_t drive_capability = hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_MEDIUM) noexcept;
 
   /**
    * @brief Destructor - ensures proper cleanup including interrupt resources.
@@ -253,7 +253,7 @@ protected:
    * @brief Get current drive capability setting.
    * @return Current drive capability level
    */
-  [[nodiscard]] hf_gpio_drive_strength_t GetDriveCapability() const noexcept {
+  [[nodiscard]] hf_gpio_drive_cap_t GetDriveCapability() const noexcept {
     return drive_capability_;
   }
 
@@ -265,7 +265,7 @@ protected:
    *          Higher drive capability allows for faster switching and driving larger loads
    *          but increases power consumption and EMI.
    */
-  hf_gpio_err_t SetDriveCapability(hf_gpio_drive_strength_t capability) noexcept;
+  hf_gpio_err_t SetDriveCapability(hf_gpio_drive_cap_t capability) noexcept;
 
   /**
    * @brief Check if glitch filters are supported.
@@ -582,7 +582,7 @@ private:
   void *platform_semaphore_;             ///< Platform-specific semaphore for WaitForInterrupt
 
   // Advanced GPIO state
-  hf_gpio_drive_strength_t drive_capability_;      ///< Current drive capability setting
+  hf_gpio_drive_cap_t drive_capability_;      ///< Current drive capability setting
   hf_gpio_glitch_filter_type_t glitch_filter_type_;   ///< Type of glitch filter configured
   bool pin_glitch_filter_enabled_;            ///< Pin glitch filter enabled
   bool flex_glitch_filter_enabled_;           ///< Flexible glitch filter enabled

--- a/src/mcu/esp32/EspGpio.cpp
+++ b/src/mcu/esp32/EspGpio.cpp
@@ -95,7 +95,7 @@ namespace {
 
 EspGpio::EspGpio(HfPinNumber pin_num, Direction direction, ActiveState active_state,
                  OutputMode output_mode, PullMode pull_mode,
-                 GpioDriveCapability drive_capability) noexcept
+                 hf_gpio_drive_cap_t drive_capability) noexcept
     : BaseGpio(pin_num, direction, active_state, output_mode, pull_mode),
       interrupt_trigger_(hf_gpio_interrupt_trigger_t::HF_GPIO_INTERRUPT_TRIGGER_NONE), interrupt_callback_(nullptr),
       interrupt_user_data_(nullptr), interrupt_enabled_(false), interrupt_count_(0),
@@ -230,10 +230,10 @@ bool EspGpio::Initialize() noexcept {
 
   // Set drive capability
   if (current_direction_ == hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT) {
-    ret = SetDriveCapability(drive_capability_);
-    if (ret != ESP_OK) {
-      ESP_LOGW(TAG, "Failed to set drive capability for GPIO%d: %s", 
-               static_cast<int>(pin_), esp_err_to_name(ret));
+    HfGpioErr drv_ret = SetDriveCapability(drive_capability_);
+    if (drv_ret != HfGpioErr::GPIO_SUCCESS) {
+      ESP_LOGW(TAG, "Failed to set drive capability for GPIO%d",
+               static_cast<int>(pin_));
     }
   }
 
@@ -846,7 +846,7 @@ HfGpioErr EspGpio::IsActiveImpl(bool &is_active) noexcept {
 // ADVANCED ESP32C6 FEATURES IMPLEMENTATION
 //==============================================================================
 
-HfGpioErr EspGpio::SetDriveCapability(GpioDriveCapability capability) noexcept {
+HfGpioErr EspGpio::SetDriveCapability(hf_gpio_drive_cap_t capability) noexcept {
   if (!EnsureInitialized()) {
     return HfGpioErr::GPIO_ERR_NOT_INITIALIZED;
   }
@@ -855,16 +855,16 @@ HfGpioErr EspGpio::SetDriveCapability(GpioDriveCapability capability) noexcept {
 
   gpio_drive_cap_t esp_cap;
   switch (capability) {
-    case GpioDriveCapability::Weak:
+    case hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_WEAK:
       esp_cap = GPIO_DRIVE_CAP_0;
       break;
-    case GpioDriveCapability::Stronger:
+    case hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_STRONGER:
       esp_cap = GPIO_DRIVE_CAP_1;
       break;
-    case GpioDriveCapability::Medium:
+    case hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_MEDIUM:
       esp_cap = GPIO_DRIVE_CAP_2;
       break;
-    case GpioDriveCapability::Strongest:
+    case hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_STRONGEST:
       esp_cap = GPIO_DRIVE_CAP_3;
       break;
     default:


### PR DESCRIPTION
## Summary
- include updated EspTypes for GPIO
- use new `hf_gpio_drive_cap_t` type throughout EspGpio
- adjust drive capability handling in implementation
