### PR TITLE
Fix NVS statistics interface

### DIFF
--- a/inc/mcu/esp32/EspNvs.h
+++ b/inc/mcu/esp32/EspNvs.h
@@ -240,13 +240,13 @@ public:
    * @brief Get NVS operation statistics.
    * @return Statistics structure with operation counts and performance data
    */
-  hf_nvs_statistics_t GetStatistics() const noexcept;
+  hf_nvs_err_t GetStatistics(hf_nvs_statistics_t &statistics) const noexcept override;
 
   /**
    * @brief Get NVS diagnostic information.
    * @return Diagnostics structure with error tracking and health status
    */
-  hf_nvs_diagnostics_t GetDiagnostics() const noexcept;
+  hf_nvs_err_t GetDiagnostics(hf_nvs_diagnostics_t &diagnostics) const noexcept override;
 
 private:
   //==============================================//

--- a/src/mcu/esp32/EspNvs.cpp
+++ b/src/mcu/esp32/EspNvs.cpp
@@ -468,18 +468,18 @@ size_t EspNvs::GetMaxKeyLength() const noexcept {
   return HF_NVS_MAX_KEY_LENGTH;
 }
 
-size_t EspNvs::GetMaxValueSize() const noexcept {
-  return HF_NVS_MAX_VALUE_SIZE;
+size_t EspNvs::GetMaxValueSize() const noexcept { return HF_NVS_MAX_VALUE_SIZE; }
+
+hf_nvs_err_t EspNvs::GetStatistics(hf_nvs_statistics_t &statistics) const noexcept {
+  RtosUniqueLock<RtosMutex> lock(mutex_);
+  statistics = statistics_;
+  return hf_nvs_err_t::NVS_SUCCESS;
 }
 
-hf_nvs_statistics_t EspNvs::GetStatistics() const noexcept {
+hf_nvs_err_t EspNvs::GetDiagnostics(hf_nvs_diagnostics_t &diagnostics) const noexcept {
   RtosUniqueLock<RtosMutex> lock(mutex_);
-  return statistics_;
-}
-
-hf_nvs_diagnostics_t EspNvs::GetDiagnostics() const noexcept {
-  RtosUniqueLock<RtosMutex> lock(mutex_);
-  return diagnostics_;
+  diagnostics = diagnostics_;
+  return hf_nvs_err_t::NVS_SUCCESS;
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary
- update EspNvs to return error codes for `GetStatistics` and `GetDiagnostics`
- update implementation accordingly

## Testing
- `clang-format -i inc/mcu/esp32/EspNvs.h src/mcu/esp32/EspNvs.cpp`