### PR TITLE
Improve unique_ptr allocation error handling

### DIFF
--- a/src/mcu/esp32/EspSpi.cpp
+++ b/src/mcu/esp32/EspSpi.cpp
@@ -136,11 +136,17 @@ int EspSpiBus::CreateDevice(const hf_spi_device_config_t& device_config) noexcep
   }
   
   // Create and store the device
-  auto device = std::make_unique<EspSpiDevice>(this, handle, device_config);
-  devices_.push_back(std::move(device));
-  
-  // Return the index of the newly created device
-  return static_cast<int>(devices_.size() - 1);
+  try {
+    auto device = std::make_unique<EspSpiDevice>(this, handle, device_config);
+    devices_.push_back(std::move(device));
+    
+    // Return the index of the newly created device
+    return static_cast<int>(devices_.size() - 1);
+  } catch (const std::exception& e) {
+    ESP_LOGE("EspSpiBus", "Failed to create EspSpiDevice: %s", e.what());
+    spi_bus_remove_device(handle);  // Clean up the SPI device handle
+    return -1;
+  }
 }
 
 BaseSpi* EspSpiBus::GetDevice(int device_index) noexcept {


### PR DESCRIPTION
Add exception handling for `std::make_unique` in `EspSpi.cpp` to correctly handle allocation failures.

`std::make_unique` throws `std::bad_alloc` on failure, making a subsequent null check ineffective. This change aligns `EspSpi.cpp` with the robust error handling already present in `EspI2c.cpp`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c489a3bd-ce02-4eb5-8897-ba75ad5246b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c489a3bd-ce02-4eb5-8897-ba75ad5246b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>