### PR TITLE
No exception unique ptr allocation

### DIFF
--- a/CODE_STYLE_SUMMARY.md
+++ b/CODE_STYLE_SUMMARY.md
@@ -1,0 +1,103 @@
+# 🎨 HardFOC Code Style Summary
+
+## 📋 Overview
+
+This document summarizes the code style improvements applied to the HardFOC codebase, distinguishing between source code requirements and documentation presentation.
+
+## 🔧 Source Code Style (Clean & Professional)
+
+### ✅ **Output & Logging**
+```cpp
+// ✅ GOOD - ESP-IDF logging (no emojis)
+ESP_LOGI(TAG, "Device created successfully");
+ESP_LOGE(TAG, "Failed to allocate memory for device");
+ESP_LOGW(TAG, "Configuration may be invalid");
+
+// ❌ AVOID - cout with emojis
+std::cout << "✅ Device created successfully" << std::endl;
+std::cout << "❌ Failed to allocate memory" << std::endl;
+```
+
+### ✅ **Memory Management**
+```cpp
+// ✅ GOOD - No-exception unique_ptr
+auto device = hf::utils::make_unique_nothrow<MyDevice>(params);
+if (!device) {
+    ESP_LOGE(TAG, "Memory allocation failed");
+    return false;
+}
+
+// ❌ AVOID - Exception-throwing allocation
+auto device = std::make_unique<MyDevice>(params); // throws on failure
+```
+
+### ✅ **Configuration Organization**
+```cpp
+// ✅ GOOD - Structured arrays and enums
+enum class PinType : size_t { LED = 0, MOTOR = 1, PIN_COUNT = 2 };
+static constexpr std::array<int, static_cast<size_t>(PinType::PIN_COUNT)> PINS = {2, 3};
+
+// ❌ AVOID - Scattered individual constants
+static constexpr int LED_PIN = 2;
+static constexpr int MOTOR_PIN = 3;
+```
+
+## 📚 Documentation Style (Expressive & Visual)
+
+### ✅ **Example Code in Docs**
+```cpp
+if (!spi_.EnsureInitialized()) {
+    printf("❌ SPI initialization failed\n");  // Emojis OK in docs
+    return false;
+}
+
+printf("✅ Device configured successfully\n");   // Visual feedback
+printf("📊 Read %zu bytes of data\n", length);   // Clear categorization
+```
+
+### ✅ **Documentation Formatting**
+- 🎯 **Purpose**: Emojis provide visual categorization
+- 📊 **Status**: Help readers quickly identify outcomes  
+- ⚠️ **Warnings**: Draw attention to important points
+- 🔧 **Technical**: Indicate implementation details
+
+## 🎯 **Key Principles**
+
+| Context | Emoji Usage | Logging | Style |
+|---------|-------------|---------|-------|
+| **Source Code** | ❌ None | ESP-IDF | Professional |
+| **Documentation** | ✅ Encouraged | Examples only | Visual & Clear |
+| **Comments** | ❌ Minimal | N/A | Descriptive text |
+| **Examples** | ✅ In docs only | Show best practices | Educational |
+
+## 📝 **Quick Reference**
+
+### When to Use Emojis ✅
+- 📖 Documentation markdown files
+- 💡 Code examples in documentation  
+- 🎯 Section headers and categorization
+- ⚠️ Warnings and important notes
+
+### When to Avoid Emojis ❌
+- 🚫 ESP-IDF logging statements
+- 🚫 std::cout in source code
+- 🚫 printf in production code
+- 🚫 Error messages in embedded systems
+
+## 🏆 **Benefits Achieved**
+
+### Source Code
+- **Professional Output**: Clean logs suitable for production
+- **Embedded Compatibility**: ESP-IDF logging framework
+- **Type Safety**: Array-based configuration prevents errors
+- **Exception Safety**: No-throw memory allocation
+
+### Documentation  
+- **Developer Experience**: Visual cues improve readability
+- **Quick Scanning**: Emojis help categorize information
+- **Engagement**: Makes documentation more approachable
+- **Consistency**: Standardized visual language
+
+---
+
+**Result**: Clean, professional embedded source code with expressive, developer-friendly documentation! 🚀

--- a/MEMORY_UTILS_MIGRATION.md
+++ b/MEMORY_UTILS_MIGRATION.md
@@ -103,6 +103,12 @@ std::unique_ptr<T[]> make_unique_array_nothrow(size_t size);
 - Same performance as `std::make_unique`
 - No runtime type information required
 
+### 5. Code Organization
+- Replaced std::cout with ESP-IDF logging for embedded compatibility
+- Used std::array for better type safety and organization
+- Eliminated emojis in favor of descriptive text
+- Structured configuration using arrays and enums
+
 ## 📝 Usage Patterns
 
 ### Before (Exception-throwing)
@@ -126,7 +132,7 @@ delete[] buffer;
 // NEW - returns nullptr on failure
 auto device = hf::utils::make_unique_nothrow<MyDevice>(param1, param2);
 if (!device) {
-    // Handle allocation failure
+    ESP_LOGE(TAG, "Failed to allocate memory for MyDevice");
     return false;
 }
 // ... use device (automatic cleanup)
@@ -134,10 +140,15 @@ if (!device) {
 // NEW - array allocation with automatic cleanup
 auto buffer = hf::utils::make_unique_array_nothrow<uint8_t>(size);
 if (!buffer) {
-    // Handle allocation failure
+    ESP_LOGE(TAG, "Failed to allocate memory for buffer");
     return false;
 }
 // ... use buffer.get() (automatic cleanup)
+
+// NEW - organized configuration using arrays
+enum class PinType : size_t { LED = 0, MOTOR = 1, PIN_COUNT = 2 };
+static constexpr std::array<int, static_cast<size_t>(PinType::PIN_COUNT)> PINS = {2, 3};
+config.pin = PINS[static_cast<size_t>(PinType::LED)];
 ```
 
 ## 🔍 Error Handling Pattern
@@ -163,10 +174,13 @@ if (!resource) {
 
 ## 📊 Migration Statistics
 
-- **Files Modified**: 6 core files + 2 documentation files
+- **Files Modified**: 6 core files + 2 documentation files + 1 test file
 - **Functions Replaced**: 8 `std::make_unique` calls + 5 raw `new` calls
 - **Safety Improvements**: 13 null pointer checks added
 - **Manual Cleanup Removed**: 9 `delete`/`delete[]` calls eliminated
+- **Logging Improvements**: Replaced std::cout with ESP-IDF logging
+- **Array Usage**: Added std::array usage for better organization
+- **Emojis Removed**: Replaced with descriptive text in all output
 
 ## ✅ Testing
 

--- a/MEMORY_UTILS_MIGRATION.md
+++ b/MEMORY_UTILS_MIGRATION.md
@@ -103,11 +103,11 @@ std::unique_ptr<T[]> make_unique_array_nothrow(size_t size);
 - Same performance as `std::make_unique`
 - No runtime type information required
 
-### 5. Code Organization
-- Replaced std::cout with ESP-IDF logging for embedded compatibility
-- Used std::array for better type safety and organization
-- Eliminated emojis in favor of descriptive text
-- Structured configuration using arrays and enums
+### 5. Code Organization  
+- 🔄 Replaced std::cout with ESP-IDF logging for embedded compatibility
+- 🗂️ Used std::array for better type safety and organization
+- 🚫 Eliminated emojis from source code output/logging (kept in docs)
+- 📋 Structured configuration using arrays and enums
 
 ## 📝 Usage Patterns
 
@@ -179,8 +179,8 @@ if (!resource) {
 - **Safety Improvements**: 13 null pointer checks added
 - **Manual Cleanup Removed**: 9 `delete`/`delete[]` calls eliminated
 - **Logging Improvements**: Replaced std::cout with ESP-IDF logging
-- **Array Usage**: Added std::array usage for better organization
-- **Emojis Removed**: Replaced with descriptive text in all output
+- **Array Usage**: Added std::array usage for better organization  
+- **Emojis Cleaned**: Removed from source code output (kept in documentation)
 
 ## ✅ Testing
 
@@ -196,4 +196,19 @@ Expected output demonstrates successful allocation, error handling, and automati
 
 ---
 
-**Note**: This migration maintains full backward compatibility while providing a safer, exception-free alternative for memory management in the HardFOC ecosystem.
+## 🎨 **Code Style Guidelines Applied**
+
+### Source Code (Clean, Professional)
+- ✅ ESP-IDF logging instead of std::cout
+- ✅ No emojis in program output or logs  
+- ✅ Structured error handling with proper return codes
+- ✅ Type-safe arrays and enums for configuration
+
+### Documentation (Expressive, Visual)
+- ✅ Emojis retained for better readability and visual appeal
+- ✅ Clear examples with visual indicators
+- ✅ User-friendly formatting for developers
+
+---
+
+**Note**: This migration maintains full backward compatibility while providing a safer, exception-free alternative for memory management in the HardFOC ecosystem, with clean source code and expressive documentation.

--- a/MEMORY_UTILS_MIGRATION.md
+++ b/MEMORY_UTILS_MIGRATION.md
@@ -1,0 +1,185 @@
+# Memory Utils Migration: make_unique_nothrow Implementation
+
+## 📋 Overview
+
+This document summarizes the implementation and migration to `make_unique_nothrow` template functions throughout the HardFOC codebase for exception-free unique_ptr creation.
+
+## 🎯 Motivation
+
+The standard `std::make_unique` throws `std::bad_alloc` on memory allocation failure, which is incompatible with no-exception design requirements. Our `make_unique_nothrow` templates provide safe alternatives that return `nullptr` instead of throwing exceptions.
+
+## 🔧 Implementation
+
+### New Header File
+- **Location**: `/workspace/inc/utils/memory_utils.h`
+- **Namespace**: `hf::utils`
+
+### Template Functions
+
+#### 1. `make_unique_nothrow<T>`
+```cpp
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique_nothrow(Args&&... args);
+```
+- Creates single objects using `new(std::nothrow)`
+- Returns `nullptr` on allocation failure
+- Perfect forwarding of constructor arguments
+
+#### 2. `make_unique_array_nothrow<T>`
+```cpp
+template<typename T>
+std::unique_ptr<T[]> make_unique_array_nothrow(size_t size);
+```
+- Creates arrays using `new(std::nothrow) T[size]`
+- Returns `nullptr` on allocation failure
+- Specialized for array types
+
+## 🔄 Migration Changes
+
+### Files Modified
+
+#### Core Implementation Files
+1. **`/workspace/examples/wifi_bluetooth_example.cpp`**
+   - Added `#include "utils/memory_utils.h"`
+   - Replaced `std::make_unique<EspWifi>` with `hf::utils::make_unique_nothrow<EspWifi>`
+   - Replaced `std::make_unique<EspBluetooth>` with `hf::utils::make_unique_nothrow<EspBluetooth>`
+   - Added null pointer checks with error logging
+
+2. **`/workspace/src/mcu/esp32/EspSpi.cpp`**
+   - Added `#include "utils/memory_utils.h"`
+   - Replaced `std::make_unique<EspSpiDevice>` with `hf::utils::make_unique_nothrow<EspSpiDevice>`
+   - Added null pointer check before vector insertion
+
+3. **`/workspace/src/mcu/esp32/EspI2c.cpp`**
+   - Added `#include "utils/memory_utils.h"`
+   - Replaced `std::make_unique<EspI2cDevice>` with `hf::utils::make_unique_nothrow<EspI2cDevice>`
+   - Added null pointer check before vector insertion
+
+4. **`/workspace/examples/esp32/main/advanced_pwm_example.cpp`**
+   - Added `#include "utils/memory_utils.h"` and `#include <memory>`
+   - Changed `g_pwm_controller` from `EspPwm*` to `std::unique_ptr<EspPwm>`
+   - Replaced `new EspPwm` with `hf::utils::make_unique_nothrow<EspPwm>`
+   - Replaced all `delete g_pwm_controller` calls with `g_pwm_controller.reset()`
+
+#### Documentation Files
+5. **`/workspace/docs/api/BaseSpi.md`**
+   - Added `#include "utils/memory_utils.h"` to all code examples
+   - Replaced raw `new uint8_t[]` with `hf::utils::make_unique_array_nothrow<uint8_t>`
+   - Replaced manual `delete[]` calls with automatic cleanup
+   - Added null pointer checks in all examples
+
+6. **`/workspace/docs/api/BaseI2c.md`**
+   - Added `#include "utils/memory_utils.h"` to code examples
+   - Replaced raw `new uint8_t[]` with `hf::utils::make_unique_array_nothrow<uint8_t>`
+   - Replaced manual `delete[]` calls with automatic cleanup
+
+### New Test File
+7. **`/workspace/examples/memory_utils_test.cpp`**
+   - Comprehensive test program demonstrating usage
+   - Tests single object allocation
+   - Tests array allocation
+   - Tests failure handling for large allocations
+   - Tests vector of unique_ptrs
+
+## ✨ Benefits
+
+### 1. Exception Safety
+- No `std::bad_alloc` exceptions thrown
+- Graceful handling of allocation failures
+- Compatible with no-exception environments
+
+### 2. RAII Compliance
+- Automatic memory cleanup when objects go out of scope
+- No manual `delete` calls required
+- Exception-safe resource management
+
+### 3. Type Safety
+- Compile-time type checking
+- No raw pointer arithmetic
+- Prevents memory leaks and double-deletion
+
+### 4. Performance
+- Zero overhead compared to raw pointers
+- Same performance as `std::make_unique`
+- No runtime type information required
+
+## 📝 Usage Patterns
+
+### Before (Exception-throwing)
+```cpp
+// OLD - throws std::bad_alloc on failure
+auto device = std::make_unique<MyDevice>(param1, param2);
+
+// OLD - raw pointer with manual cleanup
+MyDevice* device = new MyDevice(param1, param2);
+// ... use device ...
+delete device;
+
+// OLD - raw array with manual cleanup
+uint8_t* buffer = new uint8_t[size];
+// ... use buffer ...
+delete[] buffer;
+```
+
+### After (No-exception)
+```cpp
+// NEW - returns nullptr on failure
+auto device = hf::utils::make_unique_nothrow<MyDevice>(param1, param2);
+if (!device) {
+    // Handle allocation failure
+    return false;
+}
+// ... use device (automatic cleanup)
+
+// NEW - array allocation with automatic cleanup
+auto buffer = hf::utils::make_unique_array_nothrow<uint8_t>(size);
+if (!buffer) {
+    // Handle allocation failure
+    return false;
+}
+// ... use buffer.get() (automatic cleanup)
+```
+
+## 🔍 Error Handling Pattern
+
+All migration follows this consistent pattern:
+
+```cpp
+auto resource = hf::utils::make_unique_nothrow<ResourceType>(args...);
+if (!resource) {
+    ESP_LOGE(TAG, "Failed to allocate memory for ResourceType");
+    // Clean up any already-allocated resources
+    return error_code;
+}
+// Continue with normal operation
+```
+
+## 🚀 Future Considerations
+
+1. **Custom Deleters**: Consider adding support for custom deleters in future versions
+2. **Alignment**: Add aligned allocation variants if needed for hardware-specific requirements
+3. **Pool Allocation**: Consider integrating with memory pools for embedded systems
+4. **Statistics**: Add optional memory allocation tracking for debugging
+
+## 📊 Migration Statistics
+
+- **Files Modified**: 6 core files + 2 documentation files
+- **Functions Replaced**: 8 `std::make_unique` calls + 5 raw `new` calls
+- **Safety Improvements**: 13 null pointer checks added
+- **Manual Cleanup Removed**: 9 `delete`/`delete[]` calls eliminated
+
+## ✅ Testing
+
+Use the provided test program to verify functionality:
+
+```bash
+cd /workspace
+g++ -std=c++17 -I inc examples/memory_utils_test.cpp -o memory_utils_test
+./memory_utils_test
+```
+
+Expected output demonstrates successful allocation, error handling, and automatic cleanup without any exceptions.
+
+---
+
+**Note**: This migration maintains full backward compatibility while providing a safer, exception-free alternative for memory management in the HardFOC ecosystem.

--- a/docs/TypeWrappingStatus.md
+++ b/docs/TypeWrappingStatus.md
@@ -4,7 +4,7 @@
 
 ![Status](https://img.shields.io/badge/Status-Implementation%20Complete-brightgreen?style=for-the-badge&logo=checkmark)
 
-**INFO: Current implementation status of the HardFOC type wrapping system**
+**📊 Current implementation status of the HardFOC type wrapping system**
 
 </div>
 
@@ -16,11 +16,11 @@ The type wrapping system has been successfully implemented across the entire Har
 
 ---
 
-## SUCCESS: **Completed Work**
+## ✅ **Completed Work**
 
 ### 🏗️ **Core Type Definitions**
 
-- SUCCESS: **HardwareTypes.h** - Complete type wrapping system
+- ✅ **HardwareTypes.h** - Complete type wrapping system
   - All standard integer types wrapped (`hf_u8_t`, `hf_u16_t`, `hf_u32_t`, `hf_u64_t`, `hf_i8_t`, `hf_i16_t`, `hf_i32_t`, `hf_i64_t`)
   - Hardware-specific types (`hf_pin_num_t`, `hf_channel_id_t`, `hf_port_num_t`, `hf_host_id_t`)
   - Timing and frequency types (`hf_time_t`, `hf_frequency_hz_t`, `hf_baud_rate_t`)
@@ -30,32 +30,32 @@ The type wrapping system has been successfully implemented across the entire Har
 
 All base class headers have been updated to use wrapped types:
 
-- SUCCESS: **BaseAdc.h** - Complete type wrapping implementation
-- SUCCESS: **BaseCan.h** - Complete type wrapping implementation  
-- SUCCESS: **BaseGpio.h** - Complete type wrapping implementation
-- SUCCESS: **BaseI2c.h** - Complete type wrapping implementation
-- SUCCESS: **BaseUart.h** - Complete type wrapping implementation
-- SUCCESS: **BaseSpi.h** - Complete type wrapping implementation
-- SUCCESS: **BasePwm.h** - Complete type wrapping implementation
-- SUCCESS: **BasePio.h** - Complete type wrapping implementation
-- SUCCESS: **BaseNvs.h** - Complete type wrapping implementation
-- SUCCESS: **BasePeriodicTimer.h** - Complete type wrapping implementation
+- ✅ **BaseAdc.h** - Complete type wrapping implementation
+- ✅ **BaseCan.h** - Complete type wrapping implementation  
+- ✅ **BaseGpio.h** - Complete type wrapping implementation
+- ✅ **BaseI2c.h** - Complete type wrapping implementation
+- ✅ **BaseUart.h** - Complete type wrapping implementation
+- ✅ **BaseSpi.h** - Complete type wrapping implementation
+- ✅ **BasePwm.h** - Complete type wrapping implementation
+- ✅ **BasePio.h** - Complete type wrapping implementation
+- ✅ **BaseNvs.h** - Complete type wrapping implementation
+- ✅ **BasePeriodicTimer.h** - Complete type wrapping implementation
 
 ### 🔧 **ESP32 Implementation Files**
 
 Key ESP32 implementation files have been updated:
 
-- SUCCESS: **EspAdc.h** - Method signatures updated to use wrapped types
-- SUCCESS: **EspAdc.cpp** - Method implementations updated to match headers
-- SUCCESS: **EspGpio.cpp** - Key method signatures updated
-- SUCCESS: **EspSpi.cpp** - Key method signatures updated
+- ✅ **EspAdc.h** - Method signatures updated to use wrapped types
+- ✅ **EspAdc.cpp** - Method implementations updated to match headers
+- ✅ **EspGpio.cpp** - Key method signatures updated
+- ✅ **EspSpi.cpp** - Key method signatures updated
 
 ### 📚 **Documentation**
 
-- SUCCESS: **TypeWrappingSystem.md** - Comprehensive documentation with examples
-- SUCCESS: **BaseAdc.md** - API documentation updated with wrapped types
-- SUCCESS: **README.md** - Updated with type system explanation
-- SUCCESS: **docs/index.md** - Added type system section
+- ✅ **TypeWrappingSystem.md** - Comprehensive documentation with examples
+- ✅ **BaseAdc.md** - API documentation updated with wrapped types
+- ✅ **README.md** - Updated with type system explanation
+- ✅ **docs/index.md** - Added type system section
 
 ---
 
@@ -89,48 +89,48 @@ Implementation files that need method signature updates:
 
 ---
 
-## INFO: **Type Coverage Analysis**
+## 📊 **Type Coverage Analysis**
 
-### SUCCESS: **Fully Wrapped Types**
-
-| Type Category | Standard Type | Wrapped Type | Status |
-|---------------|---------------|--------------|---------|
-| **8-bit Unsigned** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **16-bit Unsigned** | `uint16_t` | `hf_u16_t` | SUCCESS: Complete |
-| **32-bit Unsigned** | `uint32_t` | `hf_u32_t` | SUCCESS: Complete |
-| **64-bit Unsigned** | `uint64_t` | `hf_u64_t` | SUCCESS: Complete |
-| **8-bit Signed** | `int8_t` | `hf_i8_t` | SUCCESS: Complete |
-| **16-bit Signed** | `int16_t` | `hf_i16_t` | SUCCESS: Complete |
-| **32-bit Signed** | `int32_t` | `hf_i32_t` | SUCCESS: Complete |
-| **64-bit Signed** | `int64_t` | `hf_i64_t` | SUCCESS: Complete |
-
-### SUCCESS: **Hardware-Specific Types**
+### ✅ **Fully Wrapped Types**
 
 | Type Category | Standard Type | Wrapped Type | Status |
 |---------------|---------------|--------------|---------|
-| **Pin Numbers** | `int32_t` | `hf_pin_num_t` | SUCCESS: Complete |
-| **Channel IDs** | `uint32_t` | `hf_channel_id_t` | SUCCESS: Complete |
-| **Port Numbers** | `uint32_t` | `hf_port_num_t` | SUCCESS: Complete |
-| **Host IDs** | `uint32_t` | `hf_host_id_t` | SUCCESS: Complete |
-| **Time** | `uint32_t` | `hf_time_t` | SUCCESS: Complete |
-| **Frequency** | `uint32_t` | `hf_frequency_hz_t` | SUCCESS: Complete |
-| **Baud Rate** | `uint32_t` | `hf_baud_rate_t` | SUCCESS: Complete |
-| **Timestamps** | `uint64_t` | `hf_timestamp_us_t` | SUCCESS: Complete |
+| **8-bit Unsigned** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **16-bit Unsigned** | `uint16_t` | `hf_u16_t` | ✅ Complete |
+| **32-bit Unsigned** | `uint32_t` | `hf_u32_t` | ✅ Complete |
+| **64-bit Unsigned** | `uint64_t` | `hf_u64_t` | ✅ Complete |
+| **8-bit Signed** | `int8_t` | `hf_i8_t` | ✅ Complete |
+| **16-bit Signed** | `int16_t` | `hf_i16_t` | ✅ Complete |
+| **32-bit Signed** | `int32_t` | `hf_i32_t` | ✅ Complete |
+| **64-bit Signed** | `int64_t` | `hf_i64_t` | ✅ Complete |
 
-### SUCCESS: **Error Code Enums**
+### ✅ **Hardware-Specific Types**
+
+| Type Category | Standard Type | Wrapped Type | Status |
+|---------------|---------------|--------------|---------|
+| **Pin Numbers** | `int32_t` | `hf_pin_num_t` | ✅ Complete |
+| **Channel IDs** | `uint32_t` | `hf_channel_id_t` | ✅ Complete |
+| **Port Numbers** | `uint32_t` | `hf_port_num_t` | ✅ Complete |
+| **Host IDs** | `uint32_t` | `hf_host_id_t` | ✅ Complete |
+| **Time** | `uint32_t` | `hf_time_t` | ✅ Complete |
+| **Frequency** | `uint32_t` | `hf_frequency_hz_t` | ✅ Complete |
+| **Baud Rate** | `uint32_t` | `hf_baud_rate_t` | ✅ Complete |
+| **Timestamps** | `uint64_t` | `hf_timestamp_us_t` | ✅ Complete |
+
+### ✅ **Error Code Enums**
 
 | Interface | Standard Type | Wrapped Type | Status |
 |-----------|---------------|--------------|---------|
-| **ADC Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **GPIO Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **CAN Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **I2C Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **SPI Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **UART Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **PWM Errors** | `uint32_t` | `hf_u32_t` | SUCCESS: Complete |
-| **PIO Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
-| **NVS Errors** | `int32_t` | `hf_i32_t` | SUCCESS: Complete |
-| **Timer Errors** | `int32_t` | `hf_i32_t` | SUCCESS: Complete |
+| **ADC Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **GPIO Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **CAN Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **I2C Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **SPI Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **UART Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **PWM Errors** | `uint32_t` | `hf_u32_t` | ✅ Complete |
+| **PIO Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
+| **NVS Errors** | `int32_t` | `hf_i32_t` | ✅ Complete |
+| **Timer Errors** | `int32_t` | `hf_i32_t` | ✅ Complete |
 
 ---
 
@@ -203,7 +203,7 @@ Implementation files that need method signature updates:
 
 ---
 
-## INFO: **Implementation Statistics**
+## 📊 **Implementation Statistics**
 
 - **Files Updated**: 15+ header and source files
 - **Type Definitions**: 16+ wrapped types
@@ -213,15 +213,15 @@ Implementation files that need method signature updates:
 
 ---
 
-## SUCCESS: **Conclusion**
+## ✅ **Conclusion**
 
 The type wrapping system implementation is **substantially complete** with a solid foundation established. The core type definitions, base classes, and key implementation files have been successfully updated. The remaining work primarily involves completing the ESP32 implementation files and updating documentation.
 
 The system now provides:
-- SUCCESS: **Consistent type safety** across all interfaces
-- SUCCESS: **Platform-agnostic design** for easy porting
-- SUCCESS: **Comprehensive documentation** with examples
-- SUCCESS: **Future-proof architecture** for evolving requirements
+- ✅ **Consistent type safety** across all interfaces
+- ✅ **Platform-agnostic design** for easy porting
+- ✅ **Comprehensive documentation** with examples
+- ✅ **Future-proof architecture** for evolving requirements
 
 This implementation represents a significant improvement in code quality, maintainability, and portability for the HardFOC Internal Interface Wrapper project.
 

--- a/docs/TypeWrappingStatus.md
+++ b/docs/TypeWrappingStatus.md
@@ -4,7 +4,7 @@
 
 ![Status](https://img.shields.io/badge/Status-Implementation%20Complete-brightgreen?style=for-the-badge&logo=checkmark)
 
-**📊 Current implementation status of the HardFOC type wrapping system**
+**INFO: Current implementation status of the HardFOC type wrapping system**
 
 </div>
 
@@ -16,11 +16,11 @@ The type wrapping system has been successfully implemented across the entire Har
 
 ---
 
-## ✅ **Completed Work**
+## SUCCESS: **Completed Work**
 
 ### 🏗️ **Core Type Definitions**
 
-- ✅ **HardwareTypes.h** - Complete type wrapping system
+- SUCCESS: **HardwareTypes.h** - Complete type wrapping system
   - All standard integer types wrapped (`hf_u8_t`, `hf_u16_t`, `hf_u32_t`, `hf_u64_t`, `hf_i8_t`, `hf_i16_t`, `hf_i32_t`, `hf_i64_t`)
   - Hardware-specific types (`hf_pin_num_t`, `hf_channel_id_t`, `hf_port_num_t`, `hf_host_id_t`)
   - Timing and frequency types (`hf_time_t`, `hf_frequency_hz_t`, `hf_baud_rate_t`)
@@ -30,32 +30,32 @@ The type wrapping system has been successfully implemented across the entire Har
 
 All base class headers have been updated to use wrapped types:
 
-- ✅ **BaseAdc.h** - Complete type wrapping implementation
-- ✅ **BaseCan.h** - Complete type wrapping implementation  
-- ✅ **BaseGpio.h** - Complete type wrapping implementation
-- ✅ **BaseI2c.h** - Complete type wrapping implementation
-- ✅ **BaseUart.h** - Complete type wrapping implementation
-- ✅ **BaseSpi.h** - Complete type wrapping implementation
-- ✅ **BasePwm.h** - Complete type wrapping implementation
-- ✅ **BasePio.h** - Complete type wrapping implementation
-- ✅ **BaseNvs.h** - Complete type wrapping implementation
-- ✅ **BasePeriodicTimer.h** - Complete type wrapping implementation
+- SUCCESS: **BaseAdc.h** - Complete type wrapping implementation
+- SUCCESS: **BaseCan.h** - Complete type wrapping implementation  
+- SUCCESS: **BaseGpio.h** - Complete type wrapping implementation
+- SUCCESS: **BaseI2c.h** - Complete type wrapping implementation
+- SUCCESS: **BaseUart.h** - Complete type wrapping implementation
+- SUCCESS: **BaseSpi.h** - Complete type wrapping implementation
+- SUCCESS: **BasePwm.h** - Complete type wrapping implementation
+- SUCCESS: **BasePio.h** - Complete type wrapping implementation
+- SUCCESS: **BaseNvs.h** - Complete type wrapping implementation
+- SUCCESS: **BasePeriodicTimer.h** - Complete type wrapping implementation
 
 ### 🔧 **ESP32 Implementation Files**
 
 Key ESP32 implementation files have been updated:
 
-- ✅ **EspAdc.h** - Method signatures updated to use wrapped types
-- ✅ **EspAdc.cpp** - Method implementations updated to match headers
-- ✅ **EspGpio.cpp** - Key method signatures updated
-- ✅ **EspSpi.cpp** - Key method signatures updated
+- SUCCESS: **EspAdc.h** - Method signatures updated to use wrapped types
+- SUCCESS: **EspAdc.cpp** - Method implementations updated to match headers
+- SUCCESS: **EspGpio.cpp** - Key method signatures updated
+- SUCCESS: **EspSpi.cpp** - Key method signatures updated
 
 ### 📚 **Documentation**
 
-- ✅ **TypeWrappingSystem.md** - Comprehensive documentation with examples
-- ✅ **BaseAdc.md** - API documentation updated with wrapped types
-- ✅ **README.md** - Updated with type system explanation
-- ✅ **docs/index.md** - Added type system section
+- SUCCESS: **TypeWrappingSystem.md** - Comprehensive documentation with examples
+- SUCCESS: **BaseAdc.md** - API documentation updated with wrapped types
+- SUCCESS: **README.md** - Updated with type system explanation
+- SUCCESS: **docs/index.md** - Added type system section
 
 ---
 
@@ -89,48 +89,48 @@ Implementation files that need method signature updates:
 
 ---
 
-## 📊 **Type Coverage Analysis**
+## INFO: **Type Coverage Analysis**
 
-### ✅ **Fully Wrapped Types**
-
-| Type Category | Standard Type | Wrapped Type | Status |
-|---------------|---------------|--------------|---------|
-| **8-bit Unsigned** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **16-bit Unsigned** | `uint16_t` | `hf_u16_t` | ✅ Complete |
-| **32-bit Unsigned** | `uint32_t` | `hf_u32_t` | ✅ Complete |
-| **64-bit Unsigned** | `uint64_t` | `hf_u64_t` | ✅ Complete |
-| **8-bit Signed** | `int8_t` | `hf_i8_t` | ✅ Complete |
-| **16-bit Signed** | `int16_t` | `hf_i16_t` | ✅ Complete |
-| **32-bit Signed** | `int32_t` | `hf_i32_t` | ✅ Complete |
-| **64-bit Signed** | `int64_t` | `hf_i64_t` | ✅ Complete |
-
-### ✅ **Hardware-Specific Types**
+### SUCCESS: **Fully Wrapped Types**
 
 | Type Category | Standard Type | Wrapped Type | Status |
 |---------------|---------------|--------------|---------|
-| **Pin Numbers** | `int32_t` | `hf_pin_num_t` | ✅ Complete |
-| **Channel IDs** | `uint32_t` | `hf_channel_id_t` | ✅ Complete |
-| **Port Numbers** | `uint32_t` | `hf_port_num_t` | ✅ Complete |
-| **Host IDs** | `uint32_t` | `hf_host_id_t` | ✅ Complete |
-| **Time** | `uint32_t` | `hf_time_t` | ✅ Complete |
-| **Frequency** | `uint32_t` | `hf_frequency_hz_t` | ✅ Complete |
-| **Baud Rate** | `uint32_t` | `hf_baud_rate_t` | ✅ Complete |
-| **Timestamps** | `uint64_t` | `hf_timestamp_us_t` | ✅ Complete |
+| **8-bit Unsigned** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **16-bit Unsigned** | `uint16_t` | `hf_u16_t` | SUCCESS: Complete |
+| **32-bit Unsigned** | `uint32_t` | `hf_u32_t` | SUCCESS: Complete |
+| **64-bit Unsigned** | `uint64_t` | `hf_u64_t` | SUCCESS: Complete |
+| **8-bit Signed** | `int8_t` | `hf_i8_t` | SUCCESS: Complete |
+| **16-bit Signed** | `int16_t` | `hf_i16_t` | SUCCESS: Complete |
+| **32-bit Signed** | `int32_t` | `hf_i32_t` | SUCCESS: Complete |
+| **64-bit Signed** | `int64_t` | `hf_i64_t` | SUCCESS: Complete |
 
-### ✅ **Error Code Enums**
+### SUCCESS: **Hardware-Specific Types**
+
+| Type Category | Standard Type | Wrapped Type | Status |
+|---------------|---------------|--------------|---------|
+| **Pin Numbers** | `int32_t` | `hf_pin_num_t` | SUCCESS: Complete |
+| **Channel IDs** | `uint32_t` | `hf_channel_id_t` | SUCCESS: Complete |
+| **Port Numbers** | `uint32_t` | `hf_port_num_t` | SUCCESS: Complete |
+| **Host IDs** | `uint32_t` | `hf_host_id_t` | SUCCESS: Complete |
+| **Time** | `uint32_t` | `hf_time_t` | SUCCESS: Complete |
+| **Frequency** | `uint32_t` | `hf_frequency_hz_t` | SUCCESS: Complete |
+| **Baud Rate** | `uint32_t` | `hf_baud_rate_t` | SUCCESS: Complete |
+| **Timestamps** | `uint64_t` | `hf_timestamp_us_t` | SUCCESS: Complete |
+
+### SUCCESS: **Error Code Enums**
 
 | Interface | Standard Type | Wrapped Type | Status |
 |-----------|---------------|--------------|---------|
-| **ADC Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **GPIO Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **CAN Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **I2C Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **SPI Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **UART Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **PWM Errors** | `uint32_t` | `hf_u32_t` | ✅ Complete |
-| **PIO Errors** | `uint8_t` | `hf_u8_t` | ✅ Complete |
-| **NVS Errors** | `int32_t` | `hf_i32_t` | ✅ Complete |
-| **Timer Errors** | `int32_t` | `hf_i32_t` | ✅ Complete |
+| **ADC Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **GPIO Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **CAN Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **I2C Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **SPI Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **UART Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **PWM Errors** | `uint32_t` | `hf_u32_t` | SUCCESS: Complete |
+| **PIO Errors** | `uint8_t` | `hf_u8_t` | SUCCESS: Complete |
+| **NVS Errors** | `int32_t` | `hf_i32_t` | SUCCESS: Complete |
+| **Timer Errors** | `int32_t` | `hf_i32_t` | SUCCESS: Complete |
 
 ---
 
@@ -203,7 +203,7 @@ Implementation files that need method signature updates:
 
 ---
 
-## 📊 **Implementation Statistics**
+## INFO: **Implementation Statistics**
 
 - **Files Updated**: 15+ header and source files
 - **Type Definitions**: 16+ wrapped types
@@ -213,15 +213,15 @@ Implementation files that need method signature updates:
 
 ---
 
-## 🎉 **Conclusion**
+## SUCCESS: **Conclusion**
 
 The type wrapping system implementation is **substantially complete** with a solid foundation established. The core type definitions, base classes, and key implementation files have been successfully updated. The remaining work primarily involves completing the ESP32 implementation files and updating documentation.
 
 The system now provides:
-- ✅ **Consistent type safety** across all interfaces
-- ✅ **Platform-agnostic design** for easy porting
-- ✅ **Comprehensive documentation** with examples
-- ✅ **Future-proof architecture** for evolving requirements
+- SUCCESS: **Consistent type safety** across all interfaces
+- SUCCESS: **Platform-agnostic design** for easy porting
+- SUCCESS: **Comprehensive documentation** with examples
+- SUCCESS: **Future-proof architecture** for evolving requirements
 
 This implementation represents a significant improvement in code quality, maintainability, and portability for the HardFOC Internal Interface Wrapper project.
 

--- a/docs/TypeWrappingSystem.md
+++ b/docs/TypeWrappingSystem.md
@@ -15,8 +15,8 @@
 - [🎯 **Overview**](#-overview)
 - [🏗️ **Type Definitions**](#️-type-definitions)
 - [🔧 **Implementation Details**](#-implementation-details)
-- [📊 **Benefits**](#-benefits)
-- [💡 **Usage Examples**](#-usage-examples)
+- [INFO: **Benefits**](#-benefits)
+- [INFO: **Usage Examples**](#-usage-examples)
 - [🔄 **Migration Guide**](#-migration-guide)
 
 ---
@@ -36,7 +36,7 @@ The HardFOC Internal Interface Wrapper implements a comprehensive type wrapping 
 
 ## 🏗️ **Type Definitions**
 
-### 📊 **Integer Type Wrappers**
+### INFO: **Integer Type Wrappers**
 
 All standard integer types are wrapped with consistent naming:
 
@@ -153,7 +153,7 @@ enum class hf_timer_err_t : hf_i32_t {
 };
 ```
 
-### 📊 **Data Structures**
+### INFO: **Data Structures**
 
 All data structures use wrapped types:
 
@@ -184,7 +184,7 @@ struct hf_gpio_diagnostics_t {
 
 ---
 
-## 📊 **Benefits**
+## INFO: **Benefits**
 
 ### 🔒 **Type Safety**
 
@@ -212,7 +212,7 @@ struct hf_gpio_diagnostics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 🔌 **GPIO Operations**
 
@@ -226,7 +226,7 @@ EspGpio led_pin(2, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT);
 void setup() {
     // Initialize with wrapped types
     if (led_pin.EnsureInitialized()) {
-        printf("✅ GPIO initialized\n");
+        printf("SUCCESS: GPIO initialized\n");
     }
 }
 
@@ -239,7 +239,7 @@ void control_led() {
 }
 ```
 
-### 📊 **ADC Reading**
+### INFO: **ADC Reading**
 
 ```cpp
 #include "inc/base/BaseAdc.h"
@@ -301,7 +301,7 @@ void configure_timer() {
     if (period_us >= min_period && period_us <= max_period) {
         hf_timer_err_t result = timer.Start(period_us);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("✅ Timer started with %llu μs period\n", period_us);
+            printf("SUCCESS: Timer started with %llu μs period\n", period_us);
         }
     }
 }
@@ -326,7 +326,7 @@ adc.ReadChannelCount(channel, raw_count);
 timer.Start(period);
 ```
 
-### ✅ **After (Wrapped Types)**
+### SUCCESS: **After (Wrapped Types)**
 
 ```cpp
 // New code using wrapped types
@@ -391,7 +391,7 @@ timer.Start(period);
 
 ## 🔗 **Related Documentation**
 
-- [📊 **BaseAdc API**](api/BaseAdc.md) - ADC interface with wrapped types
+- [INFO: **BaseAdc API**](api/BaseAdc.md) - ADC interface with wrapped types
 - [🔌 **BaseGpio API**](api/BaseGpio.md) - GPIO interface with wrapped types
 - [🚗 **BaseCan API**](api/BaseCan.md) - CAN interface with wrapped types
 - [📡 **BaseI2c API**](api/BaseI2c.md) - I2C interface with wrapped types

--- a/docs/TypeWrappingSystem.md
+++ b/docs/TypeWrappingSystem.md
@@ -15,8 +15,8 @@
 - [🎯 **Overview**](#-overview)
 - [🏗️ **Type Definitions**](#️-type-definitions)
 - [🔧 **Implementation Details**](#-implementation-details)
-- [INFO: **Benefits**](#-benefits)
-- [INFO: **Usage Examples**](#-usage-examples)
+- [📊 **Benefits**](#-benefits)
+- [📊 **Usage Examples**](#-usage-examples)
 - [🔄 **Migration Guide**](#-migration-guide)
 
 ---
@@ -36,7 +36,7 @@ The HardFOC Internal Interface Wrapper implements a comprehensive type wrapping 
 
 ## 🏗️ **Type Definitions**
 
-### INFO: **Integer Type Wrappers**
+### 📊 **Integer Type Wrappers**
 
 All standard integer types are wrapped with consistent naming:
 
@@ -153,7 +153,7 @@ enum class hf_timer_err_t : hf_i32_t {
 };
 ```
 
-### INFO: **Data Structures**
+### 📊 **Data Structures**
 
 All data structures use wrapped types:
 
@@ -184,7 +184,7 @@ struct hf_gpio_diagnostics_t {
 
 ---
 
-## INFO: **Benefits**
+## 📊 **Benefits**
 
 ### 🔒 **Type Safety**
 
@@ -212,7 +212,7 @@ struct hf_gpio_diagnostics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 🔌 **GPIO Operations**
 
@@ -226,7 +226,7 @@ EspGpio led_pin(2, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT);
 void setup() {
     // Initialize with wrapped types
     if (led_pin.EnsureInitialized()) {
-        printf("SUCCESS: GPIO initialized\n");
+        printf("✅ GPIO initialized\n");
     }
 }
 
@@ -239,7 +239,7 @@ void control_led() {
 }
 ```
 
-### INFO: **ADC Reading**
+### 📊 **ADC Reading**
 
 ```cpp
 #include "inc/base/BaseAdc.h"
@@ -301,7 +301,7 @@ void configure_timer() {
     if (period_us >= min_period && period_us <= max_period) {
         hf_timer_err_t result = timer.Start(period_us);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("SUCCESS: Timer started with %llu μs period\n", period_us);
+            printf("✅ Timer started with %llu μs period\n", period_us);
         }
     }
 }
@@ -326,7 +326,7 @@ adc.ReadChannelCount(channel, raw_count);
 timer.Start(period);
 ```
 
-### SUCCESS: **After (Wrapped Types)**
+### ✅ **After (Wrapped Types)**
 
 ```cpp
 // New code using wrapped types
@@ -391,7 +391,7 @@ timer.Start(period);
 
 ## 🔗 **Related Documentation**
 
-- [INFO: **BaseAdc API**](api/BaseAdc.md) - ADC interface with wrapped types
+- [📊 **BaseAdc API**](api/BaseAdc.md) - ADC interface with wrapped types
 - [🔌 **BaseGpio API**](api/BaseGpio.md) - GPIO interface with wrapped types
 - [🚗 **BaseCan API**](api/BaseCan.md) - CAN interface with wrapped types
 - [📡 **BaseI2c API**](api/BaseI2c.md) - I2C interface with wrapped types

--- a/docs/api/BaseAdc.md
+++ b/docs/api/BaseAdc.md
@@ -1,4 +1,4 @@
-# INFO: BaseAdc API Reference
+# 📊 BaseAdc API Reference
 
 <div align="center">
 
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -28,7 +28,7 @@ The `BaseAdc` class provides a comprehensive ADC abstraction that serves as the 
 
 ### ✨ **Key Features**
 
-- INFO: **Multi-Channel Support** - Simultaneous operation on multiple ADC channels
+- 📊 **Multi-Channel Support** - Simultaneous operation on multiple ADC channels
 - 🎯 **Hardware Calibration** - Automatic gain and offset calibration
 - ⚡ **High-Speed Conversion** - Optimized for real-time motor control
 - 🔄 **Voltage Conversion** - Direct voltage reading with calibration
@@ -37,7 +37,7 @@ The `BaseAdc` class provides a comprehensive ADC abstraction that serves as the 
 - 🏎️ **Performance Optimized** - Minimal overhead for critical applications
 - 🔌 **Platform Agnostic** - Works with internal and external ADCs
 
-### INFO: **Supported Hardware**
+### 📊 **Supported Hardware**
 
 | Implementation | Hardware Type | Channels | Resolution | Sample Rate |
 |----------------|---------------|----------|------------|-------------|
@@ -86,19 +86,19 @@ classDiagram
 
 The ADC system uses comprehensive error codes for robust error handling:
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `ADC_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `ADC_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `ADC_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `ADC_ERR_NOT_INITIALIZED` | 2 | WARNING: ADC not initialized | Call Initialize() first |
-| `ADC_ERR_ALREADY_INITIALIZED` | 3 | WARNING: ADC already initialized | Check initialization state |
+| `ADC_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `ADC_ERR_NOT_INITIALIZED` | 2 | ⚠️ ADC not initialized | Call Initialize() first |
+| `ADC_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ ADC already initialized | Check initialization state |
 | `ADC_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `ADC_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `ADC_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -108,19 +108,19 @@ The ADC system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `ADC_ERR_CHANNEL_NOT_FOUND` | 7 | 🔍 Channel not found | Use valid channel numbers |
-| `ADC_ERR_CHANNEL_NOT_ENABLED` | 8 | WARNING: Channel not enabled | Enable channel first |
+| `ADC_ERR_CHANNEL_NOT_ENABLED` | 8 | ⚠️ Channel not enabled | Enable channel first |
 | `ADC_ERR_CHANNEL_NOT_CONFIGURED` | 9 | ⚙️ Channel not configured | Configure channel parameters |
 | `ADC_ERR_CHANNEL_ALREADY_REGISTERED` | 10 | 🔄 Channel already registered | Check channel registration |
-| `ADC_ERR_CHANNEL_READ_ERR` | 11 | READ: Channel read error | Check hardware connections |
-| `ADC_ERR_CHANNEL_WRITE_ERR` | 12 | WRITE: Channel write error | Check write permissions |
+| `ADC_ERR_CHANNEL_READ_ERR` | 11 | 📖 Channel read error | Check hardware connections |
+| `ADC_ERR_CHANNEL_WRITE_ERR` | 12 | ✍️ Channel write error | Check write permissions |
 | `ADC_ERR_INVALID_CHANNEL` | 13 | 🚫 Invalid channel number | Use valid channel range |
 | `ADC_ERR_CHANNEL_BUSY` | 14 | 🔄 Channel currently in use | Wait or use different channel |
 
-### INFO: **Sampling Error Codes**
+### 📊 **Sampling Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `ADC_ERR_INVALID_SAMPLE_COUNT` | 15 | INFO: Invalid sample count | Use valid sample count |
+| `ADC_ERR_INVALID_SAMPLE_COUNT` | 15 | 📊 Invalid sample count | Use valid sample count |
 | `ADC_ERR_SAMPLE_TIMEOUT` | 16 | ⏰ Sample timeout | Check ADC clock and load |
 | `ADC_ERR_SAMPLE_OVERFLOW` | 17 | 📈 Sample overflow | Reduce sample rate |
 | `ADC_ERR_SAMPLE_UNDERFLOW` | 18 | 📉 Sample underflow | Check input signal |
@@ -138,9 +138,9 @@ The ADC system uses comprehensive error codes for robust error handling:
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `ADC_ERR_CALIBRATION_FAILURE` | 22 | INFO: Calibration failure | Re-run calibration process |
+| `ADC_ERR_CALIBRATION_FAILURE` | 22 | 📊 Calibration failure | Re-run calibration process |
 | `ADC_ERR_CALIBRATION_NOT_FOUND` | 28 | 🔍 Calibration data not found | Run calibration first |
-| `ADC_ERR_CALIBRATION_INVALID` | 29 | ERROR: Invalid calibration data | Re-calibrate |
+| `ADC_ERR_CALIBRATION_INVALID` | 29 | ❌ Invalid calibration data | Re-calibrate |
 | `ADC_ERR_CALIBRATION_EXPIRED` | 30 | ⏰ Calibration expired | Re-calibrate |
 | `ADC_ERR_CALIBRATION_DRIFT` | 31 | 📈 Calibration drift detected | Re-calibrate |
 
@@ -208,14 +208,14 @@ bool EnsureInitialized() noexcept;
 bool EnsureDeinitialized() noexcept;
 ```
 
-### INFO: **Channel Management**
+### 📊 **Channel Management**
 
 ```cpp
 /**
  * @brief Get maximum number of channels supported
  * @return Maximum channel count
  * 
- * INFO: Returns the total number of ADC channels available on this hardware.
+ * 📊 Returns the total number of ADC channels available on this hardware.
  */
 [[nodiscard]] virtual hf_u8_t GetMaxChannels() const noexcept = 0;
 
@@ -224,7 +224,7 @@ bool EnsureDeinitialized() noexcept;
  * @param channel_id Channel ID to check
  * @return true if channel is available, false otherwise
  * 
- * SUCCESS: Validates channel availability before use.
+ * ✅ Validates channel availability before use.
  */
 [[nodiscard]] virtual bool IsChannelAvailable(hf_channel_id_t channel_id) const noexcept = 0;
 ```
@@ -303,7 +303,7 @@ virtual hf_adc_err_t ReadChannel(hf_channel_id_t channel_id, hf_u32_t &channel_r
                                hf_time_t timeBetweenSamples = 0) noexcept = 0;
 ```
 
-### INFO: **Multi-Channel Operations**
+### 📊 **Multi-Channel Operations**
 
 ```cpp
 /**
@@ -314,7 +314,7 @@ virtual hf_adc_err_t ReadChannel(hf_channel_id_t channel_id, hf_u32_t &channel_r
  * @param voltages Array to store voltage readings
  * @return hf_adc_err_t error code
  * 
- * INFO: Reads multiple channels in a single operation for improved efficiency.
+ * 📊 Reads multiple channels in a single operation for improved efficiency.
  * Default implementation reads channels sequentially.
  * 
  * @example
@@ -351,7 +351,7 @@ virtual hf_adc_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_adc_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about ADC operations.
+ * 📊 Retrieves comprehensive statistics about ADC operations.
  */
 virtual hf_adc_err_t GetStatistics(hf_adc_statistics_t &statistics) const noexcept;
 
@@ -367,7 +367,7 @@ virtual hf_adc_err_t GetDiagnostics(hf_adc_diagnostics_t &diagnostics) const noe
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### 📈 **ADC Statistics Structure**
 
@@ -402,9 +402,9 @@ struct hf_adc_diagnostics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
-### INFO: **Basic Voltage Reading**
+### 📊 **Basic Voltage Reading**
 
 ```cpp
 #include "mcu/esp32/EspAdc.h"
@@ -415,7 +415,7 @@ EspAdc adc(ADC_UNIT_1, ADC_ATTEN_DB_11);
 void setup() {
     // Initialize ADC (lazy initialization)
     if (adc.EnsureInitialized()) {
-        printf("SUCCESS: ADC initialized successfully\n");
+        printf("✅ ADC initialized successfully\n");
     }
 }
 
@@ -424,7 +424,7 @@ float read_battery_voltage() {
     hf_adc_err_t result = adc.ReadChannelV(0, voltage);
     
     if (result != hf_adc_err_t::ADC_SUCCESS) {
-        printf("ERROR: ADC Error: %s\n", HfAdcErrToString(result));
+        printf("❌ ADC Error: %s\n", HfAdcErrToString(result));
         return -1.0f;  // Error value
     }
     
@@ -440,7 +440,7 @@ void monitor_battery() {
         printf("🔋 Battery: %.2f V\n", battery_voltage);
         
         if (battery_voltage < 3.0f) {
-            printf("WARNING: Low battery warning!\n");
+            printf("⚠️ Low battery warning!\n");
         }
     }
 }
@@ -489,7 +489,7 @@ void sensor_monitoring_task() {
     while (true) {
         SensorReadings sensors = read_all_sensors();
         
-        printf("INFO: Sensors - T:%.1f°C P:%.1f PSI I:%.1fA V:%.1fV\n",
+        printf("📊 Sensors - T:%.1f°C P:%.1f PSI I:%.1fA V:%.1fV\n",
                sensors.temperature, 
                sensors.pressure,
                sensors.current,
@@ -533,7 +533,7 @@ public:
             if (result == hf_adc_err_t::ADC_SUCCESS) {
                 buffer_.push_back(raw_count);
             } else {
-                printf("WARNING: Sample %zu failed: %s\n", i, HfAdcErrToString(result));
+                printf("⚠️ Sample %zu failed: %s\n", i, HfAdcErrToString(result));
             }
             
             // Minimal delay for maximum speed
@@ -543,7 +543,7 @@ public:
     
     void process_data() {
         if (buffer_.empty()) {
-            printf("ERROR: No data acquired\n");
+            printf("❌ No data acquired\n");
             return;
         }
         
@@ -589,7 +589,7 @@ public:
         hf_adc_err_t result = adc_.ReadChannelV(0, voltage, 4);  // 4-sample average
         
         if (result != hf_adc_err_t::ADC_SUCCESS) {
-            printf("ERROR: Current read error: %s\n", HfAdcErrToString(result));
+            printf("❌ Current read error: %s\n", HfAdcErrToString(result));
             return 0.0f;
         }
         
@@ -618,7 +618,7 @@ public:
     void print_statistics() {
         hf_adc_statistics_t stats;
         if (adc_.GetStatistics(stats) == hf_adc_err_t::ADC_SUCCESS) {
-            printf("INFO: ADC Statistics:\n");
+            printf("📊 ADC Statistics:\n");
             printf("   Total conversions: %u\n", stats.totalConversions);
             printf("   Successful: %u\n", stats.successfulConversions);
             printf("   Failed: %u\n", stats.failedConversions);
@@ -630,62 +630,62 @@ public:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!adc.EnsureInitialized()) {
-    printf("ERROR: ADC initialization failed\n");
+    printf("❌ ADC initialization failed\n");
     return false;
 }
 
-// SUCCESS: Validate channels before use
+// ✅ Validate channels before use
 if (!adc.IsChannelAvailable(channel_id)) {
-    printf("ERROR: Channel %u not available\n", channel_id);
+    printf("❌ Channel %u not available\n", channel_id);
     return;
 }
 
-// SUCCESS: Handle conversion errors gracefully
+// ✅ Handle conversion errors gracefully
 float voltage;
 hf_adc_err_t result = adc.ReadChannelV(channel_id, voltage);
 if (result != hf_adc_err_t::ADC_SUCCESS) {
-    printf("WARNING: ADC Error: %s\n", HfAdcErrToString(result));
+    printf("⚠️ ADC Error: %s\n", HfAdcErrToString(result));
     // Use safe default or retry logic
     voltage = 0.0f;
 }
 
-// SUCCESS: Use multi-sample averaging for accuracy
+// ✅ Use multi-sample averaging for accuracy
 float voltage;
 adc.ReadChannelV(channel_id, voltage, 8, 1);  // 8 samples, 1ms between
 
-// SUCCESS: Monitor statistics for system health
+// ✅ Monitor statistics for system health
 hf_adc_statistics_t stats;
 if (adc.GetStatistics(stats) == hf_adc_err_t::ADC_SUCCESS) {
     if (stats.failedConversions > 100) {
-        printf("WARNING: High ADC failure rate detected\n");
+        printf("⚠️ High ADC failure rate detected\n");
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 adc.ReadChannelV(0, voltage);  // May fail silently
 
-// ERROR: Don't use invalid channels
+// ❌ Don't use invalid channels
 float v = adc.ReadChannelV(99, voltage);  // Invalid channel
 
-// ERROR: Don't ignore error codes
+// ❌ Don't ignore error codes
 adc.ReadChannelV(0, voltage);  // Error handling missing
 
-// ERROR: Don't assume voltage ranges
+// ❌ Don't assume voltage ranges
 float voltage = adc.ReadChannelV(0, voltage);
 // Check attenuation settings for expected range
 
-// ERROR: Don't use without error checking in critical applications
+// ❌ Don't use without error checking in critical applications
 // Always check return values in safety-critical systems
 ```
 
@@ -724,7 +724,7 @@ adc.ReadChannelV(channel_id, voltage, 1);  // Single sample for speed
 
 <div align="center">
 
-**INFO: BaseAdc - The Foundation of Analog Measurement in HardFOC**
+**📊 BaseAdc - The Foundation of Analog Measurement in HardFOC**
 
 *Part of the HardFOC Internal Interface Wrapper Documentation*
 

--- a/docs/api/BaseAdc.md
+++ b/docs/api/BaseAdc.md
@@ -1,4 +1,4 @@
-# 📊 BaseAdc API Reference
+# INFO: BaseAdc API Reference
 
 <div align="center">
 
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -28,7 +28,7 @@ The `BaseAdc` class provides a comprehensive ADC abstraction that serves as the 
 
 ### ✨ **Key Features**
 
-- 📊 **Multi-Channel Support** - Simultaneous operation on multiple ADC channels
+- INFO: **Multi-Channel Support** - Simultaneous operation on multiple ADC channels
 - 🎯 **Hardware Calibration** - Automatic gain and offset calibration
 - ⚡ **High-Speed Conversion** - Optimized for real-time motor control
 - 🔄 **Voltage Conversion** - Direct voltage reading with calibration
@@ -37,7 +37,7 @@ The `BaseAdc` class provides a comprehensive ADC abstraction that serves as the 
 - 🏎️ **Performance Optimized** - Minimal overhead for critical applications
 - 🔌 **Platform Agnostic** - Works with internal and external ADCs
 
-### 📊 **Supported Hardware**
+### INFO: **Supported Hardware**
 
 | Implementation | Hardware Type | Channels | Resolution | Sample Rate |
 |----------------|---------------|----------|------------|-------------|
@@ -86,19 +86,19 @@ classDiagram
 
 The ADC system uses comprehensive error codes for robust error handling:
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `ADC_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `ADC_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `ADC_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `ADC_ERR_NOT_INITIALIZED` | 2 | ⚠️ ADC not initialized | Call Initialize() first |
-| `ADC_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ ADC already initialized | Check initialization state |
+| `ADC_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `ADC_ERR_NOT_INITIALIZED` | 2 | WARNING: ADC not initialized | Call Initialize() first |
+| `ADC_ERR_ALREADY_INITIALIZED` | 3 | WARNING: ADC already initialized | Check initialization state |
 | `ADC_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `ADC_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `ADC_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -108,19 +108,19 @@ The ADC system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `ADC_ERR_CHANNEL_NOT_FOUND` | 7 | 🔍 Channel not found | Use valid channel numbers |
-| `ADC_ERR_CHANNEL_NOT_ENABLED` | 8 | ⚠️ Channel not enabled | Enable channel first |
+| `ADC_ERR_CHANNEL_NOT_ENABLED` | 8 | WARNING: Channel not enabled | Enable channel first |
 | `ADC_ERR_CHANNEL_NOT_CONFIGURED` | 9 | ⚙️ Channel not configured | Configure channel parameters |
 | `ADC_ERR_CHANNEL_ALREADY_REGISTERED` | 10 | 🔄 Channel already registered | Check channel registration |
-| `ADC_ERR_CHANNEL_READ_ERR` | 11 | 📖 Channel read error | Check hardware connections |
-| `ADC_ERR_CHANNEL_WRITE_ERR` | 12 | ✍️ Channel write error | Check write permissions |
+| `ADC_ERR_CHANNEL_READ_ERR` | 11 | READ: Channel read error | Check hardware connections |
+| `ADC_ERR_CHANNEL_WRITE_ERR` | 12 | WRITE: Channel write error | Check write permissions |
 | `ADC_ERR_INVALID_CHANNEL` | 13 | 🚫 Invalid channel number | Use valid channel range |
 | `ADC_ERR_CHANNEL_BUSY` | 14 | 🔄 Channel currently in use | Wait or use different channel |
 
-### 📊 **Sampling Error Codes**
+### INFO: **Sampling Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `ADC_ERR_INVALID_SAMPLE_COUNT` | 15 | 📊 Invalid sample count | Use valid sample count |
+| `ADC_ERR_INVALID_SAMPLE_COUNT` | 15 | INFO: Invalid sample count | Use valid sample count |
 | `ADC_ERR_SAMPLE_TIMEOUT` | 16 | ⏰ Sample timeout | Check ADC clock and load |
 | `ADC_ERR_SAMPLE_OVERFLOW` | 17 | 📈 Sample overflow | Reduce sample rate |
 | `ADC_ERR_SAMPLE_UNDERFLOW` | 18 | 📉 Sample underflow | Check input signal |
@@ -138,9 +138,9 @@ The ADC system uses comprehensive error codes for robust error handling:
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `ADC_ERR_CALIBRATION_FAILURE` | 22 | 📊 Calibration failure | Re-run calibration process |
+| `ADC_ERR_CALIBRATION_FAILURE` | 22 | INFO: Calibration failure | Re-run calibration process |
 | `ADC_ERR_CALIBRATION_NOT_FOUND` | 28 | 🔍 Calibration data not found | Run calibration first |
-| `ADC_ERR_CALIBRATION_INVALID` | 29 | ❌ Invalid calibration data | Re-calibrate |
+| `ADC_ERR_CALIBRATION_INVALID` | 29 | ERROR: Invalid calibration data | Re-calibrate |
 | `ADC_ERR_CALIBRATION_EXPIRED` | 30 | ⏰ Calibration expired | Re-calibrate |
 | `ADC_ERR_CALIBRATION_DRIFT` | 31 | 📈 Calibration drift detected | Re-calibrate |
 
@@ -208,14 +208,14 @@ bool EnsureInitialized() noexcept;
 bool EnsureDeinitialized() noexcept;
 ```
 
-### 📊 **Channel Management**
+### INFO: **Channel Management**
 
 ```cpp
 /**
  * @brief Get maximum number of channels supported
  * @return Maximum channel count
  * 
- * 📊 Returns the total number of ADC channels available on this hardware.
+ * INFO: Returns the total number of ADC channels available on this hardware.
  */
 [[nodiscard]] virtual hf_u8_t GetMaxChannels() const noexcept = 0;
 
@@ -224,7 +224,7 @@ bool EnsureDeinitialized() noexcept;
  * @param channel_id Channel ID to check
  * @return true if channel is available, false otherwise
  * 
- * ✅ Validates channel availability before use.
+ * SUCCESS: Validates channel availability before use.
  */
 [[nodiscard]] virtual bool IsChannelAvailable(hf_channel_id_t channel_id) const noexcept = 0;
 ```
@@ -303,7 +303,7 @@ virtual hf_adc_err_t ReadChannel(hf_channel_id_t channel_id, hf_u32_t &channel_r
                                hf_time_t timeBetweenSamples = 0) noexcept = 0;
 ```
 
-### 📊 **Multi-Channel Operations**
+### INFO: **Multi-Channel Operations**
 
 ```cpp
 /**
@@ -314,7 +314,7 @@ virtual hf_adc_err_t ReadChannel(hf_channel_id_t channel_id, hf_u32_t &channel_r
  * @param voltages Array to store voltage readings
  * @return hf_adc_err_t error code
  * 
- * 📊 Reads multiple channels in a single operation for improved efficiency.
+ * INFO: Reads multiple channels in a single operation for improved efficiency.
  * Default implementation reads channels sequentially.
  * 
  * @example
@@ -351,7 +351,7 @@ virtual hf_adc_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_adc_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about ADC operations.
+ * INFO: Retrieves comprehensive statistics about ADC operations.
  */
 virtual hf_adc_err_t GetStatistics(hf_adc_statistics_t &statistics) const noexcept;
 
@@ -367,7 +367,7 @@ virtual hf_adc_err_t GetDiagnostics(hf_adc_diagnostics_t &diagnostics) const noe
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### 📈 **ADC Statistics Structure**
 
@@ -402,9 +402,9 @@ struct hf_adc_diagnostics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
-### 📊 **Basic Voltage Reading**
+### INFO: **Basic Voltage Reading**
 
 ```cpp
 #include "mcu/esp32/EspAdc.h"
@@ -415,7 +415,7 @@ EspAdc adc(ADC_UNIT_1, ADC_ATTEN_DB_11);
 void setup() {
     // Initialize ADC (lazy initialization)
     if (adc.EnsureInitialized()) {
-        printf("✅ ADC initialized successfully\n");
+        printf("SUCCESS: ADC initialized successfully\n");
     }
 }
 
@@ -424,7 +424,7 @@ float read_battery_voltage() {
     hf_adc_err_t result = adc.ReadChannelV(0, voltage);
     
     if (result != hf_adc_err_t::ADC_SUCCESS) {
-        printf("❌ ADC Error: %s\n", HfAdcErrToString(result));
+        printf("ERROR: ADC Error: %s\n", HfAdcErrToString(result));
         return -1.0f;  // Error value
     }
     
@@ -440,7 +440,7 @@ void monitor_battery() {
         printf("🔋 Battery: %.2f V\n", battery_voltage);
         
         if (battery_voltage < 3.0f) {
-            printf("⚠️ Low battery warning!\n");
+            printf("WARNING: Low battery warning!\n");
         }
     }
 }
@@ -489,7 +489,7 @@ void sensor_monitoring_task() {
     while (true) {
         SensorReadings sensors = read_all_sensors();
         
-        printf("📊 Sensors - T:%.1f°C P:%.1f PSI I:%.1fA V:%.1fV\n",
+        printf("INFO: Sensors - T:%.1f°C P:%.1f PSI I:%.1fA V:%.1fV\n",
                sensors.temperature, 
                sensors.pressure,
                sensors.current,
@@ -533,7 +533,7 @@ public:
             if (result == hf_adc_err_t::ADC_SUCCESS) {
                 buffer_.push_back(raw_count);
             } else {
-                printf("⚠️ Sample %zu failed: %s\n", i, HfAdcErrToString(result));
+                printf("WARNING: Sample %zu failed: %s\n", i, HfAdcErrToString(result));
             }
             
             // Minimal delay for maximum speed
@@ -543,7 +543,7 @@ public:
     
     void process_data() {
         if (buffer_.empty()) {
-            printf("❌ No data acquired\n");
+            printf("ERROR: No data acquired\n");
             return;
         }
         
@@ -589,7 +589,7 @@ public:
         hf_adc_err_t result = adc_.ReadChannelV(0, voltage, 4);  // 4-sample average
         
         if (result != hf_adc_err_t::ADC_SUCCESS) {
-            printf("❌ Current read error: %s\n", HfAdcErrToString(result));
+            printf("ERROR: Current read error: %s\n", HfAdcErrToString(result));
             return 0.0f;
         }
         
@@ -618,7 +618,7 @@ public:
     void print_statistics() {
         hf_adc_statistics_t stats;
         if (adc_.GetStatistics(stats) == hf_adc_err_t::ADC_SUCCESS) {
-            printf("📊 ADC Statistics:\n");
+            printf("INFO: ADC Statistics:\n");
             printf("   Total conversions: %u\n", stats.totalConversions);
             printf("   Successful: %u\n", stats.successfulConversions);
             printf("   Failed: %u\n", stats.failedConversions);
@@ -630,62 +630,62 @@ public:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!adc.EnsureInitialized()) {
-    printf("❌ ADC initialization failed\n");
+    printf("ERROR: ADC initialization failed\n");
     return false;
 }
 
-// ✅ Validate channels before use
+// SUCCESS: Validate channels before use
 if (!adc.IsChannelAvailable(channel_id)) {
-    printf("❌ Channel %u not available\n", channel_id);
+    printf("ERROR: Channel %u not available\n", channel_id);
     return;
 }
 
-// ✅ Handle conversion errors gracefully
+// SUCCESS: Handle conversion errors gracefully
 float voltage;
 hf_adc_err_t result = adc.ReadChannelV(channel_id, voltage);
 if (result != hf_adc_err_t::ADC_SUCCESS) {
-    printf("⚠️ ADC Error: %s\n", HfAdcErrToString(result));
+    printf("WARNING: ADC Error: %s\n", HfAdcErrToString(result));
     // Use safe default or retry logic
     voltage = 0.0f;
 }
 
-// ✅ Use multi-sample averaging for accuracy
+// SUCCESS: Use multi-sample averaging for accuracy
 float voltage;
 adc.ReadChannelV(channel_id, voltage, 8, 1);  // 8 samples, 1ms between
 
-// ✅ Monitor statistics for system health
+// SUCCESS: Monitor statistics for system health
 hf_adc_statistics_t stats;
 if (adc.GetStatistics(stats) == hf_adc_err_t::ADC_SUCCESS) {
     if (stats.failedConversions > 100) {
-        printf("⚠️ High ADC failure rate detected\n");
+        printf("WARNING: High ADC failure rate detected\n");
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 adc.ReadChannelV(0, voltage);  // May fail silently
 
-// ❌ Don't use invalid channels
+// ERROR: Don't use invalid channels
 float v = adc.ReadChannelV(99, voltage);  // Invalid channel
 
-// ❌ Don't ignore error codes
+// ERROR: Don't ignore error codes
 adc.ReadChannelV(0, voltage);  // Error handling missing
 
-// ❌ Don't assume voltage ranges
+// ERROR: Don't assume voltage ranges
 float voltage = adc.ReadChannelV(0, voltage);
 // Check attenuation settings for expected range
 
-// ❌ Don't use without error checking in critical applications
+// ERROR: Don't use without error checking in critical applications
 // Always check return values in safety-critical systems
 ```
 
@@ -724,7 +724,7 @@ adc.ReadChannelV(channel_id, voltage, 1);  // Single sample for speed
 
 <div align="center">
 
-**📊 BaseAdc - The Foundation of Analog Measurement in HardFOC**
+**INFO: BaseAdc - The Foundation of Analog Measurement in HardFOC**
 
 *Part of the HardFOC Internal Interface Wrapper Documentation*
 

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -31,13 +31,13 @@ The `BaseCan` class provides a comprehensive CAN bus abstraction that serves as 
 - 🚌 **CAN & CAN-FD Support** - Both classic CAN and CAN-FD protocols
 - 📨 **Message Filtering** - Hardware-based acceptance filtering
 - 🔄 **Error Recovery** - Automatic bus recovery and error handling
-- INFO: **Statistics & Diagnostics** - Comprehensive monitoring and reporting
+- 📊 **Statistics & Diagnostics** - Comprehensive monitoring and reporting
 - ⚡ **High Performance** - Optimized for real-time applications
 - 🛡️ **Robust Error Handling** - Detailed error codes and recovery mechanisms
 - 🔌 **Platform Agnostic** - Works with internal and external CAN controllers
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
-### INFO: **Supported Hardware**
+### 📊 **Supported Hardware**
 
 | Implementation | Hardware Type | Protocol | Speed | Features |
 |----------------|---------------|----------|-------|----------|
@@ -86,19 +86,19 @@ classDiagram
 
 The CAN system uses comprehensive error codes for robust error handling:
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `CAN_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `CAN_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `CAN_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `CAN_ERR_NOT_INITIALIZED` | 2 | WARNING: CAN not initialized | Call Initialize() first |
-| `CAN_ERR_ALREADY_INITIALIZED` | 3 | WARNING: CAN already initialized | Check initialization state |
+| `CAN_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `CAN_ERR_NOT_INITIALIZED` | 2 | ⚠️ CAN not initialized | Call Initialize() first |
+| `CAN_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ CAN already initialized | Check initialization state |
 | `CAN_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `CAN_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `CAN_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -108,10 +108,10 @@ The CAN system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `CAN_ERR_BUS_OFF` | 7 | 🚫 Bus off state | Restart CAN controller |
-| `CAN_ERR_BUS_ERROR` | 8 | ERROR: Bus error | Check bus wiring and termination |
+| `CAN_ERR_BUS_ERROR` | 8 | ❌ Bus error | Check bus wiring and termination |
 | `CAN_ERR_BUS_BUSY` | 9 | 🔄 Bus busy | Wait for bus availability |
 | `CAN_ERR_BUS_NOT_AVAILABLE` | 10 | 🚫 Bus not available | Check bus configuration |
-| `CAN_ERR_BUS_RECOVERY_FAILED` | 11 | ERROR: Bus recovery failed | Restart CAN controller |
+| `CAN_ERR_BUS_RECOVERY_FAILED` | 11 | ❌ Bus recovery failed | Restart CAN controller |
 | `CAN_ERR_BUS_ARBITRATION_LOST` | 12 | 🔄 Bus arbitration lost | Normal in multi-node systems |
 
 ### 📨 **Message Error Codes**
@@ -120,10 +120,10 @@ The CAN system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `CAN_ERR_MESSAGE_TIMEOUT` | 13 | ⏰ Message timeout | Check bus load and timing |
 | `CAN_ERR_MESSAGE_LOST` | 14 | 📤 Message lost | Check buffer sizes |
-| `CAN_ERR_MESSAGE_INVALID` | 15 | ERROR: Invalid message | Check message format |
+| `CAN_ERR_MESSAGE_INVALID` | 15 | ❌ Invalid message | Check message format |
 | `CAN_ERR_MESSAGE_TOO_LONG` | 16 | 📏 Message too long | Check DLC value |
 | `CAN_ERR_MESSAGE_INVALID_ID` | 17 | 🆔 Invalid message ID | Check ID range |
-| `CAN_ERR_MESSAGE_INVALID_DLC` | 18 | INFO: Invalid DLC | Check data length |
+| `CAN_ERR_MESSAGE_INVALID_DLC` | 18 | 📊 Invalid DLC | Check data length |
 | `CAN_ERR_QUEUE_FULL` | 19 | 📦 Queue full | Increase queue size or process faster |
 | `CAN_ERR_QUEUE_EMPTY` | 20 | 📭 Queue empty | Check message reception |
 
@@ -131,18 +131,18 @@ The CAN system uses comprehensive error codes for robust error handling:
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `CAN_ERR_TX_FAILED` | 21 | ERROR: Transmission failed | Check bus state and wiring |
+| `CAN_ERR_TX_FAILED` | 21 | ❌ Transmission failed | Check bus state and wiring |
 | `CAN_ERR_TX_ABORTED` | 22 | 🚫 Transmission aborted | Check bus errors |
-| `CAN_ERR_TX_ERROR_PASSIVE` | 23 | WARNING: Transmit error passive | Check error counters |
-| `CAN_ERR_TX_ERROR_WARNING` | 24 | WARNING: Transmit error warning | Monitor error counters |
+| `CAN_ERR_TX_ERROR_PASSIVE` | 23 | ⚠️ Transmit error passive | Check error counters |
+| `CAN_ERR_TX_ERROR_WARNING` | 24 | ⚠️ Transmit error warning | Monitor error counters |
 
 ### 📥 **Reception Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `CAN_ERR_RX_OVERRUN` | 25 | 📈 Receive overrun | Process messages faster |
-| `CAN_ERR_RX_ERROR_PASSIVE` | 26 | WARNING: Receive error passive | Check error counters |
-| `CAN_ERR_RX_ERROR_WARNING` | 27 | WARNING: Receive error warning | Monitor error counters |
+| `CAN_ERR_RX_ERROR_PASSIVE` | 26 | ⚠️ Receive error passive | Check error counters |
+| `CAN_ERR_RX_ERROR_WARNING` | 27 | ⚠️ Receive error warning | Monitor error counters |
 | `CAN_ERR_RX_FIFO_FULL` | 28 | 📦 Receive FIFO full | Process messages faster |
 
 ### 🌐 **Hardware Error Codes**
@@ -162,7 +162,7 @@ The CAN system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `CAN_ERR_INVALID_CONFIGURATION` | 35 | ⚙️ Invalid configuration | Check configuration parameters |
 | `CAN_ERR_UNSUPPORTED_OPERATION` | 36 | 🚫 Unsupported operation | Check hardware capabilities |
-| `CAN_ERR_INVALID_BAUD_RATE` | 37 | INFO: Invalid baud rate | Use supported baud rate |
+| `CAN_ERR_INVALID_BAUD_RATE` | 37 | 📊 Invalid baud rate | Use supported baud rate |
 | `CAN_ERR_INVALID_CONTROLLER_ID` | 38 | 🆔 Invalid controller ID | Use valid controller ID |
 | `CAN_ERR_FILTER_ERROR` | 39 | 🔍 Filter error | Check filter configuration |
 | `CAN_ERR_FILTER_FULL` | 40 | 📦 Filter table full | Reduce number of filters |
@@ -174,7 +174,7 @@ The CAN system uses comprehensive error codes for robust error handling:
 | `CAN_ERR_STUFF_ERROR` | 41 | 🔧 Bit stuffing error | Check bus quality |
 | `CAN_ERR_FORM_ERROR` | 42 | 📋 Frame format error | Check message format |
 | `CAN_ERR_CRC_ERROR` | 43 | 🔢 CRC error | Check bus integrity |
-| `CAN_ERR_ACK_ERROR` | 44 | SUCCESS: Acknowledgment error | Check bus termination |
+| `CAN_ERR_ACK_ERROR` | 44 | ✅ Acknowledgment error | Check bus termination |
 | `CAN_ERR_BIT_ERROR` | 45 | 🔌 Bit error | Check bus quality |
 
 ---
@@ -400,7 +400,7 @@ virtual hf_can_err_t SetReceiveCallbackFD(hf_can_fd_receive_callback_t callback)
  * @brief Check if CAN-FD is supported
  * @return true if supported, false otherwise
  * 
- * SUCCESS: Checks if the hardware supports CAN-FD protocol.
+ * ✅ Checks if the hardware supports CAN-FD protocol.
  */
 virtual bool SupportsCanFD() const noexcept;
 
@@ -421,7 +421,7 @@ virtual bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000,
  * @param status Reference to store status information
  * @return hf_can_err_t error code
  * 
- * INFO: Retrieves comprehensive CAN bus status information.
+ * 📊 Retrieves comprehensive CAN bus status information.
  * 
  * @example
  * hf_can_status_t status;
@@ -458,7 +458,7 @@ virtual hf_can_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_can_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about CAN operations.
+ * 📊 Retrieves comprehensive statistics about CAN operations.
  */
 virtual hf_can_err_t GetStatistics(hf_can_statistics_t &statistics) const noexcept;
 
@@ -474,7 +474,7 @@ virtual hf_can_err_t GetDiagnostics(hf_can_diagnostics_t &diagnostics) const noe
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### 📨 **CAN Message Structure**
 
@@ -534,7 +534,7 @@ struct hf_can_config_t {
 };
 ```
 
-### INFO: **CAN Status Structure**
+### 📊 **CAN Status Structure**
 
 ```cpp
 struct hf_can_status_t {
@@ -612,7 +612,7 @@ struct hf_can_diagnostics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 📨 **Basic Message Transmission**
 
@@ -635,7 +635,7 @@ EspCan can(config);
 void setup() {
     // Initialize CAN
     if (can.Initialize() == hf_can_err_t::CAN_SUCCESS) {
-        printf("SUCCESS: CAN initialized successfully\n");
+        printf("✅ CAN initialized successfully\n");
     }
 }
 
@@ -658,9 +658,9 @@ void send_status_message() {
     
     hf_can_err_t result = can.SendMessage(msg, 1000);
     if (result != hf_can_err_t::CAN_SUCCESS) {
-        printf("ERROR: Send failed: %s\n", HfCanErrToString(result));
+        printf("❌ Send failed: %s\n", HfCanErrToString(result));
     } else {
-        printf("SUCCESS: Message sent successfully\n");
+        printf("✅ Message sent successfully\n");
     }
 }
 ```
@@ -694,14 +694,14 @@ void receive_messages() {
                     process_command_message(msg);
                     break;
                 default:
-                    printf("WARNING: Unknown message ID: 0x%03X\n", msg.id);
+                    printf("⚠️ Unknown message ID: 0x%03X\n", msg.id);
                     break;
             }
         } else if (result == hf_can_err_t::CAN_ERR_QUEUE_EMPTY) {
             // No message available, continue
             continue;
         } else {
-            printf("ERROR: Receive error: %s\n", HfCanErrToString(result));
+            printf("❌ Receive error: %s\n", HfCanErrToString(result));
         }
     }
 }
@@ -713,7 +713,7 @@ void process_status_message(const hf_can_message_t &msg) {
         uint8_t voltage = msg.data[2];
         uint8_t current = msg.data[3];
         
-        printf("INFO: Status - Temp: %u°C, V: %uV, I: %uA\n", 
+        printf("📊 Status - Temp: %u°C, V: %uV, I: %uA\n", 
                temperature, voltage, current);
     }
 }
@@ -739,7 +739,7 @@ void setup_filtering() {
     // Accept only diagnostic messages (0x7DF-0x7FF)
     can.SetAcceptanceFilter(0x7DF, 0x7E0, false);
     
-    printf("SUCCESS: Message filtering configured\n");
+    printf("✅ Message filtering configured\n");
 }
 
 void receive_filtered_messages() {
@@ -783,7 +783,7 @@ void setup_async_reception() {
     // Set receive callback
     can.SetReceiveCallback(on_can_message);
     
-    printf("SUCCESS: Asynchronous reception enabled\n");
+    printf("✅ Asynchronous reception enabled\n");
 }
 
 void main_loop() {
@@ -830,7 +830,7 @@ public:
         
         hf_can_err_t result = can_.SendMessage(msg, 1000);
         if (result != hf_can_err_t::CAN_SUCCESS) {
-            printf("ERROR: Speed command failed: %s\n", HfCanErrToString(result));
+            printf("❌ Speed command failed: %s\n", HfCanErrToString(result));
         }
     }
     
@@ -847,7 +847,7 @@ public:
     void monitor_status() {
         hf_can_status_t status;
         if (can_.GetStatus(status) == hf_can_err_t::CAN_SUCCESS) {
-            printf("INFO: CAN Status - TX errors: %u, RX errors: %u, Bus off: %s\n",
+            printf("📊 CAN Status - TX errors: %u, RX errors: %u, Bus off: %s\n",
                    status.tx_error_count, status.rx_error_count,
                    status.bus_off ? "Yes" : "No");
         }
@@ -866,25 +866,25 @@ private:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (can.Initialize() != hf_can_err_t::CAN_SUCCESS) {
-    printf("ERROR: CAN initialization failed\n");
+    printf("❌ CAN initialization failed\n");
     return false;
 }
 
-// SUCCESS: Use appropriate timeouts
+// ✅ Use appropriate timeouts
 can.SendMessage(msg, 1000);  // 1 second timeout for critical messages
 can.ReceiveMessage(msg, 100);  // 100ms timeout for non-blocking receive
 
-// SUCCESS: Handle all error codes
+// ✅ Handle all error codes
 hf_can_err_t result = can.SendMessage(msg, timeout);
 if (result != hf_can_err_t::CAN_SUCCESS) {
-    printf("WARNING: Send error: %s\n", HfCanErrToString(result));
+    printf("⚠️ Send error: %s\n", HfCanErrToString(result));
     // Handle specific error types
     if (result == hf_can_err_t::CAN_ERR_BUS_OFF) {
         // Bus off - restart controller
@@ -893,40 +893,40 @@ if (result != hf_can_err_t::CAN_SUCCESS) {
     }
 }
 
-// SUCCESS: Use message filtering for efficiency
+// ✅ Use message filtering for efficiency
 can.SetAcceptanceFilter(0x100, 0x700, false);  // Only accept status messages
 
-// SUCCESS: Monitor bus health
+// ✅ Monitor bus health
 hf_can_status_t status;
 if (can.GetStatus(status) == hf_can_err_t::CAN_SUCCESS) {
     if (status.bus_off) {
         printf("🚨 Bus off detected!\n");
     }
     if (status.tx_error_count > 100) {
-        printf("WARNING: High TX error count: %u\n", status.tx_error_count);
+        printf("⚠️ High TX error count: %u\n", status.tx_error_count);
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 can.SendMessage(msg);  // May fail silently
 
-// ERROR: Don't use infinite timeouts in real-time systems
+// ❌ Don't use infinite timeouts in real-time systems
 can.ReceiveMessage(msg, UINT32_MAX);  // May block forever
 
-// ERROR: Don't ignore error codes
+// ❌ Don't ignore error codes
 can.SendMessage(msg);  // Error handling missing
 
-// ERROR: Don't assume message reception
+// ❌ Don't assume message reception
 // Always check return values for receive operations
 
-// ERROR: Don't use without proper bus termination
+// ❌ Don't use without proper bus termination
 // CAN bus requires proper termination resistors
 
-// ERROR: Don't ignore bus-off state
+// ❌ Don't ignore bus-off state
 // Bus-off requires controller restart
 ```
 
@@ -954,7 +954,7 @@ can.SetAcceptanceFilter(target_id, mask, extended);
 hf_can_statistics_t stats;
 can.GetStatistics(stats);
 if (stats.tx_queue_overflows > 0) {
-    printf("WARNING: TX queue overflow - increase queue size\n");
+    printf("⚠️ TX queue overflow - increase queue size\n");
 }
 ```
 

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -31,13 +31,13 @@ The `BaseCan` class provides a comprehensive CAN bus abstraction that serves as 
 - 🚌 **CAN & CAN-FD Support** - Both classic CAN and CAN-FD protocols
 - 📨 **Message Filtering** - Hardware-based acceptance filtering
 - 🔄 **Error Recovery** - Automatic bus recovery and error handling
-- 📊 **Statistics & Diagnostics** - Comprehensive monitoring and reporting
+- INFO: **Statistics & Diagnostics** - Comprehensive monitoring and reporting
 - ⚡ **High Performance** - Optimized for real-time applications
 - 🛡️ **Robust Error Handling** - Detailed error codes and recovery mechanisms
 - 🔌 **Platform Agnostic** - Works with internal and external CAN controllers
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
-### 📊 **Supported Hardware**
+### INFO: **Supported Hardware**
 
 | Implementation | Hardware Type | Protocol | Speed | Features |
 |----------------|---------------|----------|-------|----------|
@@ -86,19 +86,19 @@ classDiagram
 
 The CAN system uses comprehensive error codes for robust error handling:
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `CAN_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `CAN_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `CAN_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `CAN_ERR_NOT_INITIALIZED` | 2 | ⚠️ CAN not initialized | Call Initialize() first |
-| `CAN_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ CAN already initialized | Check initialization state |
+| `CAN_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `CAN_ERR_NOT_INITIALIZED` | 2 | WARNING: CAN not initialized | Call Initialize() first |
+| `CAN_ERR_ALREADY_INITIALIZED` | 3 | WARNING: CAN already initialized | Check initialization state |
 | `CAN_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `CAN_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `CAN_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -108,10 +108,10 @@ The CAN system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `CAN_ERR_BUS_OFF` | 7 | 🚫 Bus off state | Restart CAN controller |
-| `CAN_ERR_BUS_ERROR` | 8 | ❌ Bus error | Check bus wiring and termination |
+| `CAN_ERR_BUS_ERROR` | 8 | ERROR: Bus error | Check bus wiring and termination |
 | `CAN_ERR_BUS_BUSY` | 9 | 🔄 Bus busy | Wait for bus availability |
 | `CAN_ERR_BUS_NOT_AVAILABLE` | 10 | 🚫 Bus not available | Check bus configuration |
-| `CAN_ERR_BUS_RECOVERY_FAILED` | 11 | ❌ Bus recovery failed | Restart CAN controller |
+| `CAN_ERR_BUS_RECOVERY_FAILED` | 11 | ERROR: Bus recovery failed | Restart CAN controller |
 | `CAN_ERR_BUS_ARBITRATION_LOST` | 12 | 🔄 Bus arbitration lost | Normal in multi-node systems |
 
 ### 📨 **Message Error Codes**
@@ -120,10 +120,10 @@ The CAN system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `CAN_ERR_MESSAGE_TIMEOUT` | 13 | ⏰ Message timeout | Check bus load and timing |
 | `CAN_ERR_MESSAGE_LOST` | 14 | 📤 Message lost | Check buffer sizes |
-| `CAN_ERR_MESSAGE_INVALID` | 15 | ❌ Invalid message | Check message format |
+| `CAN_ERR_MESSAGE_INVALID` | 15 | ERROR: Invalid message | Check message format |
 | `CAN_ERR_MESSAGE_TOO_LONG` | 16 | 📏 Message too long | Check DLC value |
 | `CAN_ERR_MESSAGE_INVALID_ID` | 17 | 🆔 Invalid message ID | Check ID range |
-| `CAN_ERR_MESSAGE_INVALID_DLC` | 18 | 📊 Invalid DLC | Check data length |
+| `CAN_ERR_MESSAGE_INVALID_DLC` | 18 | INFO: Invalid DLC | Check data length |
 | `CAN_ERR_QUEUE_FULL` | 19 | 📦 Queue full | Increase queue size or process faster |
 | `CAN_ERR_QUEUE_EMPTY` | 20 | 📭 Queue empty | Check message reception |
 
@@ -131,18 +131,18 @@ The CAN system uses comprehensive error codes for robust error handling:
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `CAN_ERR_TX_FAILED` | 21 | ❌ Transmission failed | Check bus state and wiring |
+| `CAN_ERR_TX_FAILED` | 21 | ERROR: Transmission failed | Check bus state and wiring |
 | `CAN_ERR_TX_ABORTED` | 22 | 🚫 Transmission aborted | Check bus errors |
-| `CAN_ERR_TX_ERROR_PASSIVE` | 23 | ⚠️ Transmit error passive | Check error counters |
-| `CAN_ERR_TX_ERROR_WARNING` | 24 | ⚠️ Transmit error warning | Monitor error counters |
+| `CAN_ERR_TX_ERROR_PASSIVE` | 23 | WARNING: Transmit error passive | Check error counters |
+| `CAN_ERR_TX_ERROR_WARNING` | 24 | WARNING: Transmit error warning | Monitor error counters |
 
 ### 📥 **Reception Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `CAN_ERR_RX_OVERRUN` | 25 | 📈 Receive overrun | Process messages faster |
-| `CAN_ERR_RX_ERROR_PASSIVE` | 26 | ⚠️ Receive error passive | Check error counters |
-| `CAN_ERR_RX_ERROR_WARNING` | 27 | ⚠️ Receive error warning | Monitor error counters |
+| `CAN_ERR_RX_ERROR_PASSIVE` | 26 | WARNING: Receive error passive | Check error counters |
+| `CAN_ERR_RX_ERROR_WARNING` | 27 | WARNING: Receive error warning | Monitor error counters |
 | `CAN_ERR_RX_FIFO_FULL` | 28 | 📦 Receive FIFO full | Process messages faster |
 
 ### 🌐 **Hardware Error Codes**
@@ -162,7 +162,7 @@ The CAN system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `CAN_ERR_INVALID_CONFIGURATION` | 35 | ⚙️ Invalid configuration | Check configuration parameters |
 | `CAN_ERR_UNSUPPORTED_OPERATION` | 36 | 🚫 Unsupported operation | Check hardware capabilities |
-| `CAN_ERR_INVALID_BAUD_RATE` | 37 | 📊 Invalid baud rate | Use supported baud rate |
+| `CAN_ERR_INVALID_BAUD_RATE` | 37 | INFO: Invalid baud rate | Use supported baud rate |
 | `CAN_ERR_INVALID_CONTROLLER_ID` | 38 | 🆔 Invalid controller ID | Use valid controller ID |
 | `CAN_ERR_FILTER_ERROR` | 39 | 🔍 Filter error | Check filter configuration |
 | `CAN_ERR_FILTER_FULL` | 40 | 📦 Filter table full | Reduce number of filters |
@@ -174,7 +174,7 @@ The CAN system uses comprehensive error codes for robust error handling:
 | `CAN_ERR_STUFF_ERROR` | 41 | 🔧 Bit stuffing error | Check bus quality |
 | `CAN_ERR_FORM_ERROR` | 42 | 📋 Frame format error | Check message format |
 | `CAN_ERR_CRC_ERROR` | 43 | 🔢 CRC error | Check bus integrity |
-| `CAN_ERR_ACK_ERROR` | 44 | ✅ Acknowledgment error | Check bus termination |
+| `CAN_ERR_ACK_ERROR` | 44 | SUCCESS: Acknowledgment error | Check bus termination |
 | `CAN_ERR_BIT_ERROR` | 45 | 🔌 Bit error | Check bus quality |
 
 ---
@@ -400,7 +400,7 @@ virtual hf_can_err_t SetReceiveCallbackFD(hf_can_fd_receive_callback_t callback)
  * @brief Check if CAN-FD is supported
  * @return true if supported, false otherwise
  * 
- * ✅ Checks if the hardware supports CAN-FD protocol.
+ * SUCCESS: Checks if the hardware supports CAN-FD protocol.
  */
 virtual bool SupportsCanFD() const noexcept;
 
@@ -421,7 +421,7 @@ virtual bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000,
  * @param status Reference to store status information
  * @return hf_can_err_t error code
  * 
- * 📊 Retrieves comprehensive CAN bus status information.
+ * INFO: Retrieves comprehensive CAN bus status information.
  * 
  * @example
  * hf_can_status_t status;
@@ -458,7 +458,7 @@ virtual hf_can_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_can_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about CAN operations.
+ * INFO: Retrieves comprehensive statistics about CAN operations.
  */
 virtual hf_can_err_t GetStatistics(hf_can_statistics_t &statistics) const noexcept;
 
@@ -474,7 +474,7 @@ virtual hf_can_err_t GetDiagnostics(hf_can_diagnostics_t &diagnostics) const noe
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### 📨 **CAN Message Structure**
 
@@ -534,7 +534,7 @@ struct hf_can_config_t {
 };
 ```
 
-### 📊 **CAN Status Structure**
+### INFO: **CAN Status Structure**
 
 ```cpp
 struct hf_can_status_t {
@@ -612,7 +612,7 @@ struct hf_can_diagnostics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 📨 **Basic Message Transmission**
 
@@ -635,7 +635,7 @@ EspCan can(config);
 void setup() {
     // Initialize CAN
     if (can.Initialize() == hf_can_err_t::CAN_SUCCESS) {
-        printf("✅ CAN initialized successfully\n");
+        printf("SUCCESS: CAN initialized successfully\n");
     }
 }
 
@@ -658,9 +658,9 @@ void send_status_message() {
     
     hf_can_err_t result = can.SendMessage(msg, 1000);
     if (result != hf_can_err_t::CAN_SUCCESS) {
-        printf("❌ Send failed: %s\n", HfCanErrToString(result));
+        printf("ERROR: Send failed: %s\n", HfCanErrToString(result));
     } else {
-        printf("✅ Message sent successfully\n");
+        printf("SUCCESS: Message sent successfully\n");
     }
 }
 ```
@@ -694,14 +694,14 @@ void receive_messages() {
                     process_command_message(msg);
                     break;
                 default:
-                    printf("⚠️ Unknown message ID: 0x%03X\n", msg.id);
+                    printf("WARNING: Unknown message ID: 0x%03X\n", msg.id);
                     break;
             }
         } else if (result == hf_can_err_t::CAN_ERR_QUEUE_EMPTY) {
             // No message available, continue
             continue;
         } else {
-            printf("❌ Receive error: %s\n", HfCanErrToString(result));
+            printf("ERROR: Receive error: %s\n", HfCanErrToString(result));
         }
     }
 }
@@ -713,7 +713,7 @@ void process_status_message(const hf_can_message_t &msg) {
         uint8_t voltage = msg.data[2];
         uint8_t current = msg.data[3];
         
-        printf("📊 Status - Temp: %u°C, V: %uV, I: %uA\n", 
+        printf("INFO: Status - Temp: %u°C, V: %uV, I: %uA\n", 
                temperature, voltage, current);
     }
 }
@@ -739,7 +739,7 @@ void setup_filtering() {
     // Accept only diagnostic messages (0x7DF-0x7FF)
     can.SetAcceptanceFilter(0x7DF, 0x7E0, false);
     
-    printf("✅ Message filtering configured\n");
+    printf("SUCCESS: Message filtering configured\n");
 }
 
 void receive_filtered_messages() {
@@ -783,7 +783,7 @@ void setup_async_reception() {
     // Set receive callback
     can.SetReceiveCallback(on_can_message);
     
-    printf("✅ Asynchronous reception enabled\n");
+    printf("SUCCESS: Asynchronous reception enabled\n");
 }
 
 void main_loop() {
@@ -830,7 +830,7 @@ public:
         
         hf_can_err_t result = can_.SendMessage(msg, 1000);
         if (result != hf_can_err_t::CAN_SUCCESS) {
-            printf("❌ Speed command failed: %s\n", HfCanErrToString(result));
+            printf("ERROR: Speed command failed: %s\n", HfCanErrToString(result));
         }
     }
     
@@ -847,7 +847,7 @@ public:
     void monitor_status() {
         hf_can_status_t status;
         if (can_.GetStatus(status) == hf_can_err_t::CAN_SUCCESS) {
-            printf("📊 CAN Status - TX errors: %u, RX errors: %u, Bus off: %s\n",
+            printf("INFO: CAN Status - TX errors: %u, RX errors: %u, Bus off: %s\n",
                    status.tx_error_count, status.rx_error_count,
                    status.bus_off ? "Yes" : "No");
         }
@@ -866,25 +866,25 @@ private:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (can.Initialize() != hf_can_err_t::CAN_SUCCESS) {
-    printf("❌ CAN initialization failed\n");
+    printf("ERROR: CAN initialization failed\n");
     return false;
 }
 
-// ✅ Use appropriate timeouts
+// SUCCESS: Use appropriate timeouts
 can.SendMessage(msg, 1000);  // 1 second timeout for critical messages
 can.ReceiveMessage(msg, 100);  // 100ms timeout for non-blocking receive
 
-// ✅ Handle all error codes
+// SUCCESS: Handle all error codes
 hf_can_err_t result = can.SendMessage(msg, timeout);
 if (result != hf_can_err_t::CAN_SUCCESS) {
-    printf("⚠️ Send error: %s\n", HfCanErrToString(result));
+    printf("WARNING: Send error: %s\n", HfCanErrToString(result));
     // Handle specific error types
     if (result == hf_can_err_t::CAN_ERR_BUS_OFF) {
         // Bus off - restart controller
@@ -893,40 +893,40 @@ if (result != hf_can_err_t::CAN_SUCCESS) {
     }
 }
 
-// ✅ Use message filtering for efficiency
+// SUCCESS: Use message filtering for efficiency
 can.SetAcceptanceFilter(0x100, 0x700, false);  // Only accept status messages
 
-// ✅ Monitor bus health
+// SUCCESS: Monitor bus health
 hf_can_status_t status;
 if (can.GetStatus(status) == hf_can_err_t::CAN_SUCCESS) {
     if (status.bus_off) {
         printf("🚨 Bus off detected!\n");
     }
     if (status.tx_error_count > 100) {
-        printf("⚠️ High TX error count: %u\n", status.tx_error_count);
+        printf("WARNING: High TX error count: %u\n", status.tx_error_count);
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 can.SendMessage(msg);  // May fail silently
 
-// ❌ Don't use infinite timeouts in real-time systems
+// ERROR: Don't use infinite timeouts in real-time systems
 can.ReceiveMessage(msg, UINT32_MAX);  // May block forever
 
-// ❌ Don't ignore error codes
+// ERROR: Don't ignore error codes
 can.SendMessage(msg);  // Error handling missing
 
-// ❌ Don't assume message reception
+// ERROR: Don't assume message reception
 // Always check return values for receive operations
 
-// ❌ Don't use without proper bus termination
+// ERROR: Don't use without proper bus termination
 // CAN bus requires proper termination resistors
 
-// ❌ Don't ignore bus-off state
+// ERROR: Don't ignore bus-off state
 // Bus-off requires controller restart
 ```
 
@@ -954,7 +954,7 @@ can.SetAcceptanceFilter(target_id, mask, extended);
 hf_can_statistics_t stats;
 can.GetStatistics(stats);
 if (stats.tx_queue_overflows > 0) {
-    printf("⚠️ TX queue overflow - increase queue size\n");
+    printf("WARNING: TX queue overflow - increase queue size\n");
 }
 ```
 

--- a/docs/api/BaseGpio.md
+++ b/docs/api/BaseGpio.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -35,9 +35,9 @@ The `BaseGpio` class provides a comprehensive GPIO abstraction that serves as th
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with MCU GPIOs, I2C expanders, SPI expanders
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
-- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
 
-### 📊 **Supported Hardware**
+### INFO: **Supported Hardware**
 
 | Implementation | Hardware Type | Pins | Features | Use Cases |
 |----------------|---------------|------|----------|-----------|
@@ -90,19 +90,19 @@ classDiagram
 
 The GPIO system uses comprehensive error codes for robust error handling:
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `GPIO_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `GPIO_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `GPIO_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `GPIO_ERR_NOT_INITIALIZED` | 2 | ⚠️ GPIO not initialized | Call Initialize() first |
-| `GPIO_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ GPIO already initialized | Check initialization state |
+| `GPIO_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `GPIO_ERR_NOT_INITIALIZED` | 2 | WARNING: GPIO not initialized | Call Initialize() first |
+| `GPIO_ERR_ALREADY_INITIALIZED` | 3 | WARNING: GPIO already initialized | Check initialization state |
 | `GPIO_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `GPIO_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `GPIO_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -137,12 +137,12 @@ The GPIO system uses comprehensive error codes for robust error handling:
 | `GPIO_ERR_RESOURCE_BUSY` | 20 | 🔄 Resource busy | Wait for resource availability |
 | `GPIO_ERR_RESOURCE_UNAVAILABLE` | 21 | 🚫 Resource unavailable | Check resource allocation |
 
-### 📖 **I/O Error Codes**
+### READ: **I/O Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `GPIO_ERR_READ_FAILURE` | 22 | 📖 Read failure | Check pin configuration and connections |
-| `GPIO_ERR_WRITE_FAILURE` | 23 | ✍️ Write failure | Check pin configuration and load |
+| `GPIO_ERR_READ_FAILURE` | 22 | READ: Read failure | Check pin configuration and connections |
+| `GPIO_ERR_WRITE_FAILURE` | 23 | WRITE: Write failure | Check pin configuration and load |
 | `GPIO_ERR_DIRECTION_MISMATCH` | 24 | 🔄 Direction mismatch | Set correct pin direction |
 | `GPIO_ERR_PULL_RESISTOR_FAILURE` | 25 | 🔌 Pull resistor failure | Check pull resistor configuration |
 
@@ -152,8 +152,8 @@ The GPIO system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `GPIO_ERR_INTERRUPT_NOT_SUPPORTED` | 26 | 🚫 Interrupt not supported | Check hardware capabilities |
 | `GPIO_ERR_INTERRUPT_ALREADY_ENABLED` | 27 | 🔄 Interrupt already enabled | Check interrupt state |
-| `GPIO_ERR_INTERRUPT_NOT_ENABLED` | 28 | ⚠️ Interrupt not enabled | Enable interrupt first |
-| `GPIO_ERR_INTERRUPT_HANDLER_FAILED` | 29 | ❌ Interrupt handler failed | Check callback function |
+| `GPIO_ERR_INTERRUPT_NOT_ENABLED` | 28 | WARNING: Interrupt not enabled | Enable interrupt first |
+| `GPIO_ERR_INTERRUPT_HANDLER_FAILED` | 29 | ERROR: Interrupt handler failed | Check callback function |
 
 ---
 
@@ -217,7 +217,7 @@ bool EnsureDeinitialized() noexcept;
  * @brief Get current pin direction
  * @return Current direction setting
  * 
- * 📊 Returns the current pin direction (input or output).
+ * INFO: Returns the current pin direction (input or output).
  */
 [[nodiscard]] hf_gpio_direction_t GetDirection() const noexcept;
 
@@ -240,7 +240,7 @@ hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept;
  * @brief Check if pin is configured as input
  * @return true if input, false if output
  * 
- * ✅ Quick check for input mode.
+ * SUCCESS: Quick check for input mode.
  */
 [[nodiscard]] bool IsInput() const noexcept;
 
@@ -248,7 +248,7 @@ hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept;
  * @brief Check if pin is configured as output
  * @return true if output, false if input
  * 
- * ✅ Quick check for output mode.
+ * SUCCESS: Quick check for output mode.
  */
 [[nodiscard]] bool IsOutput() const noexcept;
 
@@ -256,7 +256,7 @@ hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept;
  * @brief Get output drive mode
  * @return Current output mode setting
  * 
- * 📊 Returns the current output drive mode (push-pull or open-drain).
+ * INFO: Returns the current output drive mode (push-pull or open-drain).
  */
 [[nodiscard]] hf_gpio_output_mode_t GetOutputMode() const noexcept;
 
@@ -276,7 +276,7 @@ hf_gpio_err_t SetOutputMode(hf_gpio_output_mode_t mode) noexcept;
  * @brief Get pull resistor configuration
  * @return Current pull mode setting
  * 
- * 📊 Returns the current pull resistor configuration.
+ * INFO: Returns the current pull resistor configuration.
  */
 [[nodiscard]] hf_gpio_pull_mode_t GetPullMode() const noexcept;
 
@@ -300,7 +300,7 @@ hf_gpio_err_t SetPullMode(hf_gpio_pull_mode_t mode) noexcept;
  * @brief Get current logical state
  * @return Current logical state
  * 
- * 📊 Returns the current logical state (active or inactive).
+ * INFO: Returns the current logical state (active or inactive).
  */
 [[nodiscard]] hf_gpio_state_t GetCurrentState() const noexcept;
 
@@ -308,7 +308,7 @@ hf_gpio_err_t SetPullMode(hf_gpio_pull_mode_t mode) noexcept;
  * @brief Get active state polarity
  * @return Current active state configuration
  * 
- * 📊 Returns whether the pin is active-high or active-low.
+ * INFO: Returns whether the pin is active-high or active-low.
  */
 [[nodiscard]] hf_gpio_active_state_t GetActiveState() const noexcept;
 
@@ -361,7 +361,7 @@ hf_gpio_err_t Toggle() noexcept;
  * @param is_active Reference to store result
  * @return hf_gpio_err_t error code
  * 
- * ✅ Reads the current logical state of the pin.
+ * SUCCESS: Reads the current logical state of the pin.
  * 
  * @example
  * bool is_on;
@@ -379,7 +379,7 @@ hf_gpio_err_t IsActive(bool &is_active) noexcept;
  * @brief Check if interrupts are supported
  * @return true if supported, false otherwise
  * 
- * ✅ Checks if the hardware supports interrupts.
+ * SUCCESS: Checks if the hardware supports interrupts.
  */
 [[nodiscard]] virtual bool SupportsInterrupts() const noexcept;
 
@@ -437,14 +437,14 @@ virtual hf_gpio_err_t DisableInterrupt() noexcept;
 virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept;
 ```
 
-### 📊 **Information and Status**
+### INFO: **Information and Status**
 
 ```cpp
 /**
  * @brief Check if pin is available
  * @return true if available, false otherwise
  * 
- * ✅ Checks if the pin is available for use.
+ * SUCCESS: Checks if the pin is available for use.
  */
 [[nodiscard]] virtual bool IsPinAvailable() const noexcept = 0;
 
@@ -452,7 +452,7 @@ virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept;
  * @brief Get maximum number of pins
  * @return Maximum pin count
  * 
- * 📊 Returns the total number of pins available on this hardware.
+ * INFO: Returns the total number of pins available on this hardware.
  */
 [[nodiscard]] virtual uint8_t GetMaxPins() const noexcept = 0;
 
@@ -468,7 +468,7 @@ virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept;
  * @brief Get GPIO pin number
  * @return Pin number/identifier
  * 
- * 📊 Returns the platform-agnostic pin identifier.
+ * INFO: Returns the platform-agnostic pin identifier.
  */
 [[nodiscard]] hf_pin_num_t GetPin() const noexcept;
 ```
@@ -497,7 +497,7 @@ virtual hf_gpio_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_gpio_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about GPIO operations.
+ * INFO: Retrieves comprehensive statistics about GPIO operations.
  */
 virtual hf_gpio_err_t GetStatistics(hf_gpio_statistics_t &statistics) const noexcept;
 
@@ -513,7 +513,7 @@ virtual hf_gpio_err_t GetDiagnostics(hf_gpio_diagnostics_t &diagnostics) const n
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### 🔌 **GPIO State Enums**
 
@@ -596,7 +596,7 @@ using InterruptCallback = std::function<void(BaseGpio *gpio,
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 🔌 **Basic LED Control**
 
@@ -609,7 +609,7 @@ EspGpio led_pin(2, HF_GPIO_DIRECTION_OUTPUT, HF_GPIO_ACTIVE_LOW);
 void setup_led() {
     // Initialize GPIO (lazy initialization)
     if (led_pin.EnsureInitialized()) {
-        printf("✅ LED GPIO initialized\n");
+        printf("SUCCESS: LED GPIO initialized\n");
     }
 }
 
@@ -617,7 +617,7 @@ void control_led() {
     // Turn LED on
     hf_gpio_err_t result = led_pin.SetActive();
     if (result != hf_gpio_err_t::GPIO_SUCCESS) {
-        printf("❌ LED on failed: %s\n", HfGpioErrToString(result));
+        printf("ERROR: LED on failed: %s\n", HfGpioErrToString(result));
     }
     
     // Wait a moment
@@ -626,7 +626,7 @@ void control_led() {
     // Turn LED off
     result = led_pin.SetInactive();
     if (result != hf_gpio_err_t::GPIO_SUCCESS) {
-        printf("❌ LED off failed: %s\n", HfGpioErrToString(result));
+        printf("ERROR: LED off failed: %s\n", HfGpioErrToString(result));
     }
 }
 
@@ -659,7 +659,7 @@ void on_button_press(BaseGpio* gpio, hf_gpio_interrupt_trigger_t trigger, void* 
     // Check if button is still pressed
     bool is_pressed;
     if (gpio->IsActive(is_pressed) == hf_gpio_err_t::GPIO_SUCCESS && is_pressed) {
-        printf("✅ Button confirmed pressed\n");
+        printf("SUCCESS: Button confirmed pressed\n");
         // Handle button press
     }
 }
@@ -680,12 +680,12 @@ void setup_button() {
         
         if (result == hf_gpio_err_t::GPIO_SUCCESS) {
             button_pin.EnableInterrupt();
-            printf("✅ Button interrupt configured\n");
+            printf("SUCCESS: Button interrupt configured\n");
         } else {
-            printf("❌ Button interrupt failed: %s\n", HfGpioErrToString(result));
+            printf("ERROR: Button interrupt failed: %s\n", HfGpioErrToString(result));
         }
     } else {
-        printf("⚠️ Interrupts not supported on this GPIO\n");
+        printf("WARNING: Interrupts not supported on this GPIO\n");
     }
 }
 
@@ -717,14 +717,14 @@ public:
     void set_as_output() {
         hf_gpio_err_t result = gpio_->SetDirection(HF_GPIO_DIRECTION_OUTPUT);
         if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-            printf("✅ Pin configured as output\n");
+            printf("SUCCESS: Pin configured as output\n");
         }
     }
     
     void set_as_input() {
         hf_gpio_err_t result = gpio_->SetDirection(HF_GPIO_DIRECTION_INPUT);
         if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-            printf("✅ Pin configured as input\n");
+            printf("SUCCESS: Pin configured as input\n");
         }
     }
     
@@ -736,7 +736,7 @@ public:
                 gpio_->SetInactive();
             }
         } else {
-            printf("❌ Pin not configured as output\n");
+            printf("ERROR: Pin not configured as output\n");
         }
     }
     
@@ -747,7 +747,7 @@ public:
                 return value;
             }
         } else {
-            printf("❌ Pin not configured as input\n");
+            printf("ERROR: Pin not configured as input\n");
         }
         return false;
     }
@@ -776,7 +776,7 @@ void setup_expander() {
     expander_pin1.SetDirection(HF_GPIO_DIRECTION_INPUT);
     expander_pin1.SetPullMode(HF_GPIO_PULL_MODE_UP);
     
-    printf("✅ I2C GPIO expander configured\n");
+    printf("SUCCESS: I2C GPIO expander configured\n");
 }
 
 void control_expander_led() {
@@ -793,7 +793,7 @@ void control_expander_led() {
 }
 ```
 
-### 📊 **GPIO Monitoring System**
+### INFO: **GPIO Monitoring System**
 
 ```cpp
 #include "mcu/esp32/EspGpio.h"
@@ -808,7 +808,7 @@ public:
     }
     
     void monitor_all_pins() {
-        printf("📊 GPIO Status Report:\n");
+        printf("INFO: GPIO Status Report:\n");
         printf("=====================\n");
         
         for (auto* pin : gpio_pins_) {
@@ -816,7 +816,7 @@ public:
             
             // Check if initialized
             if (!pin->IsInitialized()) {
-                printf("❌ Not initialized\n");
+                printf("ERROR: Not initialized\n");
                 continue;
             }
             
@@ -861,7 +861,7 @@ public:
             if (pin->GetDiagnostics(diag) == hf_gpio_err_t::GPIO_SUCCESS) {
                 printf("Pin %d: %s | Last error: %s | Consecutive errors: %u\n",
                        pin->GetPin(),
-                       diag.gpioHealthy ? "✅ Healthy" : "❌ Unhealthy",
+                       diag.gpioHealthy ? "SUCCESS: Healthy" : "ERROR: Unhealthy",
                        HfGpioErrToString(diag.lastErrorCode),
                        diag.consecutiveErrors);
             }
@@ -872,71 +872,71 @@ public:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!gpio.EnsureInitialized()) {
-    printf("❌ GPIO initialization failed\n");
+    printf("ERROR: GPIO initialization failed\n");
     return false;
 }
 
-// ✅ Validate pin availability
+// SUCCESS: Validate pin availability
 if (!gpio.IsPinAvailable()) {
-    printf("❌ Pin not available\n");
+    printf("ERROR: Pin not available\n");
     return;
 }
 
-// ✅ Set appropriate pull resistors for inputs
+// SUCCESS: Set appropriate pull resistors for inputs
 gpio.SetPullMode(HF_GPIO_PULL_MODE_UP);  // For buttons
 gpio.SetPullMode(HF_GPIO_PULL_MODE_DOWN);  // For active-high sensors
 
-// ✅ Use appropriate active state for LEDs
+// SUCCESS: Use appropriate active state for LEDs
 gpio.SetActiveState(HF_GPIO_ACTIVE_LOW);  // Common for LED cathodes
 
-// ✅ Handle all error codes
+// SUCCESS: Handle all error codes
 hf_gpio_err_t result = gpio.SetActive();
 if (result != hf_gpio_err_t::GPIO_SUCCESS) {
-    printf("⚠️ GPIO Error: %s\n", HfGpioErrToString(result));
+    printf("WARNING: GPIO Error: %s\n", HfGpioErrToString(result));
     // Handle specific error types
 }
 
-// ✅ Use interrupts for responsive input handling
+// SUCCESS: Use interrupts for responsive input handling
 if (gpio.SupportsInterrupts()) {
     gpio.ConfigureInterrupt(HF_GPIO_INTERRUPT_TRIGGER_FALLING_EDGE, callback);
     gpio.EnableInterrupt();
 }
 
-// ✅ Monitor statistics for system health
+// SUCCESS: Monitor statistics for system health
 hf_gpio_statistics_t stats;
 if (gpio.GetStatistics(stats) == hf_gpio_err_t::GPIO_SUCCESS) {
     if (stats.failedOperations > 10) {
-        printf("⚠️ High GPIO failure rate detected\n");
+        printf("WARNING: High GPIO failure rate detected\n");
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 gpio.SetActive();  // May fail silently
 
-// ❌ Don't use without checking pin availability
+// ERROR: Don't use without checking pin availability
 gpio.SetDirection(HF_GPIO_DIRECTION_OUTPUT);  // May fail on invalid pin
 
-// ❌ Don't ignore error codes
+// ERROR: Don't ignore error codes
 gpio.SetActive();  // Error handling missing
 
-// ❌ Don't assume pin direction
+// ERROR: Don't assume pin direction
 gpio.IsActive(value);  // May fail if pin is output
 
-// ❌ Don't use interrupts without checking support
+// ERROR: Don't use interrupts without checking support
 gpio.ConfigureInterrupt(trigger, callback);  // May fail if not supported
 
-// ❌ Don't forget pull resistors for floating inputs
+// ERROR: Don't forget pull resistors for floating inputs
 // Floating inputs can cause erratic behavior
 ```
 
@@ -960,7 +960,7 @@ gpio.SetOutputMode(HF_GPIO_OUTPUT_MODE_OPEN_DRAIN);  // For open-drain applicati
 hf_gpio_statistics_t stats;
 gpio.GetStatistics(stats);
 if (stats.averageOperationTimeUs > 100) {
-    printf("⚠️ Slow GPIO operations detected\n");
+    printf("WARNING: Slow GPIO operations detected\n");
 }
 ```
 

--- a/docs/api/BaseGpio.md
+++ b/docs/api/BaseGpio.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -35,9 +35,9 @@ The `BaseGpio` class provides a comprehensive GPIO abstraction that serves as th
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with MCU GPIOs, I2C expanders, SPI expanders
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
-- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
 
-### INFO: **Supported Hardware**
+### 📊 **Supported Hardware**
 
 | Implementation | Hardware Type | Pins | Features | Use Cases |
 |----------------|---------------|------|----------|-----------|
@@ -90,19 +90,19 @@ classDiagram
 
 The GPIO system uses comprehensive error codes for robust error handling:
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `GPIO_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `GPIO_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `GPIO_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `GPIO_ERR_NOT_INITIALIZED` | 2 | WARNING: GPIO not initialized | Call Initialize() first |
-| `GPIO_ERR_ALREADY_INITIALIZED` | 3 | WARNING: GPIO already initialized | Check initialization state |
+| `GPIO_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `GPIO_ERR_NOT_INITIALIZED` | 2 | ⚠️ GPIO not initialized | Call Initialize() first |
+| `GPIO_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ GPIO already initialized | Check initialization state |
 | `GPIO_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `GPIO_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `GPIO_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -137,12 +137,12 @@ The GPIO system uses comprehensive error codes for robust error handling:
 | `GPIO_ERR_RESOURCE_BUSY` | 20 | 🔄 Resource busy | Wait for resource availability |
 | `GPIO_ERR_RESOURCE_UNAVAILABLE` | 21 | 🚫 Resource unavailable | Check resource allocation |
 
-### READ: **I/O Error Codes**
+### 📖 **I/O Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `GPIO_ERR_READ_FAILURE` | 22 | READ: Read failure | Check pin configuration and connections |
-| `GPIO_ERR_WRITE_FAILURE` | 23 | WRITE: Write failure | Check pin configuration and load |
+| `GPIO_ERR_READ_FAILURE` | 22 | 📖 Read failure | Check pin configuration and connections |
+| `GPIO_ERR_WRITE_FAILURE` | 23 | ✍️ Write failure | Check pin configuration and load |
 | `GPIO_ERR_DIRECTION_MISMATCH` | 24 | 🔄 Direction mismatch | Set correct pin direction |
 | `GPIO_ERR_PULL_RESISTOR_FAILURE` | 25 | 🔌 Pull resistor failure | Check pull resistor configuration |
 
@@ -152,8 +152,8 @@ The GPIO system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `GPIO_ERR_INTERRUPT_NOT_SUPPORTED` | 26 | 🚫 Interrupt not supported | Check hardware capabilities |
 | `GPIO_ERR_INTERRUPT_ALREADY_ENABLED` | 27 | 🔄 Interrupt already enabled | Check interrupt state |
-| `GPIO_ERR_INTERRUPT_NOT_ENABLED` | 28 | WARNING: Interrupt not enabled | Enable interrupt first |
-| `GPIO_ERR_INTERRUPT_HANDLER_FAILED` | 29 | ERROR: Interrupt handler failed | Check callback function |
+| `GPIO_ERR_INTERRUPT_NOT_ENABLED` | 28 | ⚠️ Interrupt not enabled | Enable interrupt first |
+| `GPIO_ERR_INTERRUPT_HANDLER_FAILED` | 29 | ❌ Interrupt handler failed | Check callback function |
 
 ---
 
@@ -217,7 +217,7 @@ bool EnsureDeinitialized() noexcept;
  * @brief Get current pin direction
  * @return Current direction setting
  * 
- * INFO: Returns the current pin direction (input or output).
+ * 📊 Returns the current pin direction (input or output).
  */
 [[nodiscard]] hf_gpio_direction_t GetDirection() const noexcept;
 
@@ -240,7 +240,7 @@ hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept;
  * @brief Check if pin is configured as input
  * @return true if input, false if output
  * 
- * SUCCESS: Quick check for input mode.
+ * ✅ Quick check for input mode.
  */
 [[nodiscard]] bool IsInput() const noexcept;
 
@@ -248,7 +248,7 @@ hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept;
  * @brief Check if pin is configured as output
  * @return true if output, false if input
  * 
- * SUCCESS: Quick check for output mode.
+ * ✅ Quick check for output mode.
  */
 [[nodiscard]] bool IsOutput() const noexcept;
 
@@ -256,7 +256,7 @@ hf_gpio_err_t SetDirection(hf_gpio_direction_t direction) noexcept;
  * @brief Get output drive mode
  * @return Current output mode setting
  * 
- * INFO: Returns the current output drive mode (push-pull or open-drain).
+ * 📊 Returns the current output drive mode (push-pull or open-drain).
  */
 [[nodiscard]] hf_gpio_output_mode_t GetOutputMode() const noexcept;
 
@@ -276,7 +276,7 @@ hf_gpio_err_t SetOutputMode(hf_gpio_output_mode_t mode) noexcept;
  * @brief Get pull resistor configuration
  * @return Current pull mode setting
  * 
- * INFO: Returns the current pull resistor configuration.
+ * 📊 Returns the current pull resistor configuration.
  */
 [[nodiscard]] hf_gpio_pull_mode_t GetPullMode() const noexcept;
 
@@ -300,7 +300,7 @@ hf_gpio_err_t SetPullMode(hf_gpio_pull_mode_t mode) noexcept;
  * @brief Get current logical state
  * @return Current logical state
  * 
- * INFO: Returns the current logical state (active or inactive).
+ * 📊 Returns the current logical state (active or inactive).
  */
 [[nodiscard]] hf_gpio_state_t GetCurrentState() const noexcept;
 
@@ -308,7 +308,7 @@ hf_gpio_err_t SetPullMode(hf_gpio_pull_mode_t mode) noexcept;
  * @brief Get active state polarity
  * @return Current active state configuration
  * 
- * INFO: Returns whether the pin is active-high or active-low.
+ * 📊 Returns whether the pin is active-high or active-low.
  */
 [[nodiscard]] hf_gpio_active_state_t GetActiveState() const noexcept;
 
@@ -361,7 +361,7 @@ hf_gpio_err_t Toggle() noexcept;
  * @param is_active Reference to store result
  * @return hf_gpio_err_t error code
  * 
- * SUCCESS: Reads the current logical state of the pin.
+ * ✅ Reads the current logical state of the pin.
  * 
  * @example
  * bool is_on;
@@ -379,7 +379,7 @@ hf_gpio_err_t IsActive(bool &is_active) noexcept;
  * @brief Check if interrupts are supported
  * @return true if supported, false otherwise
  * 
- * SUCCESS: Checks if the hardware supports interrupts.
+ * ✅ Checks if the hardware supports interrupts.
  */
 [[nodiscard]] virtual bool SupportsInterrupts() const noexcept;
 
@@ -437,14 +437,14 @@ virtual hf_gpio_err_t DisableInterrupt() noexcept;
 virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept;
 ```
 
-### INFO: **Information and Status**
+### 📊 **Information and Status**
 
 ```cpp
 /**
  * @brief Check if pin is available
  * @return true if available, false otherwise
  * 
- * SUCCESS: Checks if the pin is available for use.
+ * ✅ Checks if the pin is available for use.
  */
 [[nodiscard]] virtual bool IsPinAvailable() const noexcept = 0;
 
@@ -452,7 +452,7 @@ virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept;
  * @brief Get maximum number of pins
  * @return Maximum pin count
  * 
- * INFO: Returns the total number of pins available on this hardware.
+ * 📊 Returns the total number of pins available on this hardware.
  */
 [[nodiscard]] virtual uint8_t GetMaxPins() const noexcept = 0;
 
@@ -468,7 +468,7 @@ virtual hf_gpio_err_t WaitForInterrupt(uint32_t timeout_ms = 0) noexcept;
  * @brief Get GPIO pin number
  * @return Pin number/identifier
  * 
- * INFO: Returns the platform-agnostic pin identifier.
+ * 📊 Returns the platform-agnostic pin identifier.
  */
 [[nodiscard]] hf_pin_num_t GetPin() const noexcept;
 ```
@@ -497,7 +497,7 @@ virtual hf_gpio_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_gpio_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about GPIO operations.
+ * 📊 Retrieves comprehensive statistics about GPIO operations.
  */
 virtual hf_gpio_err_t GetStatistics(hf_gpio_statistics_t &statistics) const noexcept;
 
@@ -513,7 +513,7 @@ virtual hf_gpio_err_t GetDiagnostics(hf_gpio_diagnostics_t &diagnostics) const n
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### 🔌 **GPIO State Enums**
 
@@ -596,7 +596,7 @@ using InterruptCallback = std::function<void(BaseGpio *gpio,
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 🔌 **Basic LED Control**
 
@@ -609,7 +609,7 @@ EspGpio led_pin(2, HF_GPIO_DIRECTION_OUTPUT, HF_GPIO_ACTIVE_LOW);
 void setup_led() {
     // Initialize GPIO (lazy initialization)
     if (led_pin.EnsureInitialized()) {
-        printf("SUCCESS: LED GPIO initialized\n");
+        printf("✅ LED GPIO initialized\n");
     }
 }
 
@@ -617,7 +617,7 @@ void control_led() {
     // Turn LED on
     hf_gpio_err_t result = led_pin.SetActive();
     if (result != hf_gpio_err_t::GPIO_SUCCESS) {
-        printf("ERROR: LED on failed: %s\n", HfGpioErrToString(result));
+        printf("❌ LED on failed: %s\n", HfGpioErrToString(result));
     }
     
     // Wait a moment
@@ -626,7 +626,7 @@ void control_led() {
     // Turn LED off
     result = led_pin.SetInactive();
     if (result != hf_gpio_err_t::GPIO_SUCCESS) {
-        printf("ERROR: LED off failed: %s\n", HfGpioErrToString(result));
+        printf("❌ LED off failed: %s\n", HfGpioErrToString(result));
     }
 }
 
@@ -659,7 +659,7 @@ void on_button_press(BaseGpio* gpio, hf_gpio_interrupt_trigger_t trigger, void* 
     // Check if button is still pressed
     bool is_pressed;
     if (gpio->IsActive(is_pressed) == hf_gpio_err_t::GPIO_SUCCESS && is_pressed) {
-        printf("SUCCESS: Button confirmed pressed\n");
+        printf("✅ Button confirmed pressed\n");
         // Handle button press
     }
 }
@@ -680,12 +680,12 @@ void setup_button() {
         
         if (result == hf_gpio_err_t::GPIO_SUCCESS) {
             button_pin.EnableInterrupt();
-            printf("SUCCESS: Button interrupt configured\n");
+            printf("✅ Button interrupt configured\n");
         } else {
-            printf("ERROR: Button interrupt failed: %s\n", HfGpioErrToString(result));
+            printf("❌ Button interrupt failed: %s\n", HfGpioErrToString(result));
         }
     } else {
-        printf("WARNING: Interrupts not supported on this GPIO\n");
+        printf("⚠️ Interrupts not supported on this GPIO\n");
     }
 }
 
@@ -717,14 +717,14 @@ public:
     void set_as_output() {
         hf_gpio_err_t result = gpio_->SetDirection(HF_GPIO_DIRECTION_OUTPUT);
         if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-            printf("SUCCESS: Pin configured as output\n");
+            printf("✅ Pin configured as output\n");
         }
     }
     
     void set_as_input() {
         hf_gpio_err_t result = gpio_->SetDirection(HF_GPIO_DIRECTION_INPUT);
         if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-            printf("SUCCESS: Pin configured as input\n");
+            printf("✅ Pin configured as input\n");
         }
     }
     
@@ -736,7 +736,7 @@ public:
                 gpio_->SetInactive();
             }
         } else {
-            printf("ERROR: Pin not configured as output\n");
+            printf("❌ Pin not configured as output\n");
         }
     }
     
@@ -747,7 +747,7 @@ public:
                 return value;
             }
         } else {
-            printf("ERROR: Pin not configured as input\n");
+            printf("❌ Pin not configured as input\n");
         }
         return false;
     }
@@ -776,7 +776,7 @@ void setup_expander() {
     expander_pin1.SetDirection(HF_GPIO_DIRECTION_INPUT);
     expander_pin1.SetPullMode(HF_GPIO_PULL_MODE_UP);
     
-    printf("SUCCESS: I2C GPIO expander configured\n");
+    printf("✅ I2C GPIO expander configured\n");
 }
 
 void control_expander_led() {
@@ -793,7 +793,7 @@ void control_expander_led() {
 }
 ```
 
-### INFO: **GPIO Monitoring System**
+### 📊 **GPIO Monitoring System**
 
 ```cpp
 #include "mcu/esp32/EspGpio.h"
@@ -808,7 +808,7 @@ public:
     }
     
     void monitor_all_pins() {
-        printf("INFO: GPIO Status Report:\n");
+        printf("📊 GPIO Status Report:\n");
         printf("=====================\n");
         
         for (auto* pin : gpio_pins_) {
@@ -816,7 +816,7 @@ public:
             
             // Check if initialized
             if (!pin->IsInitialized()) {
-                printf("ERROR: Not initialized\n");
+                printf("❌ Not initialized\n");
                 continue;
             }
             
@@ -861,7 +861,7 @@ public:
             if (pin->GetDiagnostics(diag) == hf_gpio_err_t::GPIO_SUCCESS) {
                 printf("Pin %d: %s | Last error: %s | Consecutive errors: %u\n",
                        pin->GetPin(),
-                       diag.gpioHealthy ? "SUCCESS: Healthy" : "ERROR: Unhealthy",
+                       diag.gpioHealthy ? "✅ Healthy" : "❌ Unhealthy",
                        HfGpioErrToString(diag.lastErrorCode),
                        diag.consecutiveErrors);
             }
@@ -872,71 +872,71 @@ public:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!gpio.EnsureInitialized()) {
-    printf("ERROR: GPIO initialization failed\n");
+    printf("❌ GPIO initialization failed\n");
     return false;
 }
 
-// SUCCESS: Validate pin availability
+// ✅ Validate pin availability
 if (!gpio.IsPinAvailable()) {
-    printf("ERROR: Pin not available\n");
+    printf("❌ Pin not available\n");
     return;
 }
 
-// SUCCESS: Set appropriate pull resistors for inputs
+// ✅ Set appropriate pull resistors for inputs
 gpio.SetPullMode(HF_GPIO_PULL_MODE_UP);  // For buttons
 gpio.SetPullMode(HF_GPIO_PULL_MODE_DOWN);  // For active-high sensors
 
-// SUCCESS: Use appropriate active state for LEDs
+// ✅ Use appropriate active state for LEDs
 gpio.SetActiveState(HF_GPIO_ACTIVE_LOW);  // Common for LED cathodes
 
-// SUCCESS: Handle all error codes
+// ✅ Handle all error codes
 hf_gpio_err_t result = gpio.SetActive();
 if (result != hf_gpio_err_t::GPIO_SUCCESS) {
-    printf("WARNING: GPIO Error: %s\n", HfGpioErrToString(result));
+    printf("⚠️ GPIO Error: %s\n", HfGpioErrToString(result));
     // Handle specific error types
 }
 
-// SUCCESS: Use interrupts for responsive input handling
+// ✅ Use interrupts for responsive input handling
 if (gpio.SupportsInterrupts()) {
     gpio.ConfigureInterrupt(HF_GPIO_INTERRUPT_TRIGGER_FALLING_EDGE, callback);
     gpio.EnableInterrupt();
 }
 
-// SUCCESS: Monitor statistics for system health
+// ✅ Monitor statistics for system health
 hf_gpio_statistics_t stats;
 if (gpio.GetStatistics(stats) == hf_gpio_err_t::GPIO_SUCCESS) {
     if (stats.failedOperations > 10) {
-        printf("WARNING: High GPIO failure rate detected\n");
+        printf("⚠️ High GPIO failure rate detected\n");
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 gpio.SetActive();  // May fail silently
 
-// ERROR: Don't use without checking pin availability
+// ❌ Don't use without checking pin availability
 gpio.SetDirection(HF_GPIO_DIRECTION_OUTPUT);  // May fail on invalid pin
 
-// ERROR: Don't ignore error codes
+// ❌ Don't ignore error codes
 gpio.SetActive();  // Error handling missing
 
-// ERROR: Don't assume pin direction
+// ❌ Don't assume pin direction
 gpio.IsActive(value);  // May fail if pin is output
 
-// ERROR: Don't use interrupts without checking support
+// ❌ Don't use interrupts without checking support
 gpio.ConfigureInterrupt(trigger, callback);  // May fail if not supported
 
-// ERROR: Don't forget pull resistors for floating inputs
+// ❌ Don't forget pull resistors for floating inputs
 // Floating inputs can cause erratic behavior
 ```
 
@@ -960,7 +960,7 @@ gpio.SetOutputMode(HF_GPIO_OUTPUT_MODE_OPEN_DRAIN);  // For open-drain applicati
 hf_gpio_statistics_t stats;
 gpio.GetStatistics(stats);
 if (stats.averageOperationTimeUs > 100) {
-    printf("WARNING: Slow GPIO operations detected\n");
+    printf("⚠️ Slow GPIO operations detected\n");
 }
 ```
 

--- a/docs/api/BaseI2c.md
+++ b/docs/api/BaseI2c.md
@@ -642,6 +642,7 @@ void temperature_monitoring() {
 
 ```cpp
 #include "mcu/esp32/EspI2c.h"
+#include "utils/memory_utils.h"
 
 class Eeprom24LC256 {
 private:
@@ -705,13 +706,18 @@ public:
             return false;
         }
         
-        uint8_t* tx_data = new uint8_t[length + 2];
+        auto tx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 2);
+        if (!tx_data) {
+            printf("❌ Failed to allocate memory for transmit buffer\n");
+            return false;
+        }
+        
         tx_data[0] = static_cast<uint8_t>(address >> 8);    // High address byte
         tx_data[1] = static_cast<uint8_t>(address & 0xFF);  // Low address byte
         memcpy(&tx_data[2], data, length);
         
-        hf_i2c_err_t result = i2c_->Write(this->address_, tx_data, length + 2);
-        delete[] tx_data;
+        hf_i2c_err_t result = i2c_->Write(this->address_, tx_data.get(), length + 2);
+        // tx_data automatically cleaned up when going out of scope
         
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
             printf("❌ Page write failed: %s\n", HfI2CErrToString(result));

--- a/docs/api/BaseI2c.md
+++ b/docs/api/BaseI2c.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -34,10 +34,10 @@ The `BaseI2c` class provides a comprehensive I2C bus abstraction that serves as 
 - ⚡ **Clock Stretching** - Automatic handling of clock stretching
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with internal and external I2C controllers
-- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
-### 📊 **Supported Hardware**
+### INFO: **Supported Hardware**
 
 | Implementation | Hardware Type | Speed | Features | Use Cases |
 |----------------|---------------|-------|----------|-----------|
@@ -90,19 +90,19 @@ classDiagram
 
 The I2C system uses comprehensive error codes for robust error handling:
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `I2C_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `I2C_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `I2C_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `I2C_ERR_NOT_INITIALIZED` | 2 | ⚠️ I2C not initialized | Call Initialize() first |
-| `I2C_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ I2C already initialized | Check initialization state |
+| `I2C_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `I2C_ERR_NOT_INITIALIZED` | 2 | WARNING: I2C not initialized | Call Initialize() first |
+| `I2C_ERR_ALREADY_INITIALIZED` | 3 | WARNING: I2C already initialized | Check initialization state |
 | `I2C_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `I2C_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `I2C_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -112,7 +112,7 @@ The I2C system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `I2C_ERR_BUS_BUSY` | 7 | 🔄 Bus busy | Wait for bus availability |
-| `I2C_ERR_BUS_ERROR` | 8 | ❌ Bus error | Check bus wiring and termination |
+| `I2C_ERR_BUS_ERROR` | 8 | ERROR: Bus error | Check bus wiring and termination |
 | `I2C_ERR_BUS_ARBITRATION_LOST` | 9 | 🔄 Arbitration lost | Normal in multi-master systems |
 | `I2C_ERR_BUS_NOT_AVAILABLE` | 10 | 🚫 Bus not available | Check bus configuration |
 | `I2C_ERR_BUS_TIMEOUT` | 11 | ⏰ Bus timeout | Check bus speed and load |
@@ -122,17 +122,17 @@ The I2C system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `I2C_ERR_DEVICE_NOT_FOUND` | 12 | 🔍 Device not found | Check device address and connections |
-| `I2C_ERR_DEVICE_NACK` | 13 | ❌ Device NACK | Check device address and data |
+| `I2C_ERR_DEVICE_NACK` | 13 | ERROR: Device NACK | Check device address and data |
 | `I2C_ERR_DEVICE_NOT_RESPONDING` | 14 | 🔇 Device not responding | Check device power and address |
 | `I2C_ERR_INVALID_ADDRESS` | 15 | 🆔 Invalid device address | Use valid 7-bit address |
 
-### 📊 **Data Error Codes**
+### INFO: **Data Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `I2C_ERR_DATA_TOO_LONG` | 16 | 📏 Data too long | Check data length limits |
-| `I2C_ERR_READ_FAILURE` | 17 | 📖 Read failure | Check device and bus state |
-| `I2C_ERR_WRITE_FAILURE` | 18 | ✍️ Write failure | Check device and bus state |
+| `I2C_ERR_READ_FAILURE` | 17 | READ: Read failure | Check device and bus state |
+| `I2C_ERR_WRITE_FAILURE` | 18 | WRITE: Write failure | Check device and bus state |
 | `I2C_ERR_TIMEOUT` | 19 | ⏰ Operation timeout | Check bus speed and device response |
 
 ### 🌐 **Hardware Error Codes**
@@ -150,7 +150,7 @@ The I2C system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `I2C_ERR_INVALID_CONFIGURATION` | 24 | ⚙️ Invalid configuration | Check configuration parameters |
 | `I2C_ERR_UNSUPPORTED_OPERATION` | 25 | 🚫 Unsupported operation | Check hardware capabilities |
-| `I2C_ERR_INVALID_CLOCK_SPEED` | 26 | 📊 Invalid clock speed | Use supported baud rate |
+| `I2C_ERR_INVALID_CLOCK_SPEED` | 26 | INFO: Invalid clock speed | Use supported baud rate |
 | `I2C_ERR_PIN_CONFIGURATION_ERROR` | 27 | 🔌 Pin configuration error | Check pin assignments |
 
 ---
@@ -434,7 +434,7 @@ virtual hf_i2c_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_i2c_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about I2C operations.
+ * INFO: Retrieves comprehensive statistics about I2C operations.
  */
 virtual hf_i2c_err_t GetStatistics(hf_i2c_statistics_t &statistics) const noexcept;
 
@@ -450,7 +450,7 @@ virtual hf_i2c_err_t GetDiagnostics(hf_i2c_diagnostics_t &diagnostics) const noe
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### 📈 **I2C Statistics Structure**
 
@@ -497,7 +497,7 @@ struct hf_i2c_diagnostics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 🔍 **Device Discovery**
 
@@ -517,7 +517,7 @@ EspI2c i2c(config);
 void discover_devices() {
     // Initialize I2C
     if (!i2c.EnsureInitialized()) {
-        printf("❌ I2C initialization failed\n");
+        printf("ERROR: I2C initialization failed\n");
         return;
     }
     
@@ -528,19 +528,19 @@ void discover_devices() {
     uint8_t count = i2c.ScanBus(devices, 16);
     
     if (count == 0) {
-        printf("❌ No I2C devices found\n");
+        printf("ERROR: No I2C devices found\n");
         return;
     }
     
-    printf("✅ Found %u I2C devices:\n", count);
+    printf("SUCCESS: Found %u I2C devices:\n", count);
     for (uint8_t i = 0; i < count; i++) {
         printf("  Address: 0x%02X\n", devices[i]);
         
         // Check if device is responding
         if (i2c.IsDevicePresent(devices[i])) {
-            printf("    Status: ✅ Responding\n");
+            printf("    Status: SUCCESS: Responding\n");
         } else {
-            printf("    Status: ❌ Not responding\n");
+            printf("    Status: ERROR: Not responding\n");
         }
     }
 }
@@ -611,16 +611,16 @@ void temperature_monitoring() {
     Tmp102Sensor sensor(&i2c, 0x48);
     
     if (!sensor.initialize()) {
-        printf("❌ Sensor initialization failed\n");
+        printf("ERROR: Sensor initialization failed\n");
         return;
     }
     
     if (!sensor.is_present()) {
-        printf("❌ Temperature sensor not found\n");
+        printf("ERROR: Temperature sensor not found\n");
         return;
     }
     
-    printf("✅ Temperature sensor found\n");
+    printf("SUCCESS: Temperature sensor found\n");
     
     // Configure sensor (12-bit resolution, normal mode)
     sensor.set_configuration(0x60A0);
@@ -630,7 +630,7 @@ void temperature_monitoring() {
         if (temperature > -900.0f) {
             printf("🌡️ Temperature: %.2f°C\n", temperature);
         } else {
-            printf("❌ Temperature read failed\n");
+            printf("ERROR: Temperature read failed\n");
         }
         
         vTaskDelay(pdMS_TO_TICKS(1000));
@@ -638,7 +638,7 @@ void temperature_monitoring() {
 }
 ```
 
-### 📊 **EEPROM Access (24LC256)**
+### INFO: **EEPROM Access (24LC256)**
 
 ```cpp
 #include "mcu/esp32/EspI2c.h"
@@ -666,7 +666,7 @@ public:
         
         hf_i2c_err_t result = i2c_->Write(this->address_, tx_data, 3);
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("❌ Write failed: %s\n", HfI2CErrToString(result));
+            printf("ERROR: Write failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -684,7 +684,7 @@ public:
         // Write address, then read data
         hf_i2c_err_t result = i2c_->WriteRead(this->address_, addr_data, 2, &data, 1);
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("❌ Read failed: %s\n", HfI2CErrToString(result));
+            printf("ERROR: Read failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -693,7 +693,7 @@ public:
     
     bool write_page(uint16_t address, const uint8_t* data, uint8_t length) {
         if (length > 64) {  // Page size limit
-            printf("❌ Page size too large\n");
+            printf("ERROR: Page size too large\n");
             return false;
         }
         
@@ -702,13 +702,13 @@ public:
         uint16_t page_end = page_start + 64;
         
         if (address + length > page_end) {
-            printf("❌ Data crosses page boundary\n");
+            printf("ERROR: Data crosses page boundary\n");
             return false;
         }
         
         auto tx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 2);
         if (!tx_data) {
-            printf("❌ Failed to allocate memory for transmit buffer\n");
+            printf("ERROR: Failed to allocate memory for transmit buffer\n");
             return false;
         }
         
@@ -720,7 +720,7 @@ public:
         // tx_data automatically cleaned up when going out of scope
         
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("❌ Page write failed: %s\n", HfI2CErrToString(result));
+            printf("ERROR: Page write failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -738,7 +738,7 @@ public:
         // Write address, then read data
         hf_i2c_err_t result = i2c_->WriteRead(this->address_, addr_data, 2, data, length);
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("❌ Read failed: %s\n", HfI2CErrToString(result));
+            printf("ERROR: Read failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -751,7 +751,7 @@ void eeprom_test() {
     Eeprom24LC256 eeprom(&i2c, 0x50);
     
     if (!eeprom.initialize()) {
-        printf("❌ EEPROM initialization failed\n");
+        printf("ERROR: EEPROM initialization failed\n");
         return;
     }
     
@@ -760,14 +760,14 @@ void eeprom_test() {
     uint16_t write_addr = 0x0000;
     
     if (eeprom.write_page(write_addr, test_data, sizeof(test_data) - 1)) {
-        printf("✅ Data written to EEPROM\n");
+        printf("SUCCESS: Data written to EEPROM\n");
     }
     
     // Read back data
     uint8_t read_data[16];
     if (eeprom.read_bytes(write_addr, read_data, sizeof(test_data) - 1)) {
         read_data[sizeof(test_data) - 1] = '\0';  // Null terminate
-        printf("📖 Read from EEPROM: %s\n", read_data);
+        printf("READ: Read from EEPROM: %s\n", read_data);
     }
 }
 ```
@@ -793,7 +793,7 @@ public:
     
     bool select_channel(uint8_t channel) {
         if (channel > 7) {
-            printf("❌ Invalid channel: %u\n", channel);
+            printf("ERROR: Invalid channel: %u\n", channel);
             return false;
         }
         
@@ -802,10 +802,10 @@ public:
         
         if (result == hf_i2c_err_t::I2C_SUCCESS) {
             current_channel_ = channel;
-            printf("✅ Selected channel %u\n", channel);
+            printf("SUCCESS: Selected channel %u\n", channel);
             return true;
         } else {
-            printf("❌ Channel selection failed: %s\n", HfI2CErrToString(result));
+            printf("ERROR: Channel selection failed: %s\n", HfI2CErrToString(result));
             return false;
         }
     }
@@ -850,7 +850,7 @@ void multiplexer_test() {
     Pca9548Multiplexer mux(&i2c, 0x70);
     
     if (!mux.initialize()) {
-        printf("❌ Multiplexer initialization failed\n");
+        printf("ERROR: Multiplexer initialization failed\n");
         return;
     }
     
@@ -861,7 +861,7 @@ void multiplexer_test() {
     if (mux.select_channel(0)) {
         // Now communicate with device on channel 0
         if (i2c.IsDevicePresent(0x48)) {
-            printf("✅ Device 0x48 found on channel 0\n");
+            printf("SUCCESS: Device 0x48 found on channel 0\n");
         }
     }
 }
@@ -869,25 +869,25 @@ void multiplexer_test() {
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!i2c.EnsureInitialized()) {
-    printf("❌ I2C initialization failed\n");
+    printf("ERROR: I2C initialization failed\n");
     return false;
 }
 
-// ✅ Use appropriate timeouts
+// SUCCESS: Use appropriate timeouts
 i2c.Write(addr, data, length, 1000);  // 1 second timeout for critical operations
 i2c.Read(addr, data, length, 500);    // 500ms timeout for normal reads
 
-// ✅ Handle all error codes
+// SUCCESS: Handle all error codes
 hf_i2c_err_t result = i2c.Write(addr, data, length);
 if (result != hf_i2c_err_t::I2C_SUCCESS) {
-    printf("⚠️ I2C Error: %s\n", HfI2CErrToString(result));
+    printf("WARNING: I2C Error: %s\n", HfI2CErrToString(result));
     // Handle specific error types
     if (result == hf_i2c_err_t::I2C_ERR_DEVICE_NACK) {
         // Device not responding - check address
@@ -896,45 +896,45 @@ if (result != hf_i2c_err_t::I2C_SUCCESS) {
     }
 }
 
-// ✅ Use device presence checks
+// SUCCESS: Use device presence checks
 if (i2c.IsDevicePresent(device_addr)) {
     // Device is available
 } else {
-    printf("❌ Device 0x%02X not found\n", device_addr);
+    printf("ERROR: Device 0x%02X not found\n", device_addr);
 }
 
-// ✅ Use register access methods for convenience
+// SUCCESS: Use register access methods for convenience
 i2c.WriteRegister(addr, reg, value);  // Easier than manual write
 i2c.ReadRegister(addr, reg, value);   // Easier than manual read
 
-// ✅ Monitor bus health
+// SUCCESS: Monitor bus health
 hf_i2c_statistics_t stats;
 if (i2c.GetStatistics(stats) == hf_i2c_err_t::I2C_SUCCESS) {
     if (stats.failed_transactions > 10) {
-        printf("⚠️ High I2C failure rate detected\n");
+        printf("WARNING: High I2C failure rate detected\n");
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 i2c.Write(addr, data, length);  // May fail silently
 
-// ❌ Don't use infinite timeouts in real-time systems
+// ERROR: Don't use infinite timeouts in real-time systems
 i2c.Read(addr, data, length, UINT32_MAX);  // May block forever
 
-// ❌ Don't ignore error codes
+// ERROR: Don't ignore error codes
 i2c.Write(addr, data, length);  // Error handling missing
 
-// ❌ Don't assume device presence
+// ERROR: Don't assume device presence
 // Always check if device responds before communication
 
-// ❌ Don't use without proper pull-up resistors
+// ERROR: Don't use without proper pull-up resistors
 // I2C bus requires external pull-up resistors
 
-// ❌ Don't ignore clock stretching
+// ERROR: Don't ignore clock stretching
 // Some devices stretch the clock during communication
 ```
 
@@ -963,7 +963,7 @@ i2c.WriteRegister(addr, reg, value);  // Optimized for register access
 hf_i2c_statistics_t stats;
 i2c.GetStatistics(stats);
 if (stats.average_response_time_us > 1000) {
-    printf("⚠️ Slow I2C response detected\n");
+    printf("WARNING: Slow I2C response detected\n");
 }
 ```
 

--- a/docs/api/BaseI2c.md
+++ b/docs/api/BaseI2c.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -34,10 +34,10 @@ The `BaseI2c` class provides a comprehensive I2C bus abstraction that serves as 
 - ⚡ **Clock Stretching** - Automatic handling of clock stretching
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with internal and external I2C controllers
-- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
-### INFO: **Supported Hardware**
+### 📊 **Supported Hardware**
 
 | Implementation | Hardware Type | Speed | Features | Use Cases |
 |----------------|---------------|-------|----------|-----------|
@@ -90,19 +90,19 @@ classDiagram
 
 The I2C system uses comprehensive error codes for robust error handling:
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `I2C_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `I2C_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `I2C_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `I2C_ERR_NOT_INITIALIZED` | 2 | WARNING: I2C not initialized | Call Initialize() first |
-| `I2C_ERR_ALREADY_INITIALIZED` | 3 | WARNING: I2C already initialized | Check initialization state |
+| `I2C_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `I2C_ERR_NOT_INITIALIZED` | 2 | ⚠️ I2C not initialized | Call Initialize() first |
+| `I2C_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ I2C already initialized | Check initialization state |
 | `I2C_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `I2C_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `I2C_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -112,7 +112,7 @@ The I2C system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `I2C_ERR_BUS_BUSY` | 7 | 🔄 Bus busy | Wait for bus availability |
-| `I2C_ERR_BUS_ERROR` | 8 | ERROR: Bus error | Check bus wiring and termination |
+| `I2C_ERR_BUS_ERROR` | 8 | ❌ Bus error | Check bus wiring and termination |
 | `I2C_ERR_BUS_ARBITRATION_LOST` | 9 | 🔄 Arbitration lost | Normal in multi-master systems |
 | `I2C_ERR_BUS_NOT_AVAILABLE` | 10 | 🚫 Bus not available | Check bus configuration |
 | `I2C_ERR_BUS_TIMEOUT` | 11 | ⏰ Bus timeout | Check bus speed and load |
@@ -122,17 +122,17 @@ The I2C system uses comprehensive error codes for robust error handling:
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `I2C_ERR_DEVICE_NOT_FOUND` | 12 | 🔍 Device not found | Check device address and connections |
-| `I2C_ERR_DEVICE_NACK` | 13 | ERROR: Device NACK | Check device address and data |
+| `I2C_ERR_DEVICE_NACK` | 13 | ❌ Device NACK | Check device address and data |
 | `I2C_ERR_DEVICE_NOT_RESPONDING` | 14 | 🔇 Device not responding | Check device power and address |
 | `I2C_ERR_INVALID_ADDRESS` | 15 | 🆔 Invalid device address | Use valid 7-bit address |
 
-### INFO: **Data Error Codes**
+### 📊 **Data Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `I2C_ERR_DATA_TOO_LONG` | 16 | 📏 Data too long | Check data length limits |
-| `I2C_ERR_READ_FAILURE` | 17 | READ: Read failure | Check device and bus state |
-| `I2C_ERR_WRITE_FAILURE` | 18 | WRITE: Write failure | Check device and bus state |
+| `I2C_ERR_READ_FAILURE` | 17 | 📖 Read failure | Check device and bus state |
+| `I2C_ERR_WRITE_FAILURE` | 18 | ✍️ Write failure | Check device and bus state |
 | `I2C_ERR_TIMEOUT` | 19 | ⏰ Operation timeout | Check bus speed and device response |
 
 ### 🌐 **Hardware Error Codes**
@@ -150,7 +150,7 @@ The I2C system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `I2C_ERR_INVALID_CONFIGURATION` | 24 | ⚙️ Invalid configuration | Check configuration parameters |
 | `I2C_ERR_UNSUPPORTED_OPERATION` | 25 | 🚫 Unsupported operation | Check hardware capabilities |
-| `I2C_ERR_INVALID_CLOCK_SPEED` | 26 | INFO: Invalid clock speed | Use supported baud rate |
+| `I2C_ERR_INVALID_CLOCK_SPEED` | 26 | 📊 Invalid clock speed | Use supported baud rate |
 | `I2C_ERR_PIN_CONFIGURATION_ERROR` | 27 | 🔌 Pin configuration error | Check pin assignments |
 
 ---
@@ -434,7 +434,7 @@ virtual hf_i2c_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_i2c_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about I2C operations.
+ * 📊 Retrieves comprehensive statistics about I2C operations.
  */
 virtual hf_i2c_err_t GetStatistics(hf_i2c_statistics_t &statistics) const noexcept;
 
@@ -450,7 +450,7 @@ virtual hf_i2c_err_t GetDiagnostics(hf_i2c_diagnostics_t &diagnostics) const noe
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### 📈 **I2C Statistics Structure**
 
@@ -497,7 +497,7 @@ struct hf_i2c_diagnostics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 🔍 **Device Discovery**
 
@@ -517,7 +517,7 @@ EspI2c i2c(config);
 void discover_devices() {
     // Initialize I2C
     if (!i2c.EnsureInitialized()) {
-        printf("ERROR: I2C initialization failed\n");
+        printf("❌ I2C initialization failed\n");
         return;
     }
     
@@ -528,19 +528,19 @@ void discover_devices() {
     uint8_t count = i2c.ScanBus(devices, 16);
     
     if (count == 0) {
-        printf("ERROR: No I2C devices found\n");
+        printf("❌ No I2C devices found\n");
         return;
     }
     
-    printf("SUCCESS: Found %u I2C devices:\n", count);
+    printf("✅ Found %u I2C devices:\n", count);
     for (uint8_t i = 0; i < count; i++) {
         printf("  Address: 0x%02X\n", devices[i]);
         
         // Check if device is responding
         if (i2c.IsDevicePresent(devices[i])) {
-            printf("    Status: SUCCESS: Responding\n");
+            printf("    Status: ✅ Responding\n");
         } else {
-            printf("    Status: ERROR: Not responding\n");
+            printf("    Status: ❌ Not responding\n");
         }
     }
 }
@@ -611,16 +611,16 @@ void temperature_monitoring() {
     Tmp102Sensor sensor(&i2c, 0x48);
     
     if (!sensor.initialize()) {
-        printf("ERROR: Sensor initialization failed\n");
+        printf("❌ Sensor initialization failed\n");
         return;
     }
     
     if (!sensor.is_present()) {
-        printf("ERROR: Temperature sensor not found\n");
+        printf("❌ Temperature sensor not found\n");
         return;
     }
     
-    printf("SUCCESS: Temperature sensor found\n");
+    printf("✅ Temperature sensor found\n");
     
     // Configure sensor (12-bit resolution, normal mode)
     sensor.set_configuration(0x60A0);
@@ -630,7 +630,7 @@ void temperature_monitoring() {
         if (temperature > -900.0f) {
             printf("🌡️ Temperature: %.2f°C\n", temperature);
         } else {
-            printf("ERROR: Temperature read failed\n");
+            printf("❌ Temperature read failed\n");
         }
         
         vTaskDelay(pdMS_TO_TICKS(1000));
@@ -638,7 +638,7 @@ void temperature_monitoring() {
 }
 ```
 
-### INFO: **EEPROM Access (24LC256)**
+### 📊 **EEPROM Access (24LC256)**
 
 ```cpp
 #include "mcu/esp32/EspI2c.h"
@@ -666,7 +666,7 @@ public:
         
         hf_i2c_err_t result = i2c_->Write(this->address_, tx_data, 3);
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("ERROR: Write failed: %s\n", HfI2CErrToString(result));
+            printf("❌ Write failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -684,7 +684,7 @@ public:
         // Write address, then read data
         hf_i2c_err_t result = i2c_->WriteRead(this->address_, addr_data, 2, &data, 1);
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("ERROR: Read failed: %s\n", HfI2CErrToString(result));
+            printf("❌ Read failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -693,7 +693,7 @@ public:
     
     bool write_page(uint16_t address, const uint8_t* data, uint8_t length) {
         if (length > 64) {  // Page size limit
-            printf("ERROR: Page size too large\n");
+            printf("❌ Page size too large\n");
             return false;
         }
         
@@ -702,13 +702,13 @@ public:
         uint16_t page_end = page_start + 64;
         
         if (address + length > page_end) {
-            printf("ERROR: Data crosses page boundary\n");
+            printf("❌ Data crosses page boundary\n");
             return false;
         }
         
         auto tx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 2);
         if (!tx_data) {
-            printf("ERROR: Failed to allocate memory for transmit buffer\n");
+            printf("❌ Failed to allocate memory for transmit buffer\n");
             return false;
         }
         
@@ -720,7 +720,7 @@ public:
         // tx_data automatically cleaned up when going out of scope
         
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("ERROR: Page write failed: %s\n", HfI2CErrToString(result));
+            printf("❌ Page write failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -738,7 +738,7 @@ public:
         // Write address, then read data
         hf_i2c_err_t result = i2c_->WriteRead(this->address_, addr_data, 2, data, length);
         if (result != hf_i2c_err_t::I2C_SUCCESS) {
-            printf("ERROR: Read failed: %s\n", HfI2CErrToString(result));
+            printf("❌ Read failed: %s\n", HfI2CErrToString(result));
             return false;
         }
         
@@ -751,7 +751,7 @@ void eeprom_test() {
     Eeprom24LC256 eeprom(&i2c, 0x50);
     
     if (!eeprom.initialize()) {
-        printf("ERROR: EEPROM initialization failed\n");
+        printf("❌ EEPROM initialization failed\n");
         return;
     }
     
@@ -760,14 +760,14 @@ void eeprom_test() {
     uint16_t write_addr = 0x0000;
     
     if (eeprom.write_page(write_addr, test_data, sizeof(test_data) - 1)) {
-        printf("SUCCESS: Data written to EEPROM\n");
+        printf("✅ Data written to EEPROM\n");
     }
     
     // Read back data
     uint8_t read_data[16];
     if (eeprom.read_bytes(write_addr, read_data, sizeof(test_data) - 1)) {
         read_data[sizeof(test_data) - 1] = '\0';  // Null terminate
-        printf("READ: Read from EEPROM: %s\n", read_data);
+        printf("📖 Read from EEPROM: %s\n", read_data);
     }
 }
 ```
@@ -793,7 +793,7 @@ public:
     
     bool select_channel(uint8_t channel) {
         if (channel > 7) {
-            printf("ERROR: Invalid channel: %u\n", channel);
+            printf("❌ Invalid channel: %u\n", channel);
             return false;
         }
         
@@ -802,10 +802,10 @@ public:
         
         if (result == hf_i2c_err_t::I2C_SUCCESS) {
             current_channel_ = channel;
-            printf("SUCCESS: Selected channel %u\n", channel);
+            printf("✅ Selected channel %u\n", channel);
             return true;
         } else {
-            printf("ERROR: Channel selection failed: %s\n", HfI2CErrToString(result));
+            printf("❌ Channel selection failed: %s\n", HfI2CErrToString(result));
             return false;
         }
     }
@@ -850,7 +850,7 @@ void multiplexer_test() {
     Pca9548Multiplexer mux(&i2c, 0x70);
     
     if (!mux.initialize()) {
-        printf("ERROR: Multiplexer initialization failed\n");
+        printf("❌ Multiplexer initialization failed\n");
         return;
     }
     
@@ -861,7 +861,7 @@ void multiplexer_test() {
     if (mux.select_channel(0)) {
         // Now communicate with device on channel 0
         if (i2c.IsDevicePresent(0x48)) {
-            printf("SUCCESS: Device 0x48 found on channel 0\n");
+            printf("✅ Device 0x48 found on channel 0\n");
         }
     }
 }
@@ -869,25 +869,25 @@ void multiplexer_test() {
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!i2c.EnsureInitialized()) {
-    printf("ERROR: I2C initialization failed\n");
+    printf("❌ I2C initialization failed\n");
     return false;
 }
 
-// SUCCESS: Use appropriate timeouts
+// ✅ Use appropriate timeouts
 i2c.Write(addr, data, length, 1000);  // 1 second timeout for critical operations
 i2c.Read(addr, data, length, 500);    // 500ms timeout for normal reads
 
-// SUCCESS: Handle all error codes
+// ✅ Handle all error codes
 hf_i2c_err_t result = i2c.Write(addr, data, length);
 if (result != hf_i2c_err_t::I2C_SUCCESS) {
-    printf("WARNING: I2C Error: %s\n", HfI2CErrToString(result));
+    printf("⚠️ I2C Error: %s\n", HfI2CErrToString(result));
     // Handle specific error types
     if (result == hf_i2c_err_t::I2C_ERR_DEVICE_NACK) {
         // Device not responding - check address
@@ -896,45 +896,45 @@ if (result != hf_i2c_err_t::I2C_SUCCESS) {
     }
 }
 
-// SUCCESS: Use device presence checks
+// ✅ Use device presence checks
 if (i2c.IsDevicePresent(device_addr)) {
     // Device is available
 } else {
-    printf("ERROR: Device 0x%02X not found\n", device_addr);
+    printf("❌ Device 0x%02X not found\n", device_addr);
 }
 
-// SUCCESS: Use register access methods for convenience
+// ✅ Use register access methods for convenience
 i2c.WriteRegister(addr, reg, value);  // Easier than manual write
 i2c.ReadRegister(addr, reg, value);   // Easier than manual read
 
-// SUCCESS: Monitor bus health
+// ✅ Monitor bus health
 hf_i2c_statistics_t stats;
 if (i2c.GetStatistics(stats) == hf_i2c_err_t::I2C_SUCCESS) {
     if (stats.failed_transactions > 10) {
-        printf("WARNING: High I2C failure rate detected\n");
+        printf("⚠️ High I2C failure rate detected\n");
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 i2c.Write(addr, data, length);  // May fail silently
 
-// ERROR: Don't use infinite timeouts in real-time systems
+// ❌ Don't use infinite timeouts in real-time systems
 i2c.Read(addr, data, length, UINT32_MAX);  // May block forever
 
-// ERROR: Don't ignore error codes
+// ❌ Don't ignore error codes
 i2c.Write(addr, data, length);  // Error handling missing
 
-// ERROR: Don't assume device presence
+// ❌ Don't assume device presence
 // Always check if device responds before communication
 
-// ERROR: Don't use without proper pull-up resistors
+// ❌ Don't use without proper pull-up resistors
 // I2C bus requires external pull-up resistors
 
-// ERROR: Don't ignore clock stretching
+// ❌ Don't ignore clock stretching
 // Some devices stretch the clock during communication
 ```
 
@@ -963,7 +963,7 @@ i2c.WriteRegister(addr, reg, value);  // Optimized for register access
 hf_i2c_statistics_t stats;
 i2c.GetStatistics(stats);
 if (stats.average_response_time_us > 1000) {
-    printf("WARNING: Slow I2C response detected\n");
+    printf("⚠️ Slow I2C response detected\n");
 }
 ```
 

--- a/docs/api/BaseNvs.md
+++ b/docs/api/BaseNvs.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -34,10 +34,10 @@ The `BaseNvs` class provides a comprehensive non-volatile storage abstraction th
 - 🔒 **Atomic Operations** - Safe concurrent access
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with flash, EEPROM, and other storage
-- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
-### 📊 **Supported Hardware**
+### INFO: **Supported Hardware**
 
 | Implementation | Hardware Type | Capacity | Features | Use Cases |
 |----------------|---------------|----------|----------|-----------|
@@ -93,19 +93,19 @@ classDiagram
 
 The NVS system uses comprehensive error codes for robust error handling:
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `NVS_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `NVS_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `NVS_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `NVS_ERR_NOT_INITIALIZED` | 2 | ⚠️ NVS not initialized | Call Initialize() first |
-| `NVS_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ NVS already initialized | Check initialization state |
+| `NVS_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `NVS_ERR_NOT_INITIALIZED` | 2 | WARNING: NVS not initialized | Call Initialize() first |
+| `NVS_ERR_ALREADY_INITIALIZED` | 3 | WARNING: NVS already initialized | Check initialization state |
 | `NVS_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `NVS_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `NVS_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -116,11 +116,11 @@ The NVS system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `NVS_ERR_KEY_NOT_FOUND` | 7 | 🔍 Key not found | Check key name or create key first |
 | `NVS_ERR_KEY_TOO_LONG` | 8 | 📏 Key too long | Use shorter key name |
-| `NVS_ERR_VALUE_TOO_LARGE` | 9 | 📊 Value too large | Check storage capacity |
+| `NVS_ERR_VALUE_TOO_LARGE` | 9 | INFO: Value too large | Check storage capacity |
 | `NVS_ERR_NAMESPACE_NOT_FOUND` | 10 | 🗂️ Namespace not found | Create namespace first |
 | `NVS_ERR_STORAGE_FULL` | 11 | 📦 Storage full | Free space or use larger storage |
-| `NVS_ERR_INVALID_DATA` | 12 | ❌ Invalid data | Check data format |
-| `NVS_ERR_READ_ONLY` | 13 | 📖 Read only mode | Check write permissions |
+| `NVS_ERR_INVALID_DATA` | 12 | ERROR: Invalid data | Check data format |
+| `NVS_ERR_READ_ONLY` | 13 | READ: Read only mode | Check write permissions |
 | `NVS_ERR_CORRUPTED` | 14 | 💥 Data corrupted | Re-initialize storage |
 
 ### 🔐 **Encryption Error Codes**
@@ -138,7 +138,7 @@ The NVS system uses comprehensive error codes for robust error handling:
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `NVS_ERR_VERSION_MISMATCH` | 21 | 📊 Version mismatch | Update storage format |
+| `NVS_ERR_VERSION_MISMATCH` | 21 | INFO: Version mismatch | Update storage format |
 | `NVS_ERR_NO_FREE_PAGES` | 22 | 📄 No free pages | Free space or reinitialize |
 | `NVS_ERR_PARTITION_NOT_FOUND` | 23 | 🗂️ Partition not found | Check partition configuration |
 | `NVS_ERR_ITERATOR_INVALID` | 24 | 🔄 Iterator invalid | Restart iteration |
@@ -225,7 +225,7 @@ virtual hf_nvs_err_t SetU32(const char *key, uint32_t value) noexcept = 0;
  * @param value Reference to store retrieved value
  * @return hf_nvs_err_t error code
  * 
- * 📖 Retrieves a 32-bit unsigned integer value.
+ * READ: Retrieves a 32-bit unsigned integer value.
  * 
  * @example
  * uint32_t boot_count;
@@ -267,7 +267,7 @@ virtual hf_nvs_err_t SetString(const char *key, const char *value) noexcept = 0;
  * @param actual_size Actual size of the string (optional)
  * @return hf_nvs_err_t error code
  * 
- * 📖 Retrieves a string value.
+ * READ: Retrieves a string value.
  * 
  * @example
  * char device_name[32];
@@ -310,7 +310,7 @@ virtual hf_nvs_err_t SetBlob(const char *key, const void *data, size_t data_size
  * @param actual_size Actual size of the data (optional)
  * @return hf_nvs_err_t error code
  * 
- * 📖 Retrieves binary data.
+ * READ: Retrieves binary data.
  * 
  * @example
  * uint8_t config_data[64];
@@ -366,7 +366,7 @@ virtual hf_nvs_err_t EraseAll() noexcept = 0;
  * @param size Reference to store size
  * @return hf_nvs_err_t error code
  * 
- * 📊 Gets the size of a stored value without reading it.
+ * INFO: Gets the size of a stored value without reading it.
  * 
  * @example
  * size_t value_size;
@@ -378,14 +378,14 @@ virtual hf_nvs_err_t EraseAll() noexcept = 0;
 virtual hf_nvs_err_t GetSize(const char *key, size_t &size) noexcept = 0;
 ```
 
-### 📊 **Information Methods**
+### INFO: **Information Methods**
 
 ```cpp
 /**
  * @brief Get maximum key length
  * @return Maximum key length in characters
  * 
- * 📊 Returns the maximum allowed key length for this storage.
+ * INFO: Returns the maximum allowed key length for this storage.
  */
 virtual size_t GetMaxKeyLength() const noexcept = 0;
 
@@ -393,7 +393,7 @@ virtual size_t GetMaxKeyLength() const noexcept = 0;
  * @brief Get maximum value size
  * @return Maximum value size in bytes
  * 
- * 📊 Returns the maximum allowed value size for this storage.
+ * INFO: Returns the maximum allowed value size for this storage.
  */
 virtual size_t GetMaxValueSize() const noexcept = 0;
 ```
@@ -422,7 +422,7 @@ virtual hf_nvs_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_nvs_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about NVS operations.
+ * INFO: Retrieves comprehensive statistics about NVS operations.
  */
 virtual hf_nvs_err_t GetStatistics(hf_nvs_statistics_t &statistics) const noexcept;
 
@@ -438,7 +438,7 @@ virtual hf_nvs_err_t GetDiagnostics(hf_nvs_diagnostics_t &diagnostics) const noe
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### 📈 **NVS Statistics Structure**
 
@@ -472,7 +472,7 @@ struct hf_nvs_diagnostics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 🔧 **Configuration Storage**
 
@@ -494,23 +494,23 @@ public:
         // Store individual values
         hf_nvs_err_t result = config_nvs_.SetU32("device_id", config.device_id);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to save device_id: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to save device_id: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         result = config_nvs_.SetString("device_name", config.device_name.c_str());
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to save device_name: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to save device_name: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         result = config_nvs_.SetU32("baud_rate", config.baud_rate);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to save baud_rate: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to save baud_rate: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("✅ Device configuration saved successfully\n");
+        printf("SUCCESS: Device configuration saved successfully\n");
         return true;
     }
     
@@ -522,9 +522,9 @@ public:
             config.device_id = device_id;
         } else if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             config.device_id = 1;  // Default value
-            printf("⚠️ Using default device_id: %u\n", config.device_id);
+            printf("WARNING: Using default device_id: %u\n", config.device_id);
         } else {
-            printf("❌ Failed to load device_id: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load device_id: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -535,9 +535,9 @@ public:
             config.device_name = std::string(device_name, name_size);
         } else if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             config.device_name = "DefaultDevice";  // Default value
-            printf("⚠️ Using default device_name: %s\n", config.device_name.c_str());
+            printf("WARNING: Using default device_name: %s\n", config.device_name.c_str());
         } else {
-            printf("❌ Failed to load device_name: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load device_name: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -547,18 +547,18 @@ public:
             config.baud_rate = baud_rate;
         } else if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             config.baud_rate = 115200;  // Default value
-            printf("⚠️ Using default baud_rate: %u\n", config.baud_rate);
+            printf("WARNING: Using default baud_rate: %u\n", config.baud_rate);
         } else {
-            printf("❌ Failed to load baud_rate: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load baud_rate: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("✅ Device configuration loaded successfully\n");
+        printf("SUCCESS: Device configuration loaded successfully\n");
         return true;
     }
     
     void print_config_info() {
-        printf("📊 Configuration Storage Info:\n");
+        printf("INFO: Configuration Storage Info:\n");
         printf("  Max key length: %zu characters\n", config_nvs_.GetMaxKeyLength());
         printf("  Max value size: %zu bytes\n", config_nvs_.GetMaxValueSize());
         
@@ -581,7 +581,7 @@ struct DeviceConfig {
 };
 ```
 
-### 📊 **Calibration Data Storage**
+### INFO: **Calibration Data Storage**
 
 ```cpp
 #include "mcu/esp32/EspNvs.h"
@@ -601,7 +601,7 @@ public:
         // Store calibration data as blob
         hf_nvs_err_t result = calib_nvs_.SetBlob("adc_calib", &calib, sizeof(calib));
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to save ADC calibration: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to save ADC calibration: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -609,11 +609,11 @@ public:
         uint32_t timestamp = static_cast<uint32_t>(time(nullptr));
         result = calib_nvs_.SetU32("adc_calib_time", timestamp);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to save calibration timestamp: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to save calibration timestamp: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("✅ ADC calibration saved successfully\n");
+        printf("SUCCESS: ADC calibration saved successfully\n");
         return true;
     }
     
@@ -622,12 +622,12 @@ public:
         size_t calib_size;
         hf_nvs_err_t result = calib_nvs_.GetSize("adc_calib", calib_size);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Calibration not found\n");
+            printf("ERROR: Calibration not found\n");
             return false;
         }
         
         if (calib_size != sizeof(AdcCalibration)) {
-            printf("❌ Calibration size mismatch: expected %zu, got %zu\n", 
+            printf("ERROR: Calibration size mismatch: expected %zu, got %zu\n", 
                    sizeof(AdcCalibration), calib_size);
             return false;
         }
@@ -635,7 +635,7 @@ public:
         // Load calibration data
         result = calib_nvs_.GetBlob("adc_calib", &calib, sizeof(calib));
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to load ADC calibration: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load ADC calibration: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -645,10 +645,10 @@ public:
         if (result == hf_nvs_err_t::NVS_SUCCESS) {
             uint32_t current_time = static_cast<uint32_t>(time(nullptr));
             uint32_t age_days = (current_time - timestamp) / (24 * 3600);
-            printf("✅ ADC calibration loaded (age: %u days)\n", age_days);
+            printf("SUCCESS: ADC calibration loaded (age: %u days)\n", age_days);
             
             if (age_days > 30) {
-                printf("⚠️ Calibration is old (%u days), consider re-calibration\n", age_days);
+                printf("WARNING: Calibration is old (%u days), consider re-calibration\n", age_days);
             }
         }
         
@@ -700,7 +700,7 @@ public:
         if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             log_index_ = 0;  // Start from beginning
         } else if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to load log index: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load log index: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -714,7 +714,7 @@ public:
         // Store log message
         hf_nvs_err_t result = log_nvs_.SetString(key, message);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to store log entry: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to store log entry: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -722,11 +722,11 @@ public:
         log_index_++;
         result = log_nvs_.SetU32("log_index", log_index_);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to update log index: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to update log index: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("✅ Log entry %u stored: %s\n", log_index_ - 1, message);
+        printf("SUCCESS: Log entry %u stored: %s\n", log_index_ - 1, message);
         return true;
     }
     
@@ -791,11 +791,11 @@ public:
         // Enable encryption if supported
         hf_nvs_err_t result = secure_nvs_.SetEncryption(true);
         if (result == hf_nvs_err_t::NVS_SUCCESS) {
-            printf("✅ Encryption enabled\n");
+            printf("SUCCESS: Encryption enabled\n");
         } else if (result == hf_nvs_err_t::NVS_ERR_ENCRYPTION_NOT_SUPPORTED) {
-            printf("⚠️ Encryption not supported on this storage\n");
+            printf("WARNING: Encryption not supported on this storage\n");
         } else {
-            printf("❌ Failed to enable encryption: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to enable encryption: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -806,18 +806,18 @@ public:
         // Store username
         hf_nvs_err_t result = secure_nvs_.SetString("username", username);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to store username: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to store username: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         // Store password
         result = secure_nvs_.SetString("password", password);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to store password: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to store password: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("✅ Credentials stored securely\n");
+        printf("SUCCESS: Credentials stored securely\n");
         return true;
     }
     
@@ -826,18 +826,18 @@ public:
         // Load username
         hf_nvs_err_t result = secure_nvs_.GetString("username", username, username_size);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to load username: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load username: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         // Load password
         result = secure_nvs_.GetString("password", password, password_size);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("❌ Failed to load password: %s\n", HfNvsErrToString(result));
+            printf("ERROR: Failed to load password: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("✅ Credentials loaded successfully\n");
+        printf("SUCCESS: Credentials loaded successfully\n");
         return true;
     }
     
@@ -851,18 +851,18 @@ public:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!nvs.EnsureInitialized()) {
-    printf("❌ NVS initialization failed\n");
+    printf("ERROR: NVS initialization failed\n");
     return false;
 }
 
-// ✅ Use appropriate error handling
+// SUCCESS: Use appropriate error handling
 uint32_t value;
 hf_nvs_err_t result = nvs.GetU32("key", value);
 if (result == hf_nvs_err_t::NVS_SUCCESS) {
@@ -871,63 +871,63 @@ if (result == hf_nvs_err_t::NVS_SUCCESS) {
     // Key doesn't exist, use default
     value = default_value;
 } else {
-    printf("❌ NVS Error: %s\n", HfNvsErrToString(result));
+    printf("ERROR: NVS Error: %s\n", HfNvsErrToString(result));
     return false;
 }
 
-// ✅ Check data sizes before operations
+// SUCCESS: Check data sizes before operations
 size_t required_size;
 if (nvs.GetSize("key", required_size) == hf_nvs_err_t::NVS_SUCCESS) {
     if (required_size > buffer_size) {
-        printf("❌ Buffer too small, need %zu bytes\n", required_size);
+        printf("ERROR: Buffer too small, need %zu bytes\n", required_size);
         return false;
     }
 }
 
-// ✅ Use namespaces for organization
+// SUCCESS: Use namespaces for organization
 EspNvs config_nvs("config");
 EspNvs calib_nvs("calibration");
 EspNvs logs_nvs("logs");
 
-// ✅ Validate data integrity
+// SUCCESS: Validate data integrity
 uint16_t stored_checksum;
 if (nvs.GetU32("checksum", stored_checksum) == hf_nvs_err_t::NVS_SUCCESS) {
     uint16_t calculated_checksum = calculate_checksum(data, size);
     if (stored_checksum != calculated_checksum) {
-        printf("❌ Data integrity check failed\n");
+        printf("ERROR: Data integrity check failed\n");
         return false;
     }
 }
 
-// ✅ Monitor storage health
+// SUCCESS: Monitor storage health
 hf_nvs_statistics_t stats;
 if (nvs.GetStatistics(stats) == hf_nvs_err_t::NVS_SUCCESS) {
     if (stats.failed_ops > 10) {
-        printf("⚠️ High NVS failure rate detected\n");
+        printf("WARNING: High NVS failure rate detected\n");
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 nvs.SetU32("key", value);  // May fail silently
 
-// ❌ Don't ignore error codes
+// ERROR: Don't ignore error codes
 nvs.GetString("key", buffer, size);  // Error handling missing
 
-// ❌ Don't assume key exists
+// ERROR: Don't assume key exists
 uint32_t value = nvs.GetU32("key");  // May return garbage
 
-// ❌ Don't use without checking buffer sizes
+// ERROR: Don't use without checking buffer sizes
 char buffer[16];
 nvs.GetString("key", buffer, sizeof(buffer));  // May truncate
 
-// ❌ Don't store sensitive data unencrypted
+// ERROR: Don't store sensitive data unencrypted
 nvs.SetString("password", "secret");  // Use encrypted storage
 
-// ❌ Don't ignore storage capacity
+// ERROR: Don't ignore storage capacity
 // Check available space before large writes
 ```
 
@@ -951,7 +951,7 @@ nvs.SetString("password", "secret");  // Use encrypted storage
 hf_nvs_statistics_t stats;
 nvs.GetStatistics(stats);
 if (stats.bytes_written > max_storage_bytes) {
-    printf("⚠️ Storage usage high: %u bytes\n", stats.bytes_written);
+    printf("WARNING: Storage usage high: %u bytes\n", stats.bytes_written);
 }
 
 // 🚀 Use encryption for sensitive data

--- a/docs/api/BaseNvs.md
+++ b/docs/api/BaseNvs.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -34,10 +34,10 @@ The `BaseNvs` class provides a comprehensive non-volatile storage abstraction th
 - 🔒 **Atomic Operations** - Safe concurrent access
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with flash, EEPROM, and other storage
-- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
-### INFO: **Supported Hardware**
+### 📊 **Supported Hardware**
 
 | Implementation | Hardware Type | Capacity | Features | Use Cases |
 |----------------|---------------|----------|----------|-----------|
@@ -93,19 +93,19 @@ classDiagram
 
 The NVS system uses comprehensive error codes for robust error handling:
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `NVS_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `NVS_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `NVS_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `NVS_ERR_NOT_INITIALIZED` | 2 | WARNING: NVS not initialized | Call Initialize() first |
-| `NVS_ERR_ALREADY_INITIALIZED` | 3 | WARNING: NVS already initialized | Check initialization state |
+| `NVS_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `NVS_ERR_NOT_INITIALIZED` | 2 | ⚠️ NVS not initialized | Call Initialize() first |
+| `NVS_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ NVS already initialized | Check initialization state |
 | `NVS_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `NVS_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `NVS_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -116,11 +116,11 @@ The NVS system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `NVS_ERR_KEY_NOT_FOUND` | 7 | 🔍 Key not found | Check key name or create key first |
 | `NVS_ERR_KEY_TOO_LONG` | 8 | 📏 Key too long | Use shorter key name |
-| `NVS_ERR_VALUE_TOO_LARGE` | 9 | INFO: Value too large | Check storage capacity |
+| `NVS_ERR_VALUE_TOO_LARGE` | 9 | 📊 Value too large | Check storage capacity |
 | `NVS_ERR_NAMESPACE_NOT_FOUND` | 10 | 🗂️ Namespace not found | Create namespace first |
 | `NVS_ERR_STORAGE_FULL` | 11 | 📦 Storage full | Free space or use larger storage |
-| `NVS_ERR_INVALID_DATA` | 12 | ERROR: Invalid data | Check data format |
-| `NVS_ERR_READ_ONLY` | 13 | READ: Read only mode | Check write permissions |
+| `NVS_ERR_INVALID_DATA` | 12 | ❌ Invalid data | Check data format |
+| `NVS_ERR_READ_ONLY` | 13 | 📖 Read only mode | Check write permissions |
 | `NVS_ERR_CORRUPTED` | 14 | 💥 Data corrupted | Re-initialize storage |
 
 ### 🔐 **Encryption Error Codes**
@@ -138,7 +138,7 @@ The NVS system uses comprehensive error codes for robust error handling:
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `NVS_ERR_VERSION_MISMATCH` | 21 | INFO: Version mismatch | Update storage format |
+| `NVS_ERR_VERSION_MISMATCH` | 21 | 📊 Version mismatch | Update storage format |
 | `NVS_ERR_NO_FREE_PAGES` | 22 | 📄 No free pages | Free space or reinitialize |
 | `NVS_ERR_PARTITION_NOT_FOUND` | 23 | 🗂️ Partition not found | Check partition configuration |
 | `NVS_ERR_ITERATOR_INVALID` | 24 | 🔄 Iterator invalid | Restart iteration |
@@ -225,7 +225,7 @@ virtual hf_nvs_err_t SetU32(const char *key, uint32_t value) noexcept = 0;
  * @param value Reference to store retrieved value
  * @return hf_nvs_err_t error code
  * 
- * READ: Retrieves a 32-bit unsigned integer value.
+ * 📖 Retrieves a 32-bit unsigned integer value.
  * 
  * @example
  * uint32_t boot_count;
@@ -267,7 +267,7 @@ virtual hf_nvs_err_t SetString(const char *key, const char *value) noexcept = 0;
  * @param actual_size Actual size of the string (optional)
  * @return hf_nvs_err_t error code
  * 
- * READ: Retrieves a string value.
+ * 📖 Retrieves a string value.
  * 
  * @example
  * char device_name[32];
@@ -310,7 +310,7 @@ virtual hf_nvs_err_t SetBlob(const char *key, const void *data, size_t data_size
  * @param actual_size Actual size of the data (optional)
  * @return hf_nvs_err_t error code
  * 
- * READ: Retrieves binary data.
+ * 📖 Retrieves binary data.
  * 
  * @example
  * uint8_t config_data[64];
@@ -366,7 +366,7 @@ virtual hf_nvs_err_t EraseAll() noexcept = 0;
  * @param size Reference to store size
  * @return hf_nvs_err_t error code
  * 
- * INFO: Gets the size of a stored value without reading it.
+ * 📊 Gets the size of a stored value without reading it.
  * 
  * @example
  * size_t value_size;
@@ -378,14 +378,14 @@ virtual hf_nvs_err_t EraseAll() noexcept = 0;
 virtual hf_nvs_err_t GetSize(const char *key, size_t &size) noexcept = 0;
 ```
 
-### INFO: **Information Methods**
+### 📊 **Information Methods**
 
 ```cpp
 /**
  * @brief Get maximum key length
  * @return Maximum key length in characters
  * 
- * INFO: Returns the maximum allowed key length for this storage.
+ * 📊 Returns the maximum allowed key length for this storage.
  */
 virtual size_t GetMaxKeyLength() const noexcept = 0;
 
@@ -393,7 +393,7 @@ virtual size_t GetMaxKeyLength() const noexcept = 0;
  * @brief Get maximum value size
  * @return Maximum value size in bytes
  * 
- * INFO: Returns the maximum allowed value size for this storage.
+ * 📊 Returns the maximum allowed value size for this storage.
  */
 virtual size_t GetMaxValueSize() const noexcept = 0;
 ```
@@ -422,7 +422,7 @@ virtual hf_nvs_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_nvs_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about NVS operations.
+ * 📊 Retrieves comprehensive statistics about NVS operations.
  */
 virtual hf_nvs_err_t GetStatistics(hf_nvs_statistics_t &statistics) const noexcept;
 
@@ -438,7 +438,7 @@ virtual hf_nvs_err_t GetDiagnostics(hf_nvs_diagnostics_t &diagnostics) const noe
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### 📈 **NVS Statistics Structure**
 
@@ -472,7 +472,7 @@ struct hf_nvs_diagnostics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 🔧 **Configuration Storage**
 
@@ -494,23 +494,23 @@ public:
         // Store individual values
         hf_nvs_err_t result = config_nvs_.SetU32("device_id", config.device_id);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to save device_id: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to save device_id: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         result = config_nvs_.SetString("device_name", config.device_name.c_str());
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to save device_name: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to save device_name: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         result = config_nvs_.SetU32("baud_rate", config.baud_rate);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to save baud_rate: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to save baud_rate: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Device configuration saved successfully\n");
+        printf("✅ Device configuration saved successfully\n");
         return true;
     }
     
@@ -522,9 +522,9 @@ public:
             config.device_id = device_id;
         } else if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             config.device_id = 1;  // Default value
-            printf("WARNING: Using default device_id: %u\n", config.device_id);
+            printf("⚠️ Using default device_id: %u\n", config.device_id);
         } else {
-            printf("ERROR: Failed to load device_id: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load device_id: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -535,9 +535,9 @@ public:
             config.device_name = std::string(device_name, name_size);
         } else if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             config.device_name = "DefaultDevice";  // Default value
-            printf("WARNING: Using default device_name: %s\n", config.device_name.c_str());
+            printf("⚠️ Using default device_name: %s\n", config.device_name.c_str());
         } else {
-            printf("ERROR: Failed to load device_name: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load device_name: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -547,18 +547,18 @@ public:
             config.baud_rate = baud_rate;
         } else if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             config.baud_rate = 115200;  // Default value
-            printf("WARNING: Using default baud_rate: %u\n", config.baud_rate);
+            printf("⚠️ Using default baud_rate: %u\n", config.baud_rate);
         } else {
-            printf("ERROR: Failed to load baud_rate: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load baud_rate: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Device configuration loaded successfully\n");
+        printf("✅ Device configuration loaded successfully\n");
         return true;
     }
     
     void print_config_info() {
-        printf("INFO: Configuration Storage Info:\n");
+        printf("📊 Configuration Storage Info:\n");
         printf("  Max key length: %zu characters\n", config_nvs_.GetMaxKeyLength());
         printf("  Max value size: %zu bytes\n", config_nvs_.GetMaxValueSize());
         
@@ -581,7 +581,7 @@ struct DeviceConfig {
 };
 ```
 
-### INFO: **Calibration Data Storage**
+### 📊 **Calibration Data Storage**
 
 ```cpp
 #include "mcu/esp32/EspNvs.h"
@@ -601,7 +601,7 @@ public:
         // Store calibration data as blob
         hf_nvs_err_t result = calib_nvs_.SetBlob("adc_calib", &calib, sizeof(calib));
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to save ADC calibration: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to save ADC calibration: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -609,11 +609,11 @@ public:
         uint32_t timestamp = static_cast<uint32_t>(time(nullptr));
         result = calib_nvs_.SetU32("adc_calib_time", timestamp);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to save calibration timestamp: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to save calibration timestamp: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: ADC calibration saved successfully\n");
+        printf("✅ ADC calibration saved successfully\n");
         return true;
     }
     
@@ -622,12 +622,12 @@ public:
         size_t calib_size;
         hf_nvs_err_t result = calib_nvs_.GetSize("adc_calib", calib_size);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Calibration not found\n");
+            printf("❌ Calibration not found\n");
             return false;
         }
         
         if (calib_size != sizeof(AdcCalibration)) {
-            printf("ERROR: Calibration size mismatch: expected %zu, got %zu\n", 
+            printf("❌ Calibration size mismatch: expected %zu, got %zu\n", 
                    sizeof(AdcCalibration), calib_size);
             return false;
         }
@@ -635,7 +635,7 @@ public:
         // Load calibration data
         result = calib_nvs_.GetBlob("adc_calib", &calib, sizeof(calib));
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to load ADC calibration: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load ADC calibration: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -645,10 +645,10 @@ public:
         if (result == hf_nvs_err_t::NVS_SUCCESS) {
             uint32_t current_time = static_cast<uint32_t>(time(nullptr));
             uint32_t age_days = (current_time - timestamp) / (24 * 3600);
-            printf("SUCCESS: ADC calibration loaded (age: %u days)\n", age_days);
+            printf("✅ ADC calibration loaded (age: %u days)\n", age_days);
             
             if (age_days > 30) {
-                printf("WARNING: Calibration is old (%u days), consider re-calibration\n", age_days);
+                printf("⚠️ Calibration is old (%u days), consider re-calibration\n", age_days);
             }
         }
         
@@ -700,7 +700,7 @@ public:
         if (result == hf_nvs_err_t::NVS_ERR_KEY_NOT_FOUND) {
             log_index_ = 0;  // Start from beginning
         } else if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to load log index: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load log index: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -714,7 +714,7 @@ public:
         // Store log message
         hf_nvs_err_t result = log_nvs_.SetString(key, message);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to store log entry: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to store log entry: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -722,11 +722,11 @@ public:
         log_index_++;
         result = log_nvs_.SetU32("log_index", log_index_);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to update log index: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to update log index: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Log entry %u stored: %s\n", log_index_ - 1, message);
+        printf("✅ Log entry %u stored: %s\n", log_index_ - 1, message);
         return true;
     }
     
@@ -791,11 +791,11 @@ public:
         // Enable encryption if supported
         hf_nvs_err_t result = secure_nvs_.SetEncryption(true);
         if (result == hf_nvs_err_t::NVS_SUCCESS) {
-            printf("SUCCESS: Encryption enabled\n");
+            printf("✅ Encryption enabled\n");
         } else if (result == hf_nvs_err_t::NVS_ERR_ENCRYPTION_NOT_SUPPORTED) {
-            printf("WARNING: Encryption not supported on this storage\n");
+            printf("⚠️ Encryption not supported on this storage\n");
         } else {
-            printf("ERROR: Failed to enable encryption: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to enable encryption: %s\n", HfNvsErrToString(result));
             return false;
         }
         
@@ -806,18 +806,18 @@ public:
         // Store username
         hf_nvs_err_t result = secure_nvs_.SetString("username", username);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to store username: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to store username: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         // Store password
         result = secure_nvs_.SetString("password", password);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to store password: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to store password: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Credentials stored securely\n");
+        printf("✅ Credentials stored securely\n");
         return true;
     }
     
@@ -826,18 +826,18 @@ public:
         // Load username
         hf_nvs_err_t result = secure_nvs_.GetString("username", username, username_size);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to load username: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load username: %s\n", HfNvsErrToString(result));
             return false;
         }
         
         // Load password
         result = secure_nvs_.GetString("password", password, password_size);
         if (result != hf_nvs_err_t::NVS_SUCCESS) {
-            printf("ERROR: Failed to load password: %s\n", HfNvsErrToString(result));
+            printf("❌ Failed to load password: %s\n", HfNvsErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Credentials loaded successfully\n");
+        printf("✅ Credentials loaded successfully\n");
         return true;
     }
     
@@ -851,18 +851,18 @@ public:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!nvs.EnsureInitialized()) {
-    printf("ERROR: NVS initialization failed\n");
+    printf("❌ NVS initialization failed\n");
     return false;
 }
 
-// SUCCESS: Use appropriate error handling
+// ✅ Use appropriate error handling
 uint32_t value;
 hf_nvs_err_t result = nvs.GetU32("key", value);
 if (result == hf_nvs_err_t::NVS_SUCCESS) {
@@ -871,63 +871,63 @@ if (result == hf_nvs_err_t::NVS_SUCCESS) {
     // Key doesn't exist, use default
     value = default_value;
 } else {
-    printf("ERROR: NVS Error: %s\n", HfNvsErrToString(result));
+    printf("❌ NVS Error: %s\n", HfNvsErrToString(result));
     return false;
 }
 
-// SUCCESS: Check data sizes before operations
+// ✅ Check data sizes before operations
 size_t required_size;
 if (nvs.GetSize("key", required_size) == hf_nvs_err_t::NVS_SUCCESS) {
     if (required_size > buffer_size) {
-        printf("ERROR: Buffer too small, need %zu bytes\n", required_size);
+        printf("❌ Buffer too small, need %zu bytes\n", required_size);
         return false;
     }
 }
 
-// SUCCESS: Use namespaces for organization
+// ✅ Use namespaces for organization
 EspNvs config_nvs("config");
 EspNvs calib_nvs("calibration");
 EspNvs logs_nvs("logs");
 
-// SUCCESS: Validate data integrity
+// ✅ Validate data integrity
 uint16_t stored_checksum;
 if (nvs.GetU32("checksum", stored_checksum) == hf_nvs_err_t::NVS_SUCCESS) {
     uint16_t calculated_checksum = calculate_checksum(data, size);
     if (stored_checksum != calculated_checksum) {
-        printf("ERROR: Data integrity check failed\n");
+        printf("❌ Data integrity check failed\n");
         return false;
     }
 }
 
-// SUCCESS: Monitor storage health
+// ✅ Monitor storage health
 hf_nvs_statistics_t stats;
 if (nvs.GetStatistics(stats) == hf_nvs_err_t::NVS_SUCCESS) {
     if (stats.failed_ops > 10) {
-        printf("WARNING: High NVS failure rate detected\n");
+        printf("⚠️ High NVS failure rate detected\n");
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 nvs.SetU32("key", value);  // May fail silently
 
-// ERROR: Don't ignore error codes
+// ❌ Don't ignore error codes
 nvs.GetString("key", buffer, size);  // Error handling missing
 
-// ERROR: Don't assume key exists
+// ❌ Don't assume key exists
 uint32_t value = nvs.GetU32("key");  // May return garbage
 
-// ERROR: Don't use without checking buffer sizes
+// ❌ Don't use without checking buffer sizes
 char buffer[16];
 nvs.GetString("key", buffer, sizeof(buffer));  // May truncate
 
-// ERROR: Don't store sensitive data unencrypted
+// ❌ Don't store sensitive data unencrypted
 nvs.SetString("password", "secret");  // Use encrypted storage
 
-// ERROR: Don't ignore storage capacity
+// ❌ Don't ignore storage capacity
 // Check available space before large writes
 ```
 
@@ -951,7 +951,7 @@ nvs.SetString("password", "secret");  // Use encrypted storage
 hf_nvs_statistics_t stats;
 nvs.GetStatistics(stats);
 if (stats.bytes_written > max_storage_bytes) {
-    printf("WARNING: Storage usage high: %u bytes\n", stats.bytes_written);
+    printf("⚠️ Storage usage high: %u bytes\n", stats.bytes_written);
 }
 
 // 🚀 Use encryption for sensitive data

--- a/docs/api/BasePeriodicTimer.md
+++ b/docs/api/BasePeriodicTimer.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -33,11 +33,11 @@ The `BasePeriodicTimer` class provides a comprehensive periodic timer abstractio
 - 🔄 **Dynamic Period Control** - Change period during operation
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with hardware and software timers
-- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 - ⚡ **Low Overhead** - Optimized for real-time applications
 
-### INFO: **Supported Hardware**
+### 📊 **Supported Hardware**
 
 | Implementation | Hardware Type | Resolution | Max Period | Features | Use Cases |
 |----------------|---------------|------------|------------|----------|-----------|
@@ -90,19 +90,19 @@ classDiagram
 
 The timer system uses comprehensive error codes for robust error handling:
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `TIMER_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `TIMER_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `TIMER_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `TIMER_ERR_NOT_INITIALIZED` | 2 | WARNING: Timer not initialized | Call Initialize() first |
-| `TIMER_ERR_ALREADY_INITIALIZED` | 3 | WARNING: Timer already initialized | Check initialization state |
+| `TIMER_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `TIMER_ERR_NOT_INITIALIZED` | 2 | ⚠️ Timer not initialized | Call Initialize() first |
+| `TIMER_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ Timer already initialized | Check initialization state |
 | `TIMER_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `TIMER_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `TIMER_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -113,7 +113,7 @@ The timer system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `TIMER_ERR_ALREADY_RUNNING` | 7 | 🔄 Timer already running | Stop timer first |
 | `TIMER_ERR_NOT_RUNNING` | 8 | ⏸️ Timer not running | Start timer first |
-| `TIMER_ERR_INVALID_PERIOD` | 9 | INFO: Invalid period | Use valid period range |
+| `TIMER_ERR_INVALID_PERIOD` | 9 | 📊 Invalid period | Use valid period range |
 | `TIMER_ERR_RESOURCE_BUSY` | 10 | 🔄 Timer resource busy | Wait or use different timer |
 | `TIMER_ERR_HARDWARE_FAULT` | 11 | 💥 Hardware fault | Check hardware connections |
 | `TIMER_ERR_UNSUPPORTED_OPERATION` | 12 | 🚫 Unsupported operation | Check hardware capabilities |
@@ -216,7 +216,7 @@ virtual hf_timer_err_t SetPeriod(uint64_t period_us) noexcept = 0;
  * @param period_us Reference to store the current period
  * @return hf_timer_err_t error code
  * 
- * INFO: Retrieves the current timer period.
+ * 📊 Retrieves the current timer period.
  * 
  * @example
  * uint64_t current_period;
@@ -252,7 +252,7 @@ hf_timer_err_t SetCallback(hf_timer_callback_t callback, void *user_data = nullp
  * @brief Get current user data pointer
  * @return User data pointer
  * 
- * INFO: Returns the user data associated with the timer callback.
+ * 📊 Returns the user data associated with the timer callback.
  */
 void *GetUserData() const noexcept;
 
@@ -260,12 +260,12 @@ void *GetUserData() const noexcept;
  * @brief Check if timer has a valid callback
  * @return true if callback is set, false otherwise
  * 
- * SUCCESS: Checks if a callback function has been set.
+ * ✅ Checks if a callback function has been set.
  */
 bool HasValidCallback() const noexcept;
 ```
 
-### INFO: **Information Methods**
+### 📊 **Information Methods**
 
 ```cpp
 /**
@@ -280,7 +280,7 @@ virtual const char *GetDescription() const noexcept = 0;
  * @brief Get minimum supported timer period
  * @return Minimum period in microseconds
  * 
- * INFO: Returns the minimum supported timer period for this hardware.
+ * 📊 Returns the minimum supported timer period for this hardware.
  */
 virtual uint64_t GetMinPeriod() const noexcept = 0;
 
@@ -288,7 +288,7 @@ virtual uint64_t GetMinPeriod() const noexcept = 0;
  * @brief Get maximum supported timer period
  * @return Maximum period in microseconds
  * 
- * INFO: Returns the maximum supported timer period for this hardware.
+ * 📊 Returns the maximum supported timer period for this hardware.
  */
 virtual uint64_t GetMaxPeriod() const noexcept = 0;
 
@@ -296,7 +296,7 @@ virtual uint64_t GetMaxPeriod() const noexcept = 0;
  * @brief Get timer resolution
  * @return Timer resolution in microseconds
  * 
- * INFO: Returns the timer resolution (minimum time increment).
+ * 📊 Returns the timer resolution (minimum time increment).
  */
 virtual uint64_t GetResolution() const noexcept = 0;
 ```
@@ -311,7 +311,7 @@ virtual uint64_t GetResolution() const noexcept = 0;
  * @param last_error Last error that occurred
  * @return hf_timer_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about timer operation.
+ * 📊 Retrieves comprehensive statistics about timer operation.
  * 
  * @example
  * uint64_t callback_count, missed_callbacks;
@@ -353,7 +353,7 @@ virtual hf_timer_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_timer_err_t error code
  * 
- * INFO: Retrieves comprehensive statistics about timer operations.
+ * 📊 Retrieves comprehensive statistics about timer operations.
  */
 virtual hf_timer_err_t GetStatistics(hf_timer_statistics_t &statistics) const noexcept;
 
@@ -369,7 +369,7 @@ virtual hf_timer_err_t GetDiagnostics(hf_timer_diagnostics_t &diagnostics) const
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### 📞 **Timer Callback Type**
 
@@ -407,7 +407,7 @@ struct hf_timer_diagnostics_t {
 };
 ```
 
-### INFO: **Timer Stats Structure**
+### 📊 **Timer Stats Structure**
 
 ```cpp
 struct hf_timer_stats_t {
@@ -422,7 +422,7 @@ struct hf_timer_stats_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### ⏰ **Basic Periodic Timer**
 
@@ -446,7 +446,7 @@ void on_timer_tick(void* user_data) {
 void setup_timer() {
     // Initialize timer
     if (timer.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-        printf("ERROR: Timer initialization failed\n");
+        printf("❌ Timer initialization failed\n");
         return;
     }
     
@@ -456,21 +456,21 @@ void setup_timer() {
     // Start timer with 1 second period
     hf_timer_err_t result = timer.Start(1000000);  // 1,000,000 μs = 1 second
     if (result == hf_timer_err_t::TIMER_SUCCESS) {
-        printf("SUCCESS: Timer started successfully\n");
+        printf("✅ Timer started successfully\n");
     } else {
-        printf("ERROR: Timer start failed: %s\n", HfTimerErrToString(result));
+        printf("❌ Timer start failed: %s\n", HfTimerErrToString(result));
     }
 }
 
 void stop_timer() {
     hf_timer_err_t result = timer.Stop();
     if (result == hf_timer_err_t::TIMER_SUCCESS) {
-        printf("SUCCESS: Timer stopped successfully\n");
+        printf("✅ Timer stopped successfully\n");
     }
 }
 
 void print_timer_info() {
-    printf("INFO: Timer Information:\n");
+    printf("📊 Timer Information:\n");
     printf("  Description: %s\n", timer.GetDescription());
     printf("  Min period: %llu μs\n", timer.GetMinPeriod());
     printf("  Max period: %llu μs\n", timer.GetMaxPeriod());
@@ -501,7 +501,7 @@ public:
     bool initialize() {
         // Initialize timer
         if (timer_.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-            printf("ERROR: Control loop timer initialization failed\n");
+            printf("❌ Control loop timer initialization failed\n");
             return false;
         }
         
@@ -518,9 +518,9 @@ public:
         
         hf_timer_err_t result = timer_.Start(period_us);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("SUCCESS: Control loop started at %.1f Hz\n", frequency_hz);
+            printf("✅ Control loop started at %.1f Hz\n", frequency_hz);
         } else {
-            printf("ERROR: Control loop start failed: %s\n", HfTimerErrToString(result));
+            printf("❌ Control loop start failed: %s\n", HfTimerErrToString(result));
         }
     }
     
@@ -581,7 +581,7 @@ void control_loop_example() {
     ControlLoop controller;
     
     if (!controller.initialize()) {
-        printf("ERROR: Controller initialization failed\n");
+        printf("❌ Controller initialization failed\n");
         return;
     }
     
@@ -601,7 +601,7 @@ void control_loop_example() {
 }
 ```
 
-### INFO: **High-Frequency Sampling Timer**
+### 📊 **High-Frequency Sampling Timer**
 
 ```cpp
 #include "mcu/esp32/EspPeriodicTimer.h"
@@ -622,7 +622,7 @@ public:
     
     bool initialize() {
         if (timer_.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-            printf("ERROR: Sampler timer initialization failed\n");
+            printf("❌ Sampler timer initialization failed\n");
             return false;
         }
         
@@ -641,9 +641,9 @@ public:
         
         hf_timer_err_t result = timer_.Start(period_us);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("SUCCESS: Sampling started at %.1f Hz\n", frequency_hz);
+            printf("✅ Sampling started at %.1f Hz\n", frequency_hz);
         } else {
-            printf("ERROR: Sampling start failed: %s\n", HfTimerErrToString(result));
+            printf("❌ Sampling start failed: %s\n", HfTimerErrToString(result));
         }
     }
     
@@ -659,7 +659,7 @@ public:
     
     void print_statistics() {
         if (samples_.empty()) {
-            printf("ERROR: No samples collected\n");
+            printf("❌ No samples collected\n");
             return;
         }
         
@@ -675,7 +675,7 @@ public:
         
         float average = sum / samples_.size();
         
-        printf("INFO: Sampling Statistics:\n");
+        printf("📊 Sampling Statistics:\n");
         printf("  Samples collected: %zu\n", samples_.size());
         printf("  Average: %.3f\n", average);
         printf("  Min: %.3f\n", min_val);
@@ -716,7 +716,7 @@ void sampling_example() {
     HighFrequencySampler sampler(1000);
     
     if (!sampler.initialize()) {
-        printf("ERROR: Sampler initialization failed\n");
+        printf("❌ Sampler initialization failed\n");
         return;
     }
     
@@ -767,7 +767,7 @@ public:
     void start() {
         hf_timer_err_t result = timer_.Start(current_period_);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("SUCCESS: Adaptive timer started with period %llu μs\n", current_period_);
+            printf("✅ Adaptive timer started with period %llu μs\n", current_period_);
         }
     }
     
@@ -841,7 +841,7 @@ void adaptive_timer_example() {
     AdaptiveTimer timer(1000, 100000);  // 1ms to 100ms range
     
     if (!timer.initialize()) {
-        printf("ERROR: Adaptive timer initialization failed\n");
+        printf("❌ Adaptive timer initialization failed\n");
         return;
     }
     
@@ -866,26 +866,26 @@ void adaptive_timer_example() {
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (timer.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-    printf("ERROR: Timer initialization failed\n");
+    printf("❌ Timer initialization failed\n");
     return false;
 }
 
-// SUCCESS: Use appropriate period ranges
+// ✅ Use appropriate period ranges
 uint64_t min_period = timer.GetMinPeriod();
 uint64_t max_period = timer.GetMaxPeriod();
 uint64_t period = std::clamp(desired_period, min_period, max_period);
 
-// SUCCESS: Handle all error codes
+// ✅ Handle all error codes
 hf_timer_err_t result = timer.Start(period);
 if (result != hf_timer_err_t::TIMER_SUCCESS) {
-    printf("WARNING: Timer Error: %s\n", HfTimerErrToString(result));
+    printf("⚠️ Timer Error: %s\n", HfTimerErrToString(result));
     // Handle specific error types
     if (result == hf_timer_err_t::TIMER_ERR_INVALID_PERIOD) {
         // Period out of range
@@ -894,49 +894,49 @@ if (result != hf_timer_err_t::TIMER_SUCCESS) {
     }
 }
 
-// SUCCESS: Set callback before starting timer
+// ✅ Set callback before starting timer
 timer.SetCallback(on_timer_tick, user_data);
 timer.Start(period);
 
-// SUCCESS: Keep callbacks short and efficient
+// ✅ Keep callbacks short and efficient
 void on_timer_tick(void* user_data) {
     // Quick operations only
     // Avoid blocking operations
     // Use queues for longer tasks
 }
 
-// SUCCESS: Monitor timer statistics
+// ✅ Monitor timer statistics
 uint64_t callback_count, missed_callbacks;
 hf_timer_err_t last_error;
 if (timer.GetStats(callback_count, missed_callbacks, last_error) == hf_timer_err_t::TIMER_SUCCESS) {
     if (missed_callbacks > 0) {
-        printf("WARNING: Missed callbacks detected: %llu\n", missed_callbacks);
+        printf("⚠️ Missed callbacks detected: %llu\n", missed_callbacks);
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 timer.Start(period);  // May fail silently
 
-// ERROR: Don't use periods outside valid range
+// ❌ Don't use periods outside valid range
 timer.Start(0);  // Invalid period
 
-// ERROR: Don't ignore error codes
+// ❌ Don't ignore error codes
 timer.Start(period);  // Error handling missing
 
-// ERROR: Don't perform blocking operations in callbacks
+// ❌ Don't perform blocking operations in callbacks
 void on_timer_tick(void* user_data) {
-    vTaskDelay(100);  // ERROR: Blocking in callback
+    vTaskDelay(100);  // ❌ Blocking in callback
     // Use queues instead
 }
 
-// ERROR: Don't start timer without callback
+// ❌ Don't start timer without callback
 timer.Start(period);  // No callback set
 
-// ERROR: Don't forget to stop timer
+// ❌ Don't forget to stop timer
 // Always stop timer when done
 ```
 

--- a/docs/api/BasePeriodicTimer.md
+++ b/docs/api/BasePeriodicTimer.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -33,11 +33,11 @@ The `BasePeriodicTimer` class provides a comprehensive periodic timer abstractio
 - 🔄 **Dynamic Period Control** - Change period during operation
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🔌 **Platform Agnostic** - Works with hardware and software timers
-- 📊 **Statistics & Diagnostics** - Built-in monitoring and health reporting
+- INFO: **Statistics & Diagnostics** - Built-in monitoring and health reporting
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 - ⚡ **Low Overhead** - Optimized for real-time applications
 
-### 📊 **Supported Hardware**
+### INFO: **Supported Hardware**
 
 | Implementation | Hardware Type | Resolution | Max Period | Features | Use Cases |
 |----------------|---------------|------------|------------|----------|-----------|
@@ -90,19 +90,19 @@ classDiagram
 
 The timer system uses comprehensive error codes for robust error handling:
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `TIMER_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `TIMER_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `TIMER_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `TIMER_ERR_NOT_INITIALIZED` | 2 | ⚠️ Timer not initialized | Call Initialize() first |
-| `TIMER_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ Timer already initialized | Check initialization state |
+| `TIMER_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `TIMER_ERR_NOT_INITIALIZED` | 2 | WARNING: Timer not initialized | Call Initialize() first |
+| `TIMER_ERR_ALREADY_INITIALIZED` | 3 | WARNING: Timer already initialized | Check initialization state |
 | `TIMER_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `TIMER_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `TIMER_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -113,7 +113,7 @@ The timer system uses comprehensive error codes for robust error handling:
 |------|-------|-------------|------------|
 | `TIMER_ERR_ALREADY_RUNNING` | 7 | 🔄 Timer already running | Stop timer first |
 | `TIMER_ERR_NOT_RUNNING` | 8 | ⏸️ Timer not running | Start timer first |
-| `TIMER_ERR_INVALID_PERIOD` | 9 | 📊 Invalid period | Use valid period range |
+| `TIMER_ERR_INVALID_PERIOD` | 9 | INFO: Invalid period | Use valid period range |
 | `TIMER_ERR_RESOURCE_BUSY` | 10 | 🔄 Timer resource busy | Wait or use different timer |
 | `TIMER_ERR_HARDWARE_FAULT` | 11 | 💥 Hardware fault | Check hardware connections |
 | `TIMER_ERR_UNSUPPORTED_OPERATION` | 12 | 🚫 Unsupported operation | Check hardware capabilities |
@@ -216,7 +216,7 @@ virtual hf_timer_err_t SetPeriod(uint64_t period_us) noexcept = 0;
  * @param period_us Reference to store the current period
  * @return hf_timer_err_t error code
  * 
- * 📊 Retrieves the current timer period.
+ * INFO: Retrieves the current timer period.
  * 
  * @example
  * uint64_t current_period;
@@ -252,7 +252,7 @@ hf_timer_err_t SetCallback(hf_timer_callback_t callback, void *user_data = nullp
  * @brief Get current user data pointer
  * @return User data pointer
  * 
- * 📊 Returns the user data associated with the timer callback.
+ * INFO: Returns the user data associated with the timer callback.
  */
 void *GetUserData() const noexcept;
 
@@ -260,12 +260,12 @@ void *GetUserData() const noexcept;
  * @brief Check if timer has a valid callback
  * @return true if callback is set, false otherwise
  * 
- * ✅ Checks if a callback function has been set.
+ * SUCCESS: Checks if a callback function has been set.
  */
 bool HasValidCallback() const noexcept;
 ```
 
-### 📊 **Information Methods**
+### INFO: **Information Methods**
 
 ```cpp
 /**
@@ -280,7 +280,7 @@ virtual const char *GetDescription() const noexcept = 0;
  * @brief Get minimum supported timer period
  * @return Minimum period in microseconds
  * 
- * 📊 Returns the minimum supported timer period for this hardware.
+ * INFO: Returns the minimum supported timer period for this hardware.
  */
 virtual uint64_t GetMinPeriod() const noexcept = 0;
 
@@ -288,7 +288,7 @@ virtual uint64_t GetMinPeriod() const noexcept = 0;
  * @brief Get maximum supported timer period
  * @return Maximum period in microseconds
  * 
- * 📊 Returns the maximum supported timer period for this hardware.
+ * INFO: Returns the maximum supported timer period for this hardware.
  */
 virtual uint64_t GetMaxPeriod() const noexcept = 0;
 
@@ -296,7 +296,7 @@ virtual uint64_t GetMaxPeriod() const noexcept = 0;
  * @brief Get timer resolution
  * @return Timer resolution in microseconds
  * 
- * 📊 Returns the timer resolution (minimum time increment).
+ * INFO: Returns the timer resolution (minimum time increment).
  */
 virtual uint64_t GetResolution() const noexcept = 0;
 ```
@@ -311,7 +311,7 @@ virtual uint64_t GetResolution() const noexcept = 0;
  * @param last_error Last error that occurred
  * @return hf_timer_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about timer operation.
+ * INFO: Retrieves comprehensive statistics about timer operation.
  * 
  * @example
  * uint64_t callback_count, missed_callbacks;
@@ -353,7 +353,7 @@ virtual hf_timer_err_t ResetDiagnostics() noexcept;
  * @param statistics Reference to store statistics data
  * @return hf_timer_err_t error code
  * 
- * 📊 Retrieves comprehensive statistics about timer operations.
+ * INFO: Retrieves comprehensive statistics about timer operations.
  */
 virtual hf_timer_err_t GetStatistics(hf_timer_statistics_t &statistics) const noexcept;
 
@@ -369,7 +369,7 @@ virtual hf_timer_err_t GetDiagnostics(hf_timer_diagnostics_t &diagnostics) const
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### 📞 **Timer Callback Type**
 
@@ -407,7 +407,7 @@ struct hf_timer_diagnostics_t {
 };
 ```
 
-### 📊 **Timer Stats Structure**
+### INFO: **Timer Stats Structure**
 
 ```cpp
 struct hf_timer_stats_t {
@@ -422,7 +422,7 @@ struct hf_timer_stats_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### ⏰ **Basic Periodic Timer**
 
@@ -446,7 +446,7 @@ void on_timer_tick(void* user_data) {
 void setup_timer() {
     // Initialize timer
     if (timer.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-        printf("❌ Timer initialization failed\n");
+        printf("ERROR: Timer initialization failed\n");
         return;
     }
     
@@ -456,21 +456,21 @@ void setup_timer() {
     // Start timer with 1 second period
     hf_timer_err_t result = timer.Start(1000000);  // 1,000,000 μs = 1 second
     if (result == hf_timer_err_t::TIMER_SUCCESS) {
-        printf("✅ Timer started successfully\n");
+        printf("SUCCESS: Timer started successfully\n");
     } else {
-        printf("❌ Timer start failed: %s\n", HfTimerErrToString(result));
+        printf("ERROR: Timer start failed: %s\n", HfTimerErrToString(result));
     }
 }
 
 void stop_timer() {
     hf_timer_err_t result = timer.Stop();
     if (result == hf_timer_err_t::TIMER_SUCCESS) {
-        printf("✅ Timer stopped successfully\n");
+        printf("SUCCESS: Timer stopped successfully\n");
     }
 }
 
 void print_timer_info() {
-    printf("📊 Timer Information:\n");
+    printf("INFO: Timer Information:\n");
     printf("  Description: %s\n", timer.GetDescription());
     printf("  Min period: %llu μs\n", timer.GetMinPeriod());
     printf("  Max period: %llu μs\n", timer.GetMaxPeriod());
@@ -501,7 +501,7 @@ public:
     bool initialize() {
         // Initialize timer
         if (timer_.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-            printf("❌ Control loop timer initialization failed\n");
+            printf("ERROR: Control loop timer initialization failed\n");
             return false;
         }
         
@@ -518,9 +518,9 @@ public:
         
         hf_timer_err_t result = timer_.Start(period_us);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("✅ Control loop started at %.1f Hz\n", frequency_hz);
+            printf("SUCCESS: Control loop started at %.1f Hz\n", frequency_hz);
         } else {
-            printf("❌ Control loop start failed: %s\n", HfTimerErrToString(result));
+            printf("ERROR: Control loop start failed: %s\n", HfTimerErrToString(result));
         }
     }
     
@@ -581,7 +581,7 @@ void control_loop_example() {
     ControlLoop controller;
     
     if (!controller.initialize()) {
-        printf("❌ Controller initialization failed\n");
+        printf("ERROR: Controller initialization failed\n");
         return;
     }
     
@@ -601,7 +601,7 @@ void control_loop_example() {
 }
 ```
 
-### 📊 **High-Frequency Sampling Timer**
+### INFO: **High-Frequency Sampling Timer**
 
 ```cpp
 #include "mcu/esp32/EspPeriodicTimer.h"
@@ -622,7 +622,7 @@ public:
     
     bool initialize() {
         if (timer_.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-            printf("❌ Sampler timer initialization failed\n");
+            printf("ERROR: Sampler timer initialization failed\n");
             return false;
         }
         
@@ -641,9 +641,9 @@ public:
         
         hf_timer_err_t result = timer_.Start(period_us);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("✅ Sampling started at %.1f Hz\n", frequency_hz);
+            printf("SUCCESS: Sampling started at %.1f Hz\n", frequency_hz);
         } else {
-            printf("❌ Sampling start failed: %s\n", HfTimerErrToString(result));
+            printf("ERROR: Sampling start failed: %s\n", HfTimerErrToString(result));
         }
     }
     
@@ -659,7 +659,7 @@ public:
     
     void print_statistics() {
         if (samples_.empty()) {
-            printf("❌ No samples collected\n");
+            printf("ERROR: No samples collected\n");
             return;
         }
         
@@ -675,7 +675,7 @@ public:
         
         float average = sum / samples_.size();
         
-        printf("📊 Sampling Statistics:\n");
+        printf("INFO: Sampling Statistics:\n");
         printf("  Samples collected: %zu\n", samples_.size());
         printf("  Average: %.3f\n", average);
         printf("  Min: %.3f\n", min_val);
@@ -716,7 +716,7 @@ void sampling_example() {
     HighFrequencySampler sampler(1000);
     
     if (!sampler.initialize()) {
-        printf("❌ Sampler initialization failed\n");
+        printf("ERROR: Sampler initialization failed\n");
         return;
     }
     
@@ -767,7 +767,7 @@ public:
     void start() {
         hf_timer_err_t result = timer_.Start(current_period_);
         if (result == hf_timer_err_t::TIMER_SUCCESS) {
-            printf("✅ Adaptive timer started with period %llu μs\n", current_period_);
+            printf("SUCCESS: Adaptive timer started with period %llu μs\n", current_period_);
         }
     }
     
@@ -841,7 +841,7 @@ void adaptive_timer_example() {
     AdaptiveTimer timer(1000, 100000);  // 1ms to 100ms range
     
     if (!timer.initialize()) {
-        printf("❌ Adaptive timer initialization failed\n");
+        printf("ERROR: Adaptive timer initialization failed\n");
         return;
     }
     
@@ -866,26 +866,26 @@ void adaptive_timer_example() {
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (timer.Initialize() != hf_timer_err_t::TIMER_SUCCESS) {
-    printf("❌ Timer initialization failed\n");
+    printf("ERROR: Timer initialization failed\n");
     return false;
 }
 
-// ✅ Use appropriate period ranges
+// SUCCESS: Use appropriate period ranges
 uint64_t min_period = timer.GetMinPeriod();
 uint64_t max_period = timer.GetMaxPeriod();
 uint64_t period = std::clamp(desired_period, min_period, max_period);
 
-// ✅ Handle all error codes
+// SUCCESS: Handle all error codes
 hf_timer_err_t result = timer.Start(period);
 if (result != hf_timer_err_t::TIMER_SUCCESS) {
-    printf("⚠️ Timer Error: %s\n", HfTimerErrToString(result));
+    printf("WARNING: Timer Error: %s\n", HfTimerErrToString(result));
     // Handle specific error types
     if (result == hf_timer_err_t::TIMER_ERR_INVALID_PERIOD) {
         // Period out of range
@@ -894,49 +894,49 @@ if (result != hf_timer_err_t::TIMER_SUCCESS) {
     }
 }
 
-// ✅ Set callback before starting timer
+// SUCCESS: Set callback before starting timer
 timer.SetCallback(on_timer_tick, user_data);
 timer.Start(period);
 
-// ✅ Keep callbacks short and efficient
+// SUCCESS: Keep callbacks short and efficient
 void on_timer_tick(void* user_data) {
     // Quick operations only
     // Avoid blocking operations
     // Use queues for longer tasks
 }
 
-// ✅ Monitor timer statistics
+// SUCCESS: Monitor timer statistics
 uint64_t callback_count, missed_callbacks;
 hf_timer_err_t last_error;
 if (timer.GetStats(callback_count, missed_callbacks, last_error) == hf_timer_err_t::TIMER_SUCCESS) {
     if (missed_callbacks > 0) {
-        printf("⚠️ Missed callbacks detected: %llu\n", missed_callbacks);
+        printf("WARNING: Missed callbacks detected: %llu\n", missed_callbacks);
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 timer.Start(period);  // May fail silently
 
-// ❌ Don't use periods outside valid range
+// ERROR: Don't use periods outside valid range
 timer.Start(0);  // Invalid period
 
-// ❌ Don't ignore error codes
+// ERROR: Don't ignore error codes
 timer.Start(period);  // Error handling missing
 
-// ❌ Don't perform blocking operations in callbacks
+// ERROR: Don't perform blocking operations in callbacks
 void on_timer_tick(void* user_data) {
-    vTaskDelay(100);  // ❌ Blocking in callback
+    vTaskDelay(100);  // ERROR: Blocking in callback
     // Use queues instead
 }
 
-// ❌ Don't start timer without callback
+// ERROR: Don't start timer without callback
 timer.Start(period);  // No callback set
 
-// ❌ Don't forget to stop timer
+// ERROR: Don't forget to stop timer
 // Always stop timer when done
 ```
 

--- a/docs/api/BasePio.md
+++ b/docs/api/BasePio.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -29,7 +29,7 @@ The `BasePio` class provides a comprehensive abstraction for Programmable IO ope
 ### ✨ **Key Features**
 
 - ⚡ **Precise Timing** - Nanosecond resolution timing control
-- 📊 **Buffered Operations** - Efficient symbol transmission and reception
+- INFO: **Buffered Operations** - Efficient symbol transmission and reception
 - 🔄 **Asynchronous Operation** - Non-blocking with callback support
 - 🎯 **Multi-Channel Support** - Simultaneous operation on multiple channels
 - 🔧 **Flexible Configuration** - Configurable polarity, idle states, and timing
@@ -82,19 +82,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `PIO_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `PIO_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `PIO_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `PIO_ERR_NOT_INITIALIZED` | 2 | ⚠️ PIO not initialized | Call Initialize() first |
-| `PIO_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ PIO already initialized | Check initialization state |
+| `PIO_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `PIO_ERR_NOT_INITIALIZED` | 2 | WARNING: PIO not initialized | Call Initialize() first |
+| `PIO_ERR_ALREADY_INITIALIZED` | 3 | WARNING: PIO already initialized | Check initialization state |
 | `PIO_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `PIO_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `PIO_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -105,8 +105,8 @@ classDiagram
 |------|-------|-------------|------------|
 | `PIO_ERR_INVALID_CHANNEL` | 7 | 🚫 Invalid PIO channel | Use valid channel numbers |
 | `PIO_ERR_CHANNEL_BUSY` | 8 | 🔄 Channel already in use | Wait or use different channel |
-| `PIO_ERR_CHANNEL_NOT_AVAILABLE` | 9 | ⚠️ Channel not available | Check channel availability |
-| `PIO_ERR_INSUFFICIENT_CHANNELS` | 10 | 📊 Insufficient channels | Reduce channel count |
+| `PIO_ERR_CHANNEL_NOT_AVAILABLE` | 9 | WARNING: Channel not available | Check channel availability |
+| `PIO_ERR_INSUFFICIENT_CHANNELS` | 10 | INFO: Insufficient channels | Reduce channel count |
 
 ### ⏱️ **Timing Error Codes**
 
@@ -118,7 +118,7 @@ classDiagram
 | `PIO_ERR_DURATION_TOO_LONG` | 14 | ⏰ Duration too long | Reduce duration |
 | `PIO_ERR_DURATION_TOO_SHORT` | 15 | ⚡ Duration too short | Increase duration |
 
-### 📊 **Buffer Error Codes**
+### INFO: **Buffer Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
@@ -287,7 +287,7 @@ virtual hf_pio_err_t StartReceive(uint8_t channel_id, hf_pio_symbol_t *buffer,
 virtual hf_pio_err_t StopReceive(uint8_t channel_id, size_t &symbols_received) noexcept = 0;
 ```
 
-### 📊 **Status and Capabilities**
+### INFO: **Status and Capabilities**
 
 ```cpp
 /**
@@ -305,7 +305,7 @@ virtual bool IsChannelBusy(uint8_t channel_id) const noexcept = 0;
  * @param status [out] Status information structure
  * @return hf_pio_err_t error code
  * 
- * 📊 Retrieves comprehensive status information about a channel.
+ * INFO: Retrieves comprehensive status information about a channel.
  */
 virtual hf_pio_err_t GetChannelStatus(uint8_t channel_id,
                                     hf_pio_channel_status_t &status) const noexcept = 0;
@@ -363,7 +363,7 @@ virtual void ClearCallbacks() noexcept = 0;
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### ⚙️ **Channel Configuration**
 
@@ -388,7 +388,7 @@ struct hf_pio_symbol_t {
 };
 ```
 
-### 📊 **Channel Status**
+### INFO: **Channel Status**
 
 ```cpp
 struct hf_pio_channel_status_t {
@@ -440,7 +440,7 @@ struct hf_pio_statistics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 🎨 **WS2812 LED Control**
 
@@ -745,45 +745,45 @@ private:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!pio.EnsureInitialized()) {
-    printf("❌ PIO initialization failed\n");
+    printf("ERROR: PIO initialization failed\n");
     return false;
 }
 
-// ✅ Validate channel configuration
+// SUCCESS: Validate channel configuration
 hf_pio_capabilities_t caps;
 if (pio.GetCapabilities(caps) == hf_pio_err_t::PIO_SUCCESS) {
     if (channel_id >= caps.max_channels) {
-        printf("❌ Channel %u exceeds maximum (%u)\n", channel_id, caps.max_channels);
+        printf("ERROR: Channel %u exceeds maximum (%u)\n", channel_id, caps.max_channels);
         return;
     }
 }
 
-// ✅ Use appropriate timing resolution
+// SUCCESS: Use appropriate timing resolution
 uint32_t resolution_ns = 1000;  // 1μs for most applications
 if (high_precision_needed) {
     resolution_ns = 100;  // 100ns for precise timing
 }
 
-// ✅ Handle transmission errors gracefully
+// SUCCESS: Handle transmission errors gracefully
 hf_pio_err_t result = pio.Transmit(channel_id, symbols, count);
 if (result != hf_pio_err_t::PIO_SUCCESS) {
-    printf("⚠️ Transmission error: %s\n", HfPioErrToString(result));
+    printf("WARNING: Transmission error: %s\n", HfPioErrToString(result));
     // Implement retry logic or error recovery
 }
 
-// ✅ Use callbacks for asynchronous operation
+// SUCCESS: Use callbacks for asynchronous operation
 pio.SetTransmitCallback([](uint8_t ch, size_t sent, void* data) {
-    printf("✅ Transmitted %zu symbols on channel %u\n", sent, ch);
+    printf("SUCCESS: Transmitted %zu symbols on channel %u\n", sent, ch);
 });
 
-// ✅ Monitor channel status
+// SUCCESS: Monitor channel status
 hf_pio_channel_status_t status;
 if (pio.GetChannelStatus(channel_id, status) == hf_pio_err_t::PIO_SUCCESS) {
     if (status.is_busy) {
@@ -792,26 +792,26 @@ if (pio.GetChannelStatus(channel_id, status) == hf_pio_err_t::PIO_SUCCESS) {
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore timing requirements
+// ERROR: Don't ignore timing requirements
 // WS2812 requires precise 350ns/700ns timing
 hf_pio_symbol_t wrong_timing[] = {
     {4, true},   // 400ns - too long!
     {8, false}   // 800ns - too long!
 };
 
-// ❌ Don't use invalid channel numbers
+// ERROR: Don't use invalid channel numbers
 pio.ConfigureChannel(99, config);  // Invalid channel
 
-// ❌ Don't ignore buffer size limits
+// ERROR: Don't ignore buffer size limits
 hf_pio_symbol_t huge_buffer[10000];  // May exceed hardware limits
 
-// ❌ Don't assume all protocols work the same
+// ERROR: Don't assume all protocols work the same
 // Different IR protocols have different timing requirements
 
-// ❌ Don't forget to stop reception
+// ERROR: Don't forget to stop reception
 pio.StartReceive(0, buffer, 64);
 // Missing: pio.StopReceive(0, count);
 ```

--- a/docs/api/BasePio.md
+++ b/docs/api/BasePio.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -29,7 +29,7 @@ The `BasePio` class provides a comprehensive abstraction for Programmable IO ope
 ### ✨ **Key Features**
 
 - ⚡ **Precise Timing** - Nanosecond resolution timing control
-- INFO: **Buffered Operations** - Efficient symbol transmission and reception
+- 📊 **Buffered Operations** - Efficient symbol transmission and reception
 - 🔄 **Asynchronous Operation** - Non-blocking with callback support
 - 🎯 **Multi-Channel Support** - Simultaneous operation on multiple channels
 - 🔧 **Flexible Configuration** - Configurable polarity, idle states, and timing
@@ -82,19 +82,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `PIO_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `PIO_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `PIO_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `PIO_ERR_NOT_INITIALIZED` | 2 | WARNING: PIO not initialized | Call Initialize() first |
-| `PIO_ERR_ALREADY_INITIALIZED` | 3 | WARNING: PIO already initialized | Check initialization state |
+| `PIO_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `PIO_ERR_NOT_INITIALIZED` | 2 | ⚠️ PIO not initialized | Call Initialize() first |
+| `PIO_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ PIO already initialized | Check initialization state |
 | `PIO_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `PIO_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `PIO_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -105,8 +105,8 @@ classDiagram
 |------|-------|-------------|------------|
 | `PIO_ERR_INVALID_CHANNEL` | 7 | 🚫 Invalid PIO channel | Use valid channel numbers |
 | `PIO_ERR_CHANNEL_BUSY` | 8 | 🔄 Channel already in use | Wait or use different channel |
-| `PIO_ERR_CHANNEL_NOT_AVAILABLE` | 9 | WARNING: Channel not available | Check channel availability |
-| `PIO_ERR_INSUFFICIENT_CHANNELS` | 10 | INFO: Insufficient channels | Reduce channel count |
+| `PIO_ERR_CHANNEL_NOT_AVAILABLE` | 9 | ⚠️ Channel not available | Check channel availability |
+| `PIO_ERR_INSUFFICIENT_CHANNELS` | 10 | 📊 Insufficient channels | Reduce channel count |
 
 ### ⏱️ **Timing Error Codes**
 
@@ -118,7 +118,7 @@ classDiagram
 | `PIO_ERR_DURATION_TOO_LONG` | 14 | ⏰ Duration too long | Reduce duration |
 | `PIO_ERR_DURATION_TOO_SHORT` | 15 | ⚡ Duration too short | Increase duration |
 
-### INFO: **Buffer Error Codes**
+### 📊 **Buffer Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
@@ -287,7 +287,7 @@ virtual hf_pio_err_t StartReceive(uint8_t channel_id, hf_pio_symbol_t *buffer,
 virtual hf_pio_err_t StopReceive(uint8_t channel_id, size_t &symbols_received) noexcept = 0;
 ```
 
-### INFO: **Status and Capabilities**
+### 📊 **Status and Capabilities**
 
 ```cpp
 /**
@@ -305,7 +305,7 @@ virtual bool IsChannelBusy(uint8_t channel_id) const noexcept = 0;
  * @param status [out] Status information structure
  * @return hf_pio_err_t error code
  * 
- * INFO: Retrieves comprehensive status information about a channel.
+ * 📊 Retrieves comprehensive status information about a channel.
  */
 virtual hf_pio_err_t GetChannelStatus(uint8_t channel_id,
                                     hf_pio_channel_status_t &status) const noexcept = 0;
@@ -363,7 +363,7 @@ virtual void ClearCallbacks() noexcept = 0;
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### ⚙️ **Channel Configuration**
 
@@ -388,7 +388,7 @@ struct hf_pio_symbol_t {
 };
 ```
 
-### INFO: **Channel Status**
+### 📊 **Channel Status**
 
 ```cpp
 struct hf_pio_channel_status_t {
@@ -440,7 +440,7 @@ struct hf_pio_statistics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 🎨 **WS2812 LED Control**
 
@@ -745,45 +745,45 @@ private:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!pio.EnsureInitialized()) {
-    printf("ERROR: PIO initialization failed\n");
+    printf("❌ PIO initialization failed\n");
     return false;
 }
 
-// SUCCESS: Validate channel configuration
+// ✅ Validate channel configuration
 hf_pio_capabilities_t caps;
 if (pio.GetCapabilities(caps) == hf_pio_err_t::PIO_SUCCESS) {
     if (channel_id >= caps.max_channels) {
-        printf("ERROR: Channel %u exceeds maximum (%u)\n", channel_id, caps.max_channels);
+        printf("❌ Channel %u exceeds maximum (%u)\n", channel_id, caps.max_channels);
         return;
     }
 }
 
-// SUCCESS: Use appropriate timing resolution
+// ✅ Use appropriate timing resolution
 uint32_t resolution_ns = 1000;  // 1μs for most applications
 if (high_precision_needed) {
     resolution_ns = 100;  // 100ns for precise timing
 }
 
-// SUCCESS: Handle transmission errors gracefully
+// ✅ Handle transmission errors gracefully
 hf_pio_err_t result = pio.Transmit(channel_id, symbols, count);
 if (result != hf_pio_err_t::PIO_SUCCESS) {
-    printf("WARNING: Transmission error: %s\n", HfPioErrToString(result));
+    printf("⚠️ Transmission error: %s\n", HfPioErrToString(result));
     // Implement retry logic or error recovery
 }
 
-// SUCCESS: Use callbacks for asynchronous operation
+// ✅ Use callbacks for asynchronous operation
 pio.SetTransmitCallback([](uint8_t ch, size_t sent, void* data) {
-    printf("SUCCESS: Transmitted %zu symbols on channel %u\n", sent, ch);
+    printf("✅ Transmitted %zu symbols on channel %u\n", sent, ch);
 });
 
-// SUCCESS: Monitor channel status
+// ✅ Monitor channel status
 hf_pio_channel_status_t status;
 if (pio.GetChannelStatus(channel_id, status) == hf_pio_err_t::PIO_SUCCESS) {
     if (status.is_busy) {
@@ -792,26 +792,26 @@ if (pio.GetChannelStatus(channel_id, status) == hf_pio_err_t::PIO_SUCCESS) {
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore timing requirements
+// ❌ Don't ignore timing requirements
 // WS2812 requires precise 350ns/700ns timing
 hf_pio_symbol_t wrong_timing[] = {
     {4, true},   // 400ns - too long!
     {8, false}   // 800ns - too long!
 };
 
-// ERROR: Don't use invalid channel numbers
+// ❌ Don't use invalid channel numbers
 pio.ConfigureChannel(99, config);  // Invalid channel
 
-// ERROR: Don't ignore buffer size limits
+// ❌ Don't ignore buffer size limits
 hf_pio_symbol_t huge_buffer[10000];  // May exceed hardware limits
 
-// ERROR: Don't assume all protocols work the same
+// ❌ Don't assume all protocols work the same
 // Different IR protocols have different timing requirements
 
-// ERROR: Don't forget to stop reception
+// ❌ Don't forget to stop reception
 pio.StartReceive(0, buffer, 64);
 // Missing: pio.StopReceive(0, count);
 ```

--- a/docs/api/BasePwm.md
+++ b/docs/api/BasePwm.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -30,7 +30,7 @@ The `BasePwm` class provides a comprehensive PWM abstraction that serves as the 
 
 - 🎛️ **Multi-Channel Support** - Simultaneous operation on multiple PWM channels
 - ⚡ **Precise Frequency Control** - Configurable frequency from Hz to MHz
-- INFO: **Duty Cycle Control** - 0-100% duty cycle with high resolution
+- 📊 **Duty Cycle Control** - 0-100% duty cycle with high resolution
 - 🔄 **Phase Control** - Configurable phase relationships between channels
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🏎️ **Performance Optimized** - Hardware-accelerated PWM generation
@@ -80,19 +80,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `PWM_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `PWM_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `PWM_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `PWM_ERR_NOT_INITIALIZED` | 2 | WARNING: PWM not initialized | Call Initialize() first |
-| `PWM_ERR_ALREADY_INITIALIZED` | 3 | WARNING: PWM already initialized | Check initialization state |
+| `PWM_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `PWM_ERR_NOT_INITIALIZED` | 2 | ⚠️ PWM not initialized | Call Initialize() first |
+| `PWM_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ PWM already initialized | Check initialization state |
 | `PWM_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `PWM_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `PWM_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -103,7 +103,7 @@ classDiagram
 |------|-------|-------------|------------|
 | `PWM_ERR_INVALID_CHANNEL` | 7 | 🚫 Invalid PWM channel | Use valid channel numbers |
 | `PWM_ERR_CHANNEL_BUSY` | 8 | 🔄 Channel already in use | Wait or use different channel |
-| `PWM_ERR_CHANNEL_NOT_AVAILABLE` | 9 | WARNING: Channel not available | Check channel availability |
+| `PWM_ERR_CHANNEL_NOT_AVAILABLE` | 9 | ⚠️ Channel not available | Check channel availability |
 | `PWM_ERR_CHANNEL_NOT_CONFIGURED` | 10 | ⚙️ Channel not configured | Configure channel first |
 | `PWM_ERR_CHANNEL_ALREADY_RUNNING` | 11 | 🔄 Channel already running | Stop channel first |
 
@@ -116,7 +116,7 @@ classDiagram
 | `PWM_ERR_INVALID_FREQUENCY` | 14 | 🚫 Invalid frequency | Use valid frequency range |
 | `PWM_ERR_FREQUENCY_NOT_SUPPORTED` | 15 | 🚫 Frequency not supported | Check hardware capabilities |
 
-### INFO: **Duty Cycle Error Codes**
+### 📊 **Duty Cycle Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
@@ -232,7 +232,7 @@ virtual hf_pwm_err_t ConfigureChannel(uint8_t channel_id,
  * // Set 20 kHz for motor control
  * hf_pwm_err_t result = pwm.SetFrequency(0, 20000);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("SUCCESS: Frequency set to 20 kHz\n");
+ *     printf("✅ Frequency set to 20 kHz\n");
  * }
  */
 virtual hf_pwm_err_t SetFrequency(uint8_t channel_id, float frequency_hz) noexcept = 0;
@@ -243,12 +243,12 @@ virtual hf_pwm_err_t SetFrequency(uint8_t channel_id, float frequency_hz) noexce
  * @param frequency_hz [out] Current frequency in Hz
  * @return hf_pwm_err_t error code
  * 
- * INFO: Retrieves the current frequency setting for a channel.
+ * 📊 Retrieves the current frequency setting for a channel.
  */
 virtual hf_pwm_err_t GetFrequency(uint8_t channel_id, float &frequency_hz) const noexcept = 0;
 ```
 
-### INFO: **Duty Cycle Control**
+### 📊 **Duty Cycle Control**
 
 ```cpp
 /**
@@ -257,14 +257,14 @@ virtual hf_pwm_err_t GetFrequency(uint8_t channel_id, float &frequency_hz) const
  * @param duty_cycle_percent Duty cycle as percentage (0-100)
  * @return hf_pwm_err_t error code
  * 
- * INFO: Sets the PWM duty cycle for the specified channel.
+ * 📊 Sets the PWM duty cycle for the specified channel.
  * Duty cycle range is 0-100%.
  * 
  * @example
  * // Set 75% duty cycle
  * hf_pwm_err_t result = pwm.SetDutyCycle(0, 75.0f);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("SUCCESS: Duty cycle set to 75%%\n");
+ *     printf("✅ Duty cycle set to 75%%\n");
  * }
  */
 virtual hf_pwm_err_t SetDutyCycle(uint8_t channel_id, float duty_cycle_percent) noexcept = 0;
@@ -275,7 +275,7 @@ virtual hf_pwm_err_t SetDutyCycle(uint8_t channel_id, float duty_cycle_percent) 
  * @param duty_cycle_percent [out] Current duty cycle as percentage
  * @return hf_pwm_err_t error code
  * 
- * INFO: Retrieves the current duty cycle setting for a channel.
+ * 📊 Retrieves the current duty cycle setting for a channel.
  */
 virtual hf_pwm_err_t GetDutyCycle(uint8_t channel_id, float &duty_cycle_percent) const noexcept = 0;
 ```
@@ -296,7 +296,7 @@ virtual hf_pwm_err_t GetDutyCycle(uint8_t channel_id, float &duty_cycle_percent)
  * // Set 180° phase shift
  * hf_pwm_err_t result = pwm.SetPhase(0, 180.0f);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("SUCCESS: Phase set to 180°\n");
+ *     printf("✅ Phase set to 180°\n");
  * }
  */
 virtual hf_pwm_err_t SetPhase(uint8_t channel_id, float phase_degrees) noexcept = 0;
@@ -326,7 +326,7 @@ virtual hf_pwm_err_t GetPhase(uint8_t channel_id, float &phase_degrees) const no
  * @example
  * hf_pwm_err_t result = pwm.StartChannel(0);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("SUCCESS: PWM channel 0 started\n");
+ *     printf("✅ PWM channel 0 started\n");
  * }
  */
 virtual hf_pwm_err_t StartChannel(uint8_t channel_id) noexcept = 0;
@@ -350,7 +350,7 @@ virtual hf_pwm_err_t StopChannel(uint8_t channel_id) noexcept = 0;
 virtual bool IsChannelRunning(uint8_t channel_id) const noexcept = 0;
 ```
 
-### INFO: **Status and Capabilities**
+### 📊 **Status and Capabilities**
 
 ```cpp
 /**
@@ -359,7 +359,7 @@ virtual bool IsChannelRunning(uint8_t channel_id) const noexcept = 0;
  * @param status [out] Status information structure
  * @return hf_pwm_err_t error code
  * 
- * INFO: Retrieves comprehensive status information about a channel.
+ * 📊 Retrieves comprehensive status information about a channel.
  */
 virtual hf_pwm_err_t GetChannelStatus(uint8_t channel_id,
                                     hf_pwm_channel_status_t &status) const noexcept = 0;
@@ -376,7 +376,7 @@ virtual hf_pwm_err_t GetCapabilities(hf_pwm_capabilities_t &capabilities) const 
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### ⚙️ **Channel Configuration**
 
@@ -391,7 +391,7 @@ struct hf_pwm_channel_config_t {
 };
 ```
 
-### INFO: **Channel Status**
+### 📊 **Channel Status**
 
 ```cpp
 struct hf_pwm_channel_status_t {
@@ -438,7 +438,7 @@ struct hf_pwm_statistics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 🎛️ **Basic PWM Control**
 
@@ -455,7 +455,7 @@ public:
         pwm_ = EspPwm(LEDC_TIMER_0, LEDC_CHANNEL_0);
         
         if (!pwm_.EnsureInitialized()) {
-            printf("ERROR: PWM initialization failed\n");
+            printf("❌ PWM initialization failed\n");
             return false;
         }
         
@@ -470,47 +470,47 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: Channel configuration failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Channel configuration failed: %s\n", HfPwmErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: PWM initialized successfully\n");
+        printf("✅ PWM initialized successfully\n");
         return true;
     }
     
     void set_duty_cycle(float duty_cycle) {
         hf_pwm_err_t result = pwm_.SetDutyCycle(0, duty_cycle);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("SUCCESS: Duty cycle set to %.1f%%\n", duty_cycle);
+            printf("✅ Duty cycle set to %.1f%%\n", duty_cycle);
         } else {
-            printf("ERROR: Duty cycle set failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Duty cycle set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
     void set_frequency(float frequency_hz) {
         hf_pwm_err_t result = pwm_.SetFrequency(0, frequency_hz);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("SUCCESS: Frequency set to %.1f Hz\n", frequency_hz);
+            printf("✅ Frequency set to %.1f Hz\n", frequency_hz);
         } else {
-            printf("ERROR: Frequency set failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Frequency set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
     void start() {
         hf_pwm_err_t result = pwm_.StartChannel(0);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("SUCCESS: PWM started\n");
+            printf("✅ PWM started\n");
         } else {
-            printf("ERROR: PWM start failed: %s\n", HfPwmErrToString(result));
+            printf("❌ PWM start failed: %s\n", HfPwmErrToString(result));
         }
     }
     
     void stop() {
         hf_pwm_err_t result = pwm_.StopChannel(0);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("SUCCESS: PWM stopped\n");
+            printf("✅ PWM stopped\n");
         } else {
-            printf("ERROR: PWM stop failed: %s\n", HfPwmErrToString(result));
+            printf("❌ PWM stop failed: %s\n", HfPwmErrToString(result));
         }
     }
 };
@@ -548,18 +548,18 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: Motor PWM configuration failed\n");
+            printf("❌ Motor PWM configuration failed\n");
             return false;
         }
         
         // Start PWM output
         result = pwm_.StartChannel(0);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: Motor PWM start failed\n");
+            printf("❌ Motor PWM start failed\n");
             return false;
         }
         
-        printf("SUCCESS: Motor controller initialized\n");
+        printf("✅ Motor controller initialized\n");
         return true;
     }
     
@@ -571,7 +571,7 @@ public:
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
             printf("🚗 Motor speed: %.1f%%\n", speed_percent);
         } else {
-            printf("ERROR: Speed set failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Speed set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
@@ -583,7 +583,7 @@ public:
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
             printf("⚡ Motor frequency: %.1f Hz\n", frequency_hz);
         } else {
-            printf("ERROR: Frequency set failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Frequency set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
@@ -618,7 +618,7 @@ public:
 };
 ```
 
-### INFO: **LED Dimming Control**
+### 📊 **LED Dimming Control**
 
 ```cpp
 #include "mcu/esp32/EspPwm.h"
@@ -647,18 +647,18 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: LED PWM configuration failed\n");
+            printf("❌ LED PWM configuration failed\n");
             return false;
         }
         
         // Start PWM output
         result = pwm_.StartChannel(0);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: LED PWM start failed\n");
+            printf("❌ LED PWM start failed\n");
             return false;
         }
         
-        printf("SUCCESS: LED controller initialized\n");
+        printf("✅ LED controller initialized\n");
         return true;
     }
     
@@ -668,9 +668,9 @@ public:
         
         hf_pwm_err_t result = pwm_.SetDutyCycle(0, brightness_percent);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("INFO: LED brightness: %.1f%%\n", brightness_percent);
+            printf("📊 LED brightness: %.1f%%\n", brightness_percent);
         } else {
-            printf("ERROR: Brightness set failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Brightness set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
@@ -739,11 +739,11 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: Audio PWM configuration failed\n");
+            printf("❌ Audio PWM configuration failed\n");
             return false;
         }
         
-        printf("SUCCESS: Audio generator initialized\n");
+        printf("✅ Audio generator initialized\n");
         return true;
     }
     
@@ -751,14 +751,14 @@ public:
         // Set frequency for the note
         hf_pwm_err_t result = pwm_.SetFrequency(0, frequency_hz);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: Frequency set failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Frequency set failed: %s\n", HfPwmErrToString(result));
             return;
         }
         
         // Start playing
         result = pwm_.StartChannel(0);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("ERROR: Audio start failed: %s\n", HfPwmErrToString(result));
+            printf("❌ Audio start failed: %s\n", HfPwmErrToString(result));
             return;
         }
         
@@ -811,76 +811,76 @@ public:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!pwm.EnsureInitialized()) {
-    printf("ERROR: PWM initialization failed\n");
+    printf("❌ PWM initialization failed\n");
     return false;
 }
 
-// SUCCESS: Validate parameters before setting
+// ✅ Validate parameters before setting
 float frequency = 20000;  // 20 kHz
 if (frequency < 1000 || frequency > 50000) {
-    printf("ERROR: Frequency out of range\n");
+    printf("❌ Frequency out of range\n");
     return;
 }
 
-// SUCCESS: Handle configuration errors gracefully
+// ✅ Handle configuration errors gracefully
 hf_pwm_err_t result = pwm.ConfigureChannel(channel_id, config);
 if (result != hf_pwm_err_t::PWM_SUCCESS) {
-    printf("WARNING: Configuration error: %s\n", HfPwmErrToString(result));
+    printf("⚠️ Configuration error: %s\n", HfPwmErrToString(result));
     // Implement error recovery or fallback
 }
 
-// SUCCESS: Check channel status before operations
+// ✅ Check channel status before operations
 hf_pwm_channel_status_t status;
 if (pwm.GetChannelStatus(channel_id, status) == hf_pwm_err_t::PWM_SUCCESS) {
     if (!status.is_configured) {
-        printf("WARNING: Channel not configured\n");
+        printf("⚠️ Channel not configured\n");
         return;
     }
 }
 
-// SUCCESS: Use appropriate frequency ranges
+// ✅ Use appropriate frequency ranges
 // Motor control: 1-50 kHz
 // LED dimming: 100 Hz-1 kHz
 // Audio: 20 Hz-20 kHz
 
-// SUCCESS: Monitor statistics for system health
+// ✅ Monitor statistics for system health
 hf_pwm_statistics_t stats;
 if (pwm.GetStatistics(stats) == hf_pwm_err_t::PWM_SUCCESS) {
     if (stats.runtime_errors > 10) {
-        printf("WARNING: High PWM error rate detected\n");
+        printf("⚠️ High PWM error rate detected\n");
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 pwm.SetDutyCycle(0, 50);  // May fail silently
 
-// ERROR: Don't use invalid frequency ranges
+// ❌ Don't use invalid frequency ranges
 pwm.SetFrequency(0, 0.1f);    // Too low
 pwm.SetFrequency(0, 1000000); // Too high
 
-// ERROR: Don't use invalid duty cycles
+// ❌ Don't use invalid duty cycles
 pwm.SetDutyCycle(0, -10);  // Negative duty cycle
 pwm.SetDutyCycle(0, 150);  // Over 100%
 
-// ERROR: Don't assume all channels are available
+// ❌ Don't assume all channels are available
 pwm.ConfigureChannel(99, config);  // Invalid channel
 
-// ERROR: Don't forget to stop channels when done
+// ❌ Don't forget to stop channels when done
 pwm.StartChannel(0);
 // Missing: pwm.StopChannel(0);
 
-// ERROR: Don't use without error checking in critical applications
+// ❌ Don't use without error checking in critical applications
 // Always check return values in safety-critical systems
 ```
 

--- a/docs/api/BasePwm.md
+++ b/docs/api/BasePwm.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -30,7 +30,7 @@ The `BasePwm` class provides a comprehensive PWM abstraction that serves as the 
 
 - 🎛️ **Multi-Channel Support** - Simultaneous operation on multiple PWM channels
 - ⚡ **Precise Frequency Control** - Configurable frequency from Hz to MHz
-- 📊 **Duty Cycle Control** - 0-100% duty cycle with high resolution
+- INFO: **Duty Cycle Control** - 0-100% duty cycle with high resolution
 - 🔄 **Phase Control** - Configurable phase relationships between channels
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🏎️ **Performance Optimized** - Hardware-accelerated PWM generation
@@ -80,19 +80,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `PWM_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `PWM_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `PWM_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `PWM_ERR_NOT_INITIALIZED` | 2 | ⚠️ PWM not initialized | Call Initialize() first |
-| `PWM_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ PWM already initialized | Check initialization state |
+| `PWM_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `PWM_ERR_NOT_INITIALIZED` | 2 | WARNING: PWM not initialized | Call Initialize() first |
+| `PWM_ERR_ALREADY_INITIALIZED` | 3 | WARNING: PWM already initialized | Check initialization state |
 | `PWM_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `PWM_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `PWM_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -103,7 +103,7 @@ classDiagram
 |------|-------|-------------|------------|
 | `PWM_ERR_INVALID_CHANNEL` | 7 | 🚫 Invalid PWM channel | Use valid channel numbers |
 | `PWM_ERR_CHANNEL_BUSY` | 8 | 🔄 Channel already in use | Wait or use different channel |
-| `PWM_ERR_CHANNEL_NOT_AVAILABLE` | 9 | ⚠️ Channel not available | Check channel availability |
+| `PWM_ERR_CHANNEL_NOT_AVAILABLE` | 9 | WARNING: Channel not available | Check channel availability |
 | `PWM_ERR_CHANNEL_NOT_CONFIGURED` | 10 | ⚙️ Channel not configured | Configure channel first |
 | `PWM_ERR_CHANNEL_ALREADY_RUNNING` | 11 | 🔄 Channel already running | Stop channel first |
 
@@ -116,7 +116,7 @@ classDiagram
 | `PWM_ERR_INVALID_FREQUENCY` | 14 | 🚫 Invalid frequency | Use valid frequency range |
 | `PWM_ERR_FREQUENCY_NOT_SUPPORTED` | 15 | 🚫 Frequency not supported | Check hardware capabilities |
 
-### 📊 **Duty Cycle Error Codes**
+### INFO: **Duty Cycle Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
@@ -232,7 +232,7 @@ virtual hf_pwm_err_t ConfigureChannel(uint8_t channel_id,
  * // Set 20 kHz for motor control
  * hf_pwm_err_t result = pwm.SetFrequency(0, 20000);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("✅ Frequency set to 20 kHz\n");
+ *     printf("SUCCESS: Frequency set to 20 kHz\n");
  * }
  */
 virtual hf_pwm_err_t SetFrequency(uint8_t channel_id, float frequency_hz) noexcept = 0;
@@ -243,12 +243,12 @@ virtual hf_pwm_err_t SetFrequency(uint8_t channel_id, float frequency_hz) noexce
  * @param frequency_hz [out] Current frequency in Hz
  * @return hf_pwm_err_t error code
  * 
- * 📊 Retrieves the current frequency setting for a channel.
+ * INFO: Retrieves the current frequency setting for a channel.
  */
 virtual hf_pwm_err_t GetFrequency(uint8_t channel_id, float &frequency_hz) const noexcept = 0;
 ```
 
-### 📊 **Duty Cycle Control**
+### INFO: **Duty Cycle Control**
 
 ```cpp
 /**
@@ -257,14 +257,14 @@ virtual hf_pwm_err_t GetFrequency(uint8_t channel_id, float &frequency_hz) const
  * @param duty_cycle_percent Duty cycle as percentage (0-100)
  * @return hf_pwm_err_t error code
  * 
- * 📊 Sets the PWM duty cycle for the specified channel.
+ * INFO: Sets the PWM duty cycle for the specified channel.
  * Duty cycle range is 0-100%.
  * 
  * @example
  * // Set 75% duty cycle
  * hf_pwm_err_t result = pwm.SetDutyCycle(0, 75.0f);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("✅ Duty cycle set to 75%%\n");
+ *     printf("SUCCESS: Duty cycle set to 75%%\n");
  * }
  */
 virtual hf_pwm_err_t SetDutyCycle(uint8_t channel_id, float duty_cycle_percent) noexcept = 0;
@@ -275,7 +275,7 @@ virtual hf_pwm_err_t SetDutyCycle(uint8_t channel_id, float duty_cycle_percent) 
  * @param duty_cycle_percent [out] Current duty cycle as percentage
  * @return hf_pwm_err_t error code
  * 
- * 📊 Retrieves the current duty cycle setting for a channel.
+ * INFO: Retrieves the current duty cycle setting for a channel.
  */
 virtual hf_pwm_err_t GetDutyCycle(uint8_t channel_id, float &duty_cycle_percent) const noexcept = 0;
 ```
@@ -296,7 +296,7 @@ virtual hf_pwm_err_t GetDutyCycle(uint8_t channel_id, float &duty_cycle_percent)
  * // Set 180° phase shift
  * hf_pwm_err_t result = pwm.SetPhase(0, 180.0f);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("✅ Phase set to 180°\n");
+ *     printf("SUCCESS: Phase set to 180°\n");
  * }
  */
 virtual hf_pwm_err_t SetPhase(uint8_t channel_id, float phase_degrees) noexcept = 0;
@@ -326,7 +326,7 @@ virtual hf_pwm_err_t GetPhase(uint8_t channel_id, float &phase_degrees) const no
  * @example
  * hf_pwm_err_t result = pwm.StartChannel(0);
  * if (result == hf_pwm_err_t::PWM_SUCCESS) {
- *     printf("✅ PWM channel 0 started\n");
+ *     printf("SUCCESS: PWM channel 0 started\n");
  * }
  */
 virtual hf_pwm_err_t StartChannel(uint8_t channel_id) noexcept = 0;
@@ -350,7 +350,7 @@ virtual hf_pwm_err_t StopChannel(uint8_t channel_id) noexcept = 0;
 virtual bool IsChannelRunning(uint8_t channel_id) const noexcept = 0;
 ```
 
-### 📊 **Status and Capabilities**
+### INFO: **Status and Capabilities**
 
 ```cpp
 /**
@@ -359,7 +359,7 @@ virtual bool IsChannelRunning(uint8_t channel_id) const noexcept = 0;
  * @param status [out] Status information structure
  * @return hf_pwm_err_t error code
  * 
- * 📊 Retrieves comprehensive status information about a channel.
+ * INFO: Retrieves comprehensive status information about a channel.
  */
 virtual hf_pwm_err_t GetChannelStatus(uint8_t channel_id,
                                     hf_pwm_channel_status_t &status) const noexcept = 0;
@@ -376,7 +376,7 @@ virtual hf_pwm_err_t GetCapabilities(hf_pwm_capabilities_t &capabilities) const 
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### ⚙️ **Channel Configuration**
 
@@ -391,7 +391,7 @@ struct hf_pwm_channel_config_t {
 };
 ```
 
-### 📊 **Channel Status**
+### INFO: **Channel Status**
 
 ```cpp
 struct hf_pwm_channel_status_t {
@@ -438,7 +438,7 @@ struct hf_pwm_statistics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 🎛️ **Basic PWM Control**
 
@@ -455,7 +455,7 @@ public:
         pwm_ = EspPwm(LEDC_TIMER_0, LEDC_CHANNEL_0);
         
         if (!pwm_.EnsureInitialized()) {
-            printf("❌ PWM initialization failed\n");
+            printf("ERROR: PWM initialization failed\n");
             return false;
         }
         
@@ -470,47 +470,47 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ Channel configuration failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Channel configuration failed: %s\n", HfPwmErrToString(result));
             return false;
         }
         
-        printf("✅ PWM initialized successfully\n");
+        printf("SUCCESS: PWM initialized successfully\n");
         return true;
     }
     
     void set_duty_cycle(float duty_cycle) {
         hf_pwm_err_t result = pwm_.SetDutyCycle(0, duty_cycle);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("✅ Duty cycle set to %.1f%%\n", duty_cycle);
+            printf("SUCCESS: Duty cycle set to %.1f%%\n", duty_cycle);
         } else {
-            printf("❌ Duty cycle set failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Duty cycle set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
     void set_frequency(float frequency_hz) {
         hf_pwm_err_t result = pwm_.SetFrequency(0, frequency_hz);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("✅ Frequency set to %.1f Hz\n", frequency_hz);
+            printf("SUCCESS: Frequency set to %.1f Hz\n", frequency_hz);
         } else {
-            printf("❌ Frequency set failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Frequency set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
     void start() {
         hf_pwm_err_t result = pwm_.StartChannel(0);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("✅ PWM started\n");
+            printf("SUCCESS: PWM started\n");
         } else {
-            printf("❌ PWM start failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: PWM start failed: %s\n", HfPwmErrToString(result));
         }
     }
     
     void stop() {
         hf_pwm_err_t result = pwm_.StopChannel(0);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("✅ PWM stopped\n");
+            printf("SUCCESS: PWM stopped\n");
         } else {
-            printf("❌ PWM stop failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: PWM stop failed: %s\n", HfPwmErrToString(result));
         }
     }
 };
@@ -548,18 +548,18 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ Motor PWM configuration failed\n");
+            printf("ERROR: Motor PWM configuration failed\n");
             return false;
         }
         
         // Start PWM output
         result = pwm_.StartChannel(0);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ Motor PWM start failed\n");
+            printf("ERROR: Motor PWM start failed\n");
             return false;
         }
         
-        printf("✅ Motor controller initialized\n");
+        printf("SUCCESS: Motor controller initialized\n");
         return true;
     }
     
@@ -571,7 +571,7 @@ public:
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
             printf("🚗 Motor speed: %.1f%%\n", speed_percent);
         } else {
-            printf("❌ Speed set failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Speed set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
@@ -583,7 +583,7 @@ public:
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
             printf("⚡ Motor frequency: %.1f Hz\n", frequency_hz);
         } else {
-            printf("❌ Frequency set failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Frequency set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
@@ -618,7 +618,7 @@ public:
 };
 ```
 
-### 💡 **LED Dimming Control**
+### INFO: **LED Dimming Control**
 
 ```cpp
 #include "mcu/esp32/EspPwm.h"
@@ -647,18 +647,18 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ LED PWM configuration failed\n");
+            printf("ERROR: LED PWM configuration failed\n");
             return false;
         }
         
         // Start PWM output
         result = pwm_.StartChannel(0);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ LED PWM start failed\n");
+            printf("ERROR: LED PWM start failed\n");
             return false;
         }
         
-        printf("✅ LED controller initialized\n");
+        printf("SUCCESS: LED controller initialized\n");
         return true;
     }
     
@@ -668,9 +668,9 @@ public:
         
         hf_pwm_err_t result = pwm_.SetDutyCycle(0, brightness_percent);
         if (result == hf_pwm_err_t::PWM_SUCCESS) {
-            printf("💡 LED brightness: %.1f%%\n", brightness_percent);
+            printf("INFO: LED brightness: %.1f%%\n", brightness_percent);
         } else {
-            printf("❌ Brightness set failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Brightness set failed: %s\n", HfPwmErrToString(result));
         }
     }
     
@@ -739,11 +739,11 @@ public:
         
         hf_pwm_err_t result = pwm_.ConfigureChannel(0, config);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ Audio PWM configuration failed\n");
+            printf("ERROR: Audio PWM configuration failed\n");
             return false;
         }
         
-        printf("✅ Audio generator initialized\n");
+        printf("SUCCESS: Audio generator initialized\n");
         return true;
     }
     
@@ -751,14 +751,14 @@ public:
         // Set frequency for the note
         hf_pwm_err_t result = pwm_.SetFrequency(0, frequency_hz);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ Frequency set failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Frequency set failed: %s\n", HfPwmErrToString(result));
             return;
         }
         
         // Start playing
         result = pwm_.StartChannel(0);
         if (result != hf_pwm_err_t::PWM_SUCCESS) {
-            printf("❌ Audio start failed: %s\n", HfPwmErrToString(result));
+            printf("ERROR: Audio start failed: %s\n", HfPwmErrToString(result));
             return;
         }
         
@@ -811,76 +811,76 @@ public:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!pwm.EnsureInitialized()) {
-    printf("❌ PWM initialization failed\n");
+    printf("ERROR: PWM initialization failed\n");
     return false;
 }
 
-// ✅ Validate parameters before setting
+// SUCCESS: Validate parameters before setting
 float frequency = 20000;  // 20 kHz
 if (frequency < 1000 || frequency > 50000) {
-    printf("❌ Frequency out of range\n");
+    printf("ERROR: Frequency out of range\n");
     return;
 }
 
-// ✅ Handle configuration errors gracefully
+// SUCCESS: Handle configuration errors gracefully
 hf_pwm_err_t result = pwm.ConfigureChannel(channel_id, config);
 if (result != hf_pwm_err_t::PWM_SUCCESS) {
-    printf("⚠️ Configuration error: %s\n", HfPwmErrToString(result));
+    printf("WARNING: Configuration error: %s\n", HfPwmErrToString(result));
     // Implement error recovery or fallback
 }
 
-// ✅ Check channel status before operations
+// SUCCESS: Check channel status before operations
 hf_pwm_channel_status_t status;
 if (pwm.GetChannelStatus(channel_id, status) == hf_pwm_err_t::PWM_SUCCESS) {
     if (!status.is_configured) {
-        printf("⚠️ Channel not configured\n");
+        printf("WARNING: Channel not configured\n");
         return;
     }
 }
 
-// ✅ Use appropriate frequency ranges
+// SUCCESS: Use appropriate frequency ranges
 // Motor control: 1-50 kHz
 // LED dimming: 100 Hz-1 kHz
 // Audio: 20 Hz-20 kHz
 
-// ✅ Monitor statistics for system health
+// SUCCESS: Monitor statistics for system health
 hf_pwm_statistics_t stats;
 if (pwm.GetStatistics(stats) == hf_pwm_err_t::PWM_SUCCESS) {
     if (stats.runtime_errors > 10) {
-        printf("⚠️ High PWM error rate detected\n");
+        printf("WARNING: High PWM error rate detected\n");
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 pwm.SetDutyCycle(0, 50);  // May fail silently
 
-// ❌ Don't use invalid frequency ranges
+// ERROR: Don't use invalid frequency ranges
 pwm.SetFrequency(0, 0.1f);    // Too low
 pwm.SetFrequency(0, 1000000); // Too high
 
-// ❌ Don't use invalid duty cycles
+// ERROR: Don't use invalid duty cycles
 pwm.SetDutyCycle(0, -10);  // Negative duty cycle
 pwm.SetDutyCycle(0, 150);  // Over 100%
 
-// ❌ Don't assume all channels are available
+// ERROR: Don't assume all channels are available
 pwm.ConfigureChannel(99, config);  // Invalid channel
 
-// ❌ Don't forget to stop channels when done
+// ERROR: Don't forget to stop channels when done
 pwm.StartChannel(0);
 // Missing: pwm.StopChannel(0);
 
-// ❌ Don't use without error checking in critical applications
+// ERROR: Don't use without error checking in critical applications
 // Always check return values in safety-critical systems
 ```
 

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -31,7 +31,7 @@ The `BaseSpi` class provides a comprehensive SPI abstraction that serves as the 
 - 🔄 **Multi-Device Support** - Simultaneous communication with multiple SPI devices
 - ⚡ **High-Speed Transfer** - Configurable clock frequencies up to 80 MHz
 - 🎛️ **Flexible Modes** - Support for all SPI modes (0, 1, 2, 3)
-- 📊 **DMA Support** - Hardware-accelerated data transfer
+- INFO: **DMA Support** - Hardware-accelerated data transfer
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🏎️ **Performance Optimized** - Minimal overhead for critical applications
 - 🔌 **Platform Agnostic** - Works with various SPI hardware implementations
@@ -78,19 +78,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `SPI_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `SPI_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `SPI_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `SPI_ERR_NOT_INITIALIZED` | 2 | ⚠️ SPI not initialized | Call Initialize() first |
-| `SPI_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ SPI already initialized | Check initialization state |
+| `SPI_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `SPI_ERR_NOT_INITIALIZED` | 2 | WARNING: SPI not initialized | Call Initialize() first |
+| `SPI_ERR_ALREADY_INITIALIZED` | 3 | WARNING: SPI already initialized | Check initialization state |
 | `SPI_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `SPI_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `SPI_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -101,7 +101,7 @@ classDiagram
 |------|-------|-------------|------------|
 | `SPI_ERR_INVALID_DEVICE` | 7 | 🚫 Invalid SPI device | Use valid device numbers |
 | `SPI_ERR_DEVICE_BUSY` | 8 | 🔄 Device already in use | Wait or use different device |
-| `SPI_ERR_DEVICE_NOT_AVAILABLE` | 9 | ⚠️ Device not available | Check device availability |
+| `SPI_ERR_DEVICE_NOT_AVAILABLE` | 9 | WARNING: Device not available | Check device availability |
 | `SPI_ERR_DEVICE_NOT_CONFIGURED` | 10 | ⚙️ Device not configured | Configure device first |
 | `SPI_ERR_DEVICE_NOT_RESPONDING` | 11 | 🔇 Device not responding | Check device power and connections |
 
@@ -110,8 +110,8 @@ classDiagram
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `SPI_ERR_TRANSFER_TIMEOUT` | 12 | ⏰ Transfer timeout | Check clock frequency and device |
-| `SPI_ERR_TRANSFER_FAILURE` | 13 | ❌ Transfer failed | Check connections and device state |
-| `SPI_ERR_TRANSFER_INCOMPLETE` | 14 | 📊 Transfer incomplete | Check data length and buffer size |
+| `SPI_ERR_TRANSFER_FAILURE` | 13 | ERROR: Transfer failed | Check connections and device state |
+| `SPI_ERR_TRANSFER_INCOMPLETE` | 14 | INFO: Transfer incomplete | Check data length and buffer size |
 | `SPI_ERR_TRANSFER_ABORTED` | 15 | ⏹️ Transfer aborted | Check abort conditions |
 
 ### 🎛️ **Configuration Error Codes**
@@ -265,7 +265,7 @@ virtual hf_spi_err_t Receive(uint8_t device_id, uint8_t *data,
                            size_t length) noexcept = 0;
 ```
 
-### 📊 **Status and Capabilities**
+### INFO: **Status and Capabilities**
 
 ```cpp
 /**
@@ -274,7 +274,7 @@ virtual hf_spi_err_t Receive(uint8_t device_id, uint8_t *data,
  * @param status [out] Status information structure
  * @return hf_spi_err_t error code
  * 
- * 📊 Retrieves comprehensive status information about a device.
+ * INFO: Retrieves comprehensive status information about a device.
  */
 virtual hf_spi_err_t GetDeviceStatus(uint8_t device_id,
                                    hf_spi_device_status_t &status) const noexcept = 0;
@@ -291,7 +291,7 @@ virtual hf_spi_err_t GetCapabilities(hf_spi_capabilities_t &capabilities) const 
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### ⚙️ **Device Configuration**
 
@@ -308,7 +308,7 @@ struct hf_spi_device_config_t {
 };
 ```
 
-### 📊 **Device Status**
+### INFO: **Device Status**
 
 ```cpp
 struct hf_spi_device_status_t {
@@ -357,7 +357,7 @@ struct hf_spi_statistics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 📡 **Sensor Communication**
 
@@ -375,7 +375,7 @@ public:
         spi_ = EspSpi(SPI2_HOST, 5);  // SPI2, CS on pin 5
         
         if (!spi_.EnsureInitialized()) {
-            printf("❌ SPI initialization failed\n");
+            printf("ERROR: SPI initialization failed\n");
             return false;
         }
         
@@ -392,11 +392,11 @@ public:
         
         hf_spi_err_t result = spi_.ConfigureDevice(SENSOR_DEVICE, config);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Sensor configuration failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Sensor configuration failed: %s\n", HfSpiErrToString(result));
             return false;
         }
         
-        printf("✅ Sensor controller initialized\n");
+        printf("SUCCESS: Sensor controller initialized\n");
         return true;
     }
     
@@ -407,7 +407,7 @@ public:
         
         hf_spi_err_t result = spi_.TransmitReceive(SENSOR_DEVICE, tx_cmd, rx_data, 3);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Temperature read failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Temperature read failed: %s\n", HfSpiErrToString(result));
             return 0xFFFF;  // Error value
         }
         
@@ -426,9 +426,9 @@ public:
         
         hf_spi_err_t result = spi_.TransmitReceive(SENSOR_DEVICE, tx_data, rx_data, 3);
         if (result == hf_spi_err_t::SPI_SUCCESS) {
-            printf("✅ Config written: 0x%02X = 0x%02X\n", config_register, value);
+            printf("SUCCESS: Config written: 0x%02X = 0x%02X\n", config_register, value);
         } else {
-            printf("❌ Config write failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Config write failed: %s\n", HfSpiErrToString(result));
         }
     }
     
@@ -437,7 +437,7 @@ public:
         uint8_t tx_cmd[] = {0x04, 0x00};  // Read data command
         auto rx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 2);
         if (!rx_data) {
-            printf("❌ Failed to allocate memory for receive buffer\n");
+            printf("ERROR: Failed to allocate memory for receive buffer\n");
             return;
         }
         
@@ -445,9 +445,9 @@ public:
         if (result == hf_spi_err_t::SPI_SUCCESS) {
             // Copy data (skip command bytes)
             memcpy(data, rx_data.get() + 2, length);
-            printf("📊 Read %zu bytes of sensor data\n", length);
+            printf("INFO: Read %zu bytes of sensor data\n", length);
         } else {
-            printf("❌ Sensor data read failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Sensor data read failed: %s\n", HfSpiErrToString(result));
         }
         
         // rx_data automatically cleaned up when going out of scope
@@ -489,13 +489,13 @@ public:
         
         hf_spi_err_t result = spi_.ConfigureDevice(DISPLAY_DEVICE, config);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Display configuration failed\n");
+            printf("ERROR: Display configuration failed\n");
             return false;
         }
         
         // Initialize display
         init_display();
-        printf("✅ Display controller initialized\n");
+        printf("SUCCESS: Display controller initialized\n");
         return true;
     }
     
@@ -524,7 +524,7 @@ private:
         uint8_t rx_data;
         hf_spi_err_t result = spi_.TransmitReceive(DISPLAY_DEVICE, &command, &rx_data, 1);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Command send failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Command send failed: %s\n", HfSpiErrToString(result));
         }
     }
     
@@ -534,13 +534,13 @@ private:
         
         auto rx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length);
         if (!rx_data) {
-            printf("❌ Failed to allocate memory for receive buffer\n");
+            printf("ERROR: Failed to allocate memory for receive buffer\n");
             return;
         }
         
         hf_spi_err_t result = spi_.TransmitReceive(DISPLAY_DEVICE, data, rx_data.get(), length);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Data send failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Data send failed: %s\n", HfSpiErrToString(result));
         }
         
         // rx_data automatically cleaned up when going out of scope
@@ -617,11 +617,11 @@ public:
         
         hf_spi_err_t result = spi_.ConfigureDevice(MEMORY_DEVICE, config);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Memory configuration failed\n");
+            printf("ERROR: Memory configuration failed\n");
             return false;
         }
         
-        printf("✅ Memory controller initialized\n");
+        printf("SUCCESS: Memory controller initialized\n");
         return true;
     }
     
@@ -630,7 +630,7 @@ public:
         uint8_t tx_cmd[] = {0x03, (address >> 16) & 0xFF, (address >> 8) & 0xFF, address & 0xFF};
         auto rx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 4);
         if (!rx_data) {
-            printf("❌ Failed to allocate memory for receive buffer\n");
+            printf("ERROR: Failed to allocate memory for receive buffer\n");
             return false;
         }
         
@@ -638,10 +638,10 @@ public:
         if (result == hf_spi_err_t::SPI_SUCCESS) {
             // Copy data (skip command bytes)
             memcpy(data, rx_data.get() + 4, length);
-            printf("📖 Read %zu bytes from address 0x%06X\n", length, address);
+            printf("READ: Read %zu bytes from address 0x%06X\n", length, address);
             return true;
         } else {
-            printf("❌ Memory read failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Memory read failed: %s\n", HfSpiErrToString(result));
             return false;
         }
         // rx_data automatically cleaned up when going out of scope
@@ -653,14 +653,14 @@ public:
         uint8_t rx_data;
         hf_spi_err_t result = spi_.TransmitReceive(MEMORY_DEVICE, &write_enable, &rx_data, 1);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Write enable failed\n");
+            printf("ERROR: Write enable failed\n");
             return false;
         }
         
         // Send write command using nothrow allocation
         auto tx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 4);
         if (!tx_data) {
-            printf("❌ Failed to allocate memory for transmit buffer\n");
+            printf("ERROR: Failed to allocate memory for transmit buffer\n");
             return false;
         }
         
@@ -672,10 +672,10 @@ public:
         
         result = spi_.Transmit(MEMORY_DEVICE, tx_data.get(), length + 4);
         if (result == hf_spi_err_t::SPI_SUCCESS) {
-            printf("✍️ Wrote %zu bytes to address 0x%06X\n", length, address);
+            printf("WRITE: Wrote %zu bytes to address 0x%06X\n", length, address);
             return true;
         } else {
-            printf("❌ Memory write failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Memory write failed: %s\n", HfSpiErrToString(result));
             return false;
         }
         // tx_data automatically cleaned up when going out of scope
@@ -687,7 +687,7 @@ public:
         uint8_t rx_data;
         hf_spi_err_t result = spi_.TransmitReceive(MEMORY_DEVICE, &write_enable, &rx_data, 1);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("❌ Write enable failed\n");
+            printf("ERROR: Write enable failed\n");
             return false;
         }
         
@@ -698,7 +698,7 @@ public:
             printf("🗑️ Erased sector at address 0x%06X\n", address);
             return true;
         } else {
-            printf("❌ Sector erase failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Sector erase failed: %s\n", HfSpiErrToString(result));
             return false;
         }
     }
@@ -713,7 +713,7 @@ public:
             printf("🆔 Device ID: 0x%06X\n", device_id);
             return device_id;
         } else {
-            printf("❌ Device ID read failed: %s\n", HfSpiErrToString(result));
+            printf("ERROR: Device ID read failed: %s\n", HfSpiErrToString(result));
             return 0;
         }
     }
@@ -722,42 +722,42 @@ public:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!spi.EnsureInitialized()) {
-    printf("❌ SPI initialization failed\n");
+    printf("ERROR: SPI initialization failed\n");
     return false;
 }
 
-// ✅ Validate device configuration
+// SUCCESS: Validate device configuration
 hf_spi_capabilities_t caps;
 if (spi.GetCapabilities(caps) == hf_spi_err_t::SPI_SUCCESS) {
     if (device_id >= caps.max_devices) {
-        printf("❌ Device %u exceeds maximum (%u)\n", device_id, caps.max_devices);
+        printf("ERROR: Device %u exceeds maximum (%u)\n", device_id, caps.max_devices);
         return;
     }
 }
 
-// ✅ Use appropriate frequency for your application
+// SUCCESS: Use appropriate frequency for your application
 // Sensors: 1-10 MHz
 // Displays: 10-40 MHz
 // Memory: 20-80 MHz
 
-// ✅ Handle transfer errors gracefully
+// SUCCESS: Handle transfer errors gracefully
 hf_spi_err_t result = spi.TransmitReceive(device_id, tx_data, rx_data, length);
 if (result != hf_spi_err_t::SPI_SUCCESS) {
-    printf("⚠️ SPI Error: %s\n", HfSpiErrToString(result));
+    printf("WARNING: SPI Error: %s\n", HfSpiErrToString(result));
     // Implement retry logic or error recovery
 }
 
-// ✅ Use DMA for large transfers
+// SUCCESS: Use DMA for large transfers
 config.use_dma = (length > 32);  // Use DMA for transfers > 32 bytes
 
-// ✅ Check device status before operations
+// SUCCESS: Check device status before operations
 hf_spi_device_status_t status;
 if (spi.GetDeviceStatus(device_id, status) == hf_spi_err_t::SPI_SUCCESS) {
     if (status.is_busy) {
@@ -767,25 +767,25 @@ if (spi.GetDeviceStatus(device_id, status) == hf_spi_err_t::SPI_SUCCESS) {
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 spi.TransmitReceive(0, tx_data, rx_data, length);  // May fail silently
 
-// ❌ Don't use invalid frequencies
+// ERROR: Don't use invalid frequencies
 spi.ConfigureDevice(0, {mode: MODE_0, frequency_hz: 100000000});  // Too high
 
-// ❌ Don't use invalid device numbers
+// ERROR: Don't use invalid device numbers
 spi.ConfigureDevice(99, config);  // Invalid device
 
-// ❌ Don't ignore transfer timeouts
+// ERROR: Don't ignore transfer timeouts
 // Large transfers may timeout - check return values
 
-// ❌ Don't assume all modes are supported
+// ERROR: Don't assume all modes are supported
 // Check capabilities before using specific modes
 
-// ❌ Don't forget to handle CS pin manually when needed
+// ERROR: Don't forget to handle CS pin manually when needed
 // Some devices require manual CS control
 ```
 

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -31,7 +31,7 @@ The `BaseSpi` class provides a comprehensive SPI abstraction that serves as the 
 - 🔄 **Multi-Device Support** - Simultaneous communication with multiple SPI devices
 - ⚡ **High-Speed Transfer** - Configurable clock frequencies up to 80 MHz
 - 🎛️ **Flexible Modes** - Support for all SPI modes (0, 1, 2, 3)
-- INFO: **DMA Support** - Hardware-accelerated data transfer
+- 📊 **DMA Support** - Hardware-accelerated data transfer
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🏎️ **Performance Optimized** - Minimal overhead for critical applications
 - 🔌 **Platform Agnostic** - Works with various SPI hardware implementations
@@ -78,19 +78,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `SPI_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `SPI_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `SPI_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `SPI_ERR_NOT_INITIALIZED` | 2 | WARNING: SPI not initialized | Call Initialize() first |
-| `SPI_ERR_ALREADY_INITIALIZED` | 3 | WARNING: SPI already initialized | Check initialization state |
+| `SPI_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `SPI_ERR_NOT_INITIALIZED` | 2 | ⚠️ SPI not initialized | Call Initialize() first |
+| `SPI_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ SPI already initialized | Check initialization state |
 | `SPI_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `SPI_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `SPI_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -101,7 +101,7 @@ classDiagram
 |------|-------|-------------|------------|
 | `SPI_ERR_INVALID_DEVICE` | 7 | 🚫 Invalid SPI device | Use valid device numbers |
 | `SPI_ERR_DEVICE_BUSY` | 8 | 🔄 Device already in use | Wait or use different device |
-| `SPI_ERR_DEVICE_NOT_AVAILABLE` | 9 | WARNING: Device not available | Check device availability |
+| `SPI_ERR_DEVICE_NOT_AVAILABLE` | 9 | ⚠️ Device not available | Check device availability |
 | `SPI_ERR_DEVICE_NOT_CONFIGURED` | 10 | ⚙️ Device not configured | Configure device first |
 | `SPI_ERR_DEVICE_NOT_RESPONDING` | 11 | 🔇 Device not responding | Check device power and connections |
 
@@ -110,8 +110,8 @@ classDiagram
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
 | `SPI_ERR_TRANSFER_TIMEOUT` | 12 | ⏰ Transfer timeout | Check clock frequency and device |
-| `SPI_ERR_TRANSFER_FAILURE` | 13 | ERROR: Transfer failed | Check connections and device state |
-| `SPI_ERR_TRANSFER_INCOMPLETE` | 14 | INFO: Transfer incomplete | Check data length and buffer size |
+| `SPI_ERR_TRANSFER_FAILURE` | 13 | ❌ Transfer failed | Check connections and device state |
+| `SPI_ERR_TRANSFER_INCOMPLETE` | 14 | 📊 Transfer incomplete | Check data length and buffer size |
 | `SPI_ERR_TRANSFER_ABORTED` | 15 | ⏹️ Transfer aborted | Check abort conditions |
 
 ### 🎛️ **Configuration Error Codes**
@@ -265,7 +265,7 @@ virtual hf_spi_err_t Receive(uint8_t device_id, uint8_t *data,
                            size_t length) noexcept = 0;
 ```
 
-### INFO: **Status and Capabilities**
+### 📊 **Status and Capabilities**
 
 ```cpp
 /**
@@ -274,7 +274,7 @@ virtual hf_spi_err_t Receive(uint8_t device_id, uint8_t *data,
  * @param status [out] Status information structure
  * @return hf_spi_err_t error code
  * 
- * INFO: Retrieves comprehensive status information about a device.
+ * 📊 Retrieves comprehensive status information about a device.
  */
 virtual hf_spi_err_t GetDeviceStatus(uint8_t device_id,
                                    hf_spi_device_status_t &status) const noexcept = 0;
@@ -291,7 +291,7 @@ virtual hf_spi_err_t GetCapabilities(hf_spi_capabilities_t &capabilities) const 
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### ⚙️ **Device Configuration**
 
@@ -308,7 +308,7 @@ struct hf_spi_device_config_t {
 };
 ```
 
-### INFO: **Device Status**
+### 📊 **Device Status**
 
 ```cpp
 struct hf_spi_device_status_t {
@@ -357,7 +357,7 @@ struct hf_spi_statistics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 📡 **Sensor Communication**
 
@@ -375,7 +375,7 @@ public:
         spi_ = EspSpi(SPI2_HOST, 5);  // SPI2, CS on pin 5
         
         if (!spi_.EnsureInitialized()) {
-            printf("ERROR: SPI initialization failed\n");
+            printf("❌ SPI initialization failed\n");
             return false;
         }
         
@@ -392,11 +392,11 @@ public:
         
         hf_spi_err_t result = spi_.ConfigureDevice(SENSOR_DEVICE, config);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Sensor configuration failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Sensor configuration failed: %s\n", HfSpiErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Sensor controller initialized\n");
+        printf("✅ Sensor controller initialized\n");
         return true;
     }
     
@@ -407,7 +407,7 @@ public:
         
         hf_spi_err_t result = spi_.TransmitReceive(SENSOR_DEVICE, tx_cmd, rx_data, 3);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Temperature read failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Temperature read failed: %s\n", HfSpiErrToString(result));
             return 0xFFFF;  // Error value
         }
         
@@ -426,9 +426,9 @@ public:
         
         hf_spi_err_t result = spi_.TransmitReceive(SENSOR_DEVICE, tx_data, rx_data, 3);
         if (result == hf_spi_err_t::SPI_SUCCESS) {
-            printf("SUCCESS: Config written: 0x%02X = 0x%02X\n", config_register, value);
+            printf("✅ Config written: 0x%02X = 0x%02X\n", config_register, value);
         } else {
-            printf("ERROR: Config write failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Config write failed: %s\n", HfSpiErrToString(result));
         }
     }
     
@@ -437,7 +437,7 @@ public:
         uint8_t tx_cmd[] = {0x04, 0x00};  // Read data command
         auto rx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 2);
         if (!rx_data) {
-            printf("ERROR: Failed to allocate memory for receive buffer\n");
+            printf("❌ Failed to allocate memory for receive buffer\n");
             return;
         }
         
@@ -445,9 +445,9 @@ public:
         if (result == hf_spi_err_t::SPI_SUCCESS) {
             // Copy data (skip command bytes)
             memcpy(data, rx_data.get() + 2, length);
-            printf("INFO: Read %zu bytes of sensor data\n", length);
+            printf("📊 Read %zu bytes of sensor data\n", length);
         } else {
-            printf("ERROR: Sensor data read failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Sensor data read failed: %s\n", HfSpiErrToString(result));
         }
         
         // rx_data automatically cleaned up when going out of scope
@@ -489,13 +489,13 @@ public:
         
         hf_spi_err_t result = spi_.ConfigureDevice(DISPLAY_DEVICE, config);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Display configuration failed\n");
+            printf("❌ Display configuration failed\n");
             return false;
         }
         
         // Initialize display
         init_display();
-        printf("SUCCESS: Display controller initialized\n");
+        printf("✅ Display controller initialized\n");
         return true;
     }
     
@@ -524,7 +524,7 @@ private:
         uint8_t rx_data;
         hf_spi_err_t result = spi_.TransmitReceive(DISPLAY_DEVICE, &command, &rx_data, 1);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Command send failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Command send failed: %s\n", HfSpiErrToString(result));
         }
     }
     
@@ -534,13 +534,13 @@ private:
         
         auto rx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length);
         if (!rx_data) {
-            printf("ERROR: Failed to allocate memory for receive buffer\n");
+            printf("❌ Failed to allocate memory for receive buffer\n");
             return;
         }
         
         hf_spi_err_t result = spi_.TransmitReceive(DISPLAY_DEVICE, data, rx_data.get(), length);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Data send failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Data send failed: %s\n", HfSpiErrToString(result));
         }
         
         // rx_data automatically cleaned up when going out of scope
@@ -617,11 +617,11 @@ public:
         
         hf_spi_err_t result = spi_.ConfigureDevice(MEMORY_DEVICE, config);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Memory configuration failed\n");
+            printf("❌ Memory configuration failed\n");
             return false;
         }
         
-        printf("SUCCESS: Memory controller initialized\n");
+        printf("✅ Memory controller initialized\n");
         return true;
     }
     
@@ -630,7 +630,7 @@ public:
         uint8_t tx_cmd[] = {0x03, (address >> 16) & 0xFF, (address >> 8) & 0xFF, address & 0xFF};
         auto rx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 4);
         if (!rx_data) {
-            printf("ERROR: Failed to allocate memory for receive buffer\n");
+            printf("❌ Failed to allocate memory for receive buffer\n");
             return false;
         }
         
@@ -638,10 +638,10 @@ public:
         if (result == hf_spi_err_t::SPI_SUCCESS) {
             // Copy data (skip command bytes)
             memcpy(data, rx_data.get() + 4, length);
-            printf("READ: Read %zu bytes from address 0x%06X\n", length, address);
+            printf("📖 Read %zu bytes from address 0x%06X\n", length, address);
             return true;
         } else {
-            printf("ERROR: Memory read failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Memory read failed: %s\n", HfSpiErrToString(result));
             return false;
         }
         // rx_data automatically cleaned up when going out of scope
@@ -653,14 +653,14 @@ public:
         uint8_t rx_data;
         hf_spi_err_t result = spi_.TransmitReceive(MEMORY_DEVICE, &write_enable, &rx_data, 1);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Write enable failed\n");
+            printf("❌ Write enable failed\n");
             return false;
         }
         
         // Send write command using nothrow allocation
         auto tx_data = hf::utils::make_unique_array_nothrow<uint8_t>(length + 4);
         if (!tx_data) {
-            printf("ERROR: Failed to allocate memory for transmit buffer\n");
+            printf("❌ Failed to allocate memory for transmit buffer\n");
             return false;
         }
         
@@ -672,10 +672,10 @@ public:
         
         result = spi_.Transmit(MEMORY_DEVICE, tx_data.get(), length + 4);
         if (result == hf_spi_err_t::SPI_SUCCESS) {
-            printf("WRITE: Wrote %zu bytes to address 0x%06X\n", length, address);
+            printf("✍️ Wrote %zu bytes to address 0x%06X\n", length, address);
             return true;
         } else {
-            printf("ERROR: Memory write failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Memory write failed: %s\n", HfSpiErrToString(result));
             return false;
         }
         // tx_data automatically cleaned up when going out of scope
@@ -687,7 +687,7 @@ public:
         uint8_t rx_data;
         hf_spi_err_t result = spi_.TransmitReceive(MEMORY_DEVICE, &write_enable, &rx_data, 1);
         if (result != hf_spi_err_t::SPI_SUCCESS) {
-            printf("ERROR: Write enable failed\n");
+            printf("❌ Write enable failed\n");
             return false;
         }
         
@@ -698,7 +698,7 @@ public:
             printf("🗑️ Erased sector at address 0x%06X\n", address);
             return true;
         } else {
-            printf("ERROR: Sector erase failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Sector erase failed: %s\n", HfSpiErrToString(result));
             return false;
         }
     }
@@ -713,7 +713,7 @@ public:
             printf("🆔 Device ID: 0x%06X\n", device_id);
             return device_id;
         } else {
-            printf("ERROR: Device ID read failed: %s\n", HfSpiErrToString(result));
+            printf("❌ Device ID read failed: %s\n", HfSpiErrToString(result));
             return 0;
         }
     }
@@ -722,42 +722,42 @@ public:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!spi.EnsureInitialized()) {
-    printf("ERROR: SPI initialization failed\n");
+    printf("❌ SPI initialization failed\n");
     return false;
 }
 
-// SUCCESS: Validate device configuration
+// ✅ Validate device configuration
 hf_spi_capabilities_t caps;
 if (spi.GetCapabilities(caps) == hf_spi_err_t::SPI_SUCCESS) {
     if (device_id >= caps.max_devices) {
-        printf("ERROR: Device %u exceeds maximum (%u)\n", device_id, caps.max_devices);
+        printf("❌ Device %u exceeds maximum (%u)\n", device_id, caps.max_devices);
         return;
     }
 }
 
-// SUCCESS: Use appropriate frequency for your application
+// ✅ Use appropriate frequency for your application
 // Sensors: 1-10 MHz
 // Displays: 10-40 MHz
 // Memory: 20-80 MHz
 
-// SUCCESS: Handle transfer errors gracefully
+// ✅ Handle transfer errors gracefully
 hf_spi_err_t result = spi.TransmitReceive(device_id, tx_data, rx_data, length);
 if (result != hf_spi_err_t::SPI_SUCCESS) {
-    printf("WARNING: SPI Error: %s\n", HfSpiErrToString(result));
+    printf("⚠️ SPI Error: %s\n", HfSpiErrToString(result));
     // Implement retry logic or error recovery
 }
 
-// SUCCESS: Use DMA for large transfers
+// ✅ Use DMA for large transfers
 config.use_dma = (length > 32);  // Use DMA for transfers > 32 bytes
 
-// SUCCESS: Check device status before operations
+// ✅ Check device status before operations
 hf_spi_device_status_t status;
 if (spi.GetDeviceStatus(device_id, status) == hf_spi_err_t::SPI_SUCCESS) {
     if (status.is_busy) {
@@ -767,25 +767,25 @@ if (spi.GetDeviceStatus(device_id, status) == hf_spi_err_t::SPI_SUCCESS) {
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 spi.TransmitReceive(0, tx_data, rx_data, length);  // May fail silently
 
-// ERROR: Don't use invalid frequencies
+// ❌ Don't use invalid frequencies
 spi.ConfigureDevice(0, {mode: MODE_0, frequency_hz: 100000000});  // Too high
 
-// ERROR: Don't use invalid device numbers
+// ❌ Don't use invalid device numbers
 spi.ConfigureDevice(99, config);  // Invalid device
 
-// ERROR: Don't ignore transfer timeouts
+// ❌ Don't ignore transfer timeouts
 // Large transfers may timeout - check return values
 
-// ERROR: Don't assume all modes are supported
+// ❌ Don't assume all modes are supported
 // Check capabilities before using specific modes
 
-// ERROR: Don't forget to handle CS pin manually when needed
+// ❌ Don't forget to handle CS pin manually when needed
 // Some devices require manual CS control
 ```
 

--- a/docs/api/BaseUart.md
+++ b/docs/api/BaseUart.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [📊 **Data Structures**](#-data-structures)
-- [💡 **Usage Examples**](#-usage-examples)
-- [🧪 **Best Practices**](#-best-practices)
+- [INFO: **Data Structures**](#-data-structures)
+- [INFO: **Usage Examples**](#-usage-examples)
+- [TEST: **Best Practices**](#-best-practices)
 
 ---
 
@@ -31,7 +31,7 @@ The `BaseUart` class provides a comprehensive UART abstraction that serves as th
 - 📡 **Configurable Baud Rates** - Support for standard and custom baud rates
 - 🔧 **Flexible Data Formats** - Configurable data bits, stop bits, and parity
 - 🔄 **Flow Control** - Hardware and software flow control support
-- 📊 **DMA Support** - Hardware-accelerated data transfer
+- INFO: **DMA Support** - Hardware-accelerated data transfer
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🏎️ **Performance Optimized** - Minimal overhead for critical applications
 - 🔌 **Platform Agnostic** - Works with various UART hardware implementations
@@ -78,19 +78,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### ✅ **Success Codes**
+### SUCCESS: **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `UART_SUCCESS` | 0 | ✅ Operation completed successfully |
+| `UART_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
 
-### ❌ **General Error Codes**
+### ERROR: **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `UART_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
-| `UART_ERR_NOT_INITIALIZED` | 2 | ⚠️ UART not initialized | Call Initialize() first |
-| `UART_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ UART already initialized | Check initialization state |
+| `UART_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
+| `UART_ERR_NOT_INITIALIZED` | 2 | WARNING: UART not initialized | Call Initialize() first |
+| `UART_ERR_ALREADY_INITIALIZED` | 3 | WARNING: UART already initialized | Check initialization state |
 | `UART_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `UART_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `UART_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -101,9 +101,9 @@ classDiagram
 |------|-------|-------------|------------|
 | `UART_ERR_TRANSMIT_TIMEOUT` | 7 | ⏰ Transmit timeout | Check baud rate and flow control |
 | `UART_ERR_RECEIVE_TIMEOUT` | 8 | ⏰ Receive timeout | Check data source and timing |
-| `UART_ERR_TRANSMIT_FAILURE` | 9 | ❌ Transmit failed | Check connections and device state |
-| `UART_ERR_RECEIVE_FAILURE` | 10 | ❌ Receive failed | Check connections and device state |
-| `UART_ERR_FRAME_ERROR` | 11 | 📊 Frame error | Check baud rate and data format |
+| `UART_ERR_TRANSMIT_FAILURE` | 9 | ERROR: Transmit failed | Check connections and device state |
+| `UART_ERR_RECEIVE_FAILURE` | 10 | ERROR: Receive failed | Check connections and device state |
+| `UART_ERR_FRAME_ERROR` | 11 | INFO: Frame error | Check baud rate and data format |
 | `UART_ERR_PARITY_ERROR` | 12 | 🔍 Parity error | Check parity settings |
 
 ### ⚙️ **Configuration Error Codes**
@@ -203,7 +203,7 @@ virtual hf_uart_err_t Configure(const hf_uart_config_t &config) noexcept = 0;
  * @param config [out] Current configuration structure
  * @return hf_uart_err_t error code
  * 
- * 📊 Retrieves the current UART configuration.
+ * INFO: Retrieves the current UART configuration.
  */
 virtual hf_uart_err_t GetConfiguration(hf_uart_config_t &config) const noexcept = 0;
 ```
@@ -225,7 +225,7 @@ virtual hf_uart_err_t GetConfiguration(hf_uart_config_t &config) const noexcept 
  * hf_uart_err_t result = uart.Transmit(
  *     reinterpret_cast<const uint8_t*>(message), strlen(message));
  * if (result == hf_uart_err_t::UART_SUCCESS) {
- *     printf("✅ Message transmitted\n");
+ *     printf("SUCCESS: Message transmitted\n");
  * }
  */
 virtual hf_uart_err_t Transmit(const uint8_t *data, size_t length) noexcept = 0;
@@ -246,7 +246,7 @@ virtual hf_uart_err_t Transmit(const uint8_t *data, size_t length,
  * @brief Get number of bytes available for transmission
  * @return Number of bytes that can be transmitted
  * 
- * 📊 Returns the number of bytes that can be transmitted without blocking.
+ * INFO: Returns the number of bytes that can be transmitted without blocking.
  */
 virtual size_t GetTransmitSpace() const noexcept = 0;
 ```
@@ -288,7 +288,7 @@ virtual hf_uart_err_t Receive(uint8_t *data, size_t length,
  * @brief Get number of bytes available for reception
  * @return Number of bytes available to receive
  * 
- * 📊 Returns the number of bytes available to receive without blocking.
+ * INFO: Returns the number of bytes available to receive without blocking.
  */
 virtual size_t GetReceiveSpace() const noexcept = 0;
 
@@ -301,7 +301,7 @@ virtual size_t GetReceiveSpace() const noexcept = 0;
 virtual hf_uart_err_t FlushReceive() noexcept = 0;
 ```
 
-### 📊 **Status and Capabilities**
+### INFO: **Status and Capabilities**
 
 ```cpp
 /**
@@ -309,7 +309,7 @@ virtual hf_uart_err_t FlushReceive() noexcept = 0;
  * @param status [out] Status information structure
  * @return hf_uart_err_t error code
  * 
- * 📊 Retrieves comprehensive status information about UART.
+ * INFO: Retrieves comprehensive status information about UART.
  */
 virtual hf_uart_err_t GetStatus(hf_uart_status_t &status) const noexcept = 0;
 
@@ -325,7 +325,7 @@ virtual hf_uart_err_t GetCapabilities(hf_uart_capabilities_t &capabilities) cons
 
 ---
 
-## 📊 **Data Structures**
+## INFO: **Data Structures**
 
 ### ⚙️ **UART Configuration**
 
@@ -347,7 +347,7 @@ struct hf_uart_config_t {
 };
 ```
 
-### 📊 **UART Status**
+### INFO: **UART Status**
 
 ```cpp
 struct hf_uart_status_t {
@@ -403,7 +403,7 @@ struct hf_uart_statistics_t {
 
 ---
 
-## 💡 **Usage Examples**
+## INFO: **Usage Examples**
 
 ### 📡 **Basic Serial Communication**
 
@@ -419,7 +419,7 @@ public:
         uart_ = EspUart(UART_NUM_0);
         
         if (!uart_.EnsureInitialized()) {
-            printf("❌ UART initialization failed\n");
+            printf("ERROR: UART initialization failed\n");
             return false;
         }
         
@@ -441,11 +441,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("❌ UART configuration failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: UART configuration failed: %s\n", HfUartErrToString(result));
             return false;
         }
         
-        printf("✅ Serial communicator initialized\n");
+        printf("SUCCESS: Serial communicator initialized\n");
         return true;
     }
     
@@ -457,7 +457,7 @@ public:
         if (result == hf_uart_err_t::UART_SUCCESS) {
             printf("📤 Sent: %s", message);
         } else {
-            printf("❌ Send failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: Send failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -469,7 +469,7 @@ public:
             buffer[max_length] = '\0';  // Null terminate
             printf("📥 Received: %s", buffer);
         } else {
-            printf("❌ Receive failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: Receive failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -536,11 +536,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("❌ GPS configuration failed\n");
+            printf("ERROR: GPS configuration failed\n");
             return false;
         }
         
-        printf("✅ GPS controller initialized\n");
+        printf("SUCCESS: GPS controller initialized\n");
         return true;
     }
     
@@ -559,7 +559,7 @@ public:
             printf("⏰ GPS timeout - no data received\n");
             return false;
         } else {
-            printf("❌ GPS read failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: GPS read failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -600,7 +600,7 @@ public:
         if (result == hf_uart_err_t::UART_SUCCESS) {
             printf("📤 GPS Command: %s", command);
         } else {
-            printf("❌ GPS command failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: GPS command failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -657,11 +657,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("❌ Bluetooth configuration failed\n");
+            printf("ERROR: Bluetooth configuration failed\n");
             return false;
         }
         
-        printf("✅ Bluetooth controller initialized\n");
+        printf("SUCCESS: Bluetooth controller initialized\n");
         return true;
     }
     
@@ -673,7 +673,7 @@ public:
         if (result == hf_uart_err_t::UART_SUCCESS) {
             printf("📤 BT Sent: %s", data);
         } else {
-            printf("❌ BT send failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: BT send failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -688,7 +688,7 @@ public:
         } else if (result == hf_uart_err_t::UART_ERR_RECEIVE_TIMEOUT) {
             return false;  // No data available
         } else {
-            printf("❌ BT receive failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: BT receive failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -759,11 +759,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("❌ Modbus configuration failed\n");
+            printf("ERROR: Modbus configuration failed\n");
             return false;
         }
         
-        printf("✅ Modbus controller initialized\n");
+        printf("SUCCESS: Modbus controller initialized\n");
         return true;
     }
     
@@ -786,7 +786,7 @@ public:
         // Send request
         hf_uart_err_t result = uart_.Transmit(request, 8);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("❌ Modbus request failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: Modbus request failed: %s\n", HfUartErrToString(result));
             return false;
         }
         
@@ -802,14 +802,14 @@ public:
                     data[i] = (modbus_buffer_[3 + i * 2] << 8) | 
                               modbus_buffer_[4 + i * 2];
                 }
-                printf("✅ Read %d holding registers\n", count);
+                printf("SUCCESS: Read %d holding registers\n", count);
                 return true;
             } else {
-                printf("❌ Invalid Modbus response\n");
+                printf("ERROR: Invalid Modbus response\n");
                 return false;
             }
         } else {
-            printf("❌ Modbus response failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: Modbus response failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -832,7 +832,7 @@ public:
         // Send request
         hf_uart_err_t result = uart_.Transmit(request, 8);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("❌ Modbus write request failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: Modbus write request failed: %s\n", HfUartErrToString(result));
             return false;
         }
         
@@ -841,14 +841,14 @@ public:
         
         if (result == hf_uart_err_t::UART_SUCCESS) {
             if (memcmp(request, modbus_buffer_, 8) == 0) {
-                printf("✅ Wrote register 0x%04X = 0x%04X\n", addr, value);
+                printf("SUCCESS: Wrote register 0x%04X = 0x%04X\n", addr, value);
                 return true;
             } else {
-                printf("❌ Invalid Modbus write response\n");
+                printf("ERROR: Invalid Modbus write response\n");
                 return false;
             }
         } else {
-            printf("❌ Modbus write response failed: %s\n", HfUartErrToString(result));
+            printf("ERROR: Modbus write response failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -875,31 +875,31 @@ private:
 
 ---
 
-## 🧪 **Best Practices**
+## TEST: **Best Practices**
 
-### ✅ **Recommended Patterns**
+### SUCCESS: **Recommended Patterns**
 
 ```cpp
-// ✅ Always check initialization
+// SUCCESS: Always check initialization
 if (!uart.EnsureInitialized()) {
-    printf("❌ UART initialization failed\n");
+    printf("ERROR: UART initialization failed\n");
     return false;
 }
 
-// ✅ Use appropriate baud rates
+// SUCCESS: Use appropriate baud rates
 // Debug: 115200
 // GPS: 9600
 // Bluetooth: 115200
 // Modbus: 9600-115200
 
-// ✅ Handle timeouts gracefully
+// SUCCESS: Handle timeouts gracefully
 hf_uart_err_t result = uart.Receive(buffer, length, 1000);
 if (result == hf_uart_err_t::UART_ERR_RECEIVE_TIMEOUT) {
     printf("⏰ No data received within timeout\n");
     return false;
 }
 
-// ✅ Check buffer space before operations
+// SUCCESS: Check buffer space before operations
 if (uart.GetReceiveSpace() > 0) {
     // Data available to receive
 }
@@ -908,38 +908,38 @@ if (uart.GetTransmitSpace() >= length) {
     // Space available to transmit
 }
 
-// ✅ Use appropriate data formats
+// SUCCESS: Use appropriate data formats
 // Most applications: 8N1 (8 data bits, no parity, 1 stop bit)
 // Modbus: 8E1 (8 data bits, even parity, 1 stop bit)
 
-// ✅ Monitor statistics for system health
+// SUCCESS: Monitor statistics for system health
 hf_uart_statistics_t stats;
 if (uart.GetStatistics(stats) == hf_uart_err_t::UART_SUCCESS) {
     if (stats.frame_errors > 10) {
-        printf("⚠️ High frame error rate detected\n");
+        printf("WARNING: High frame error rate detected\n");
     }
 }
 ```
 
-### ❌ **Common Pitfalls**
+### ERROR: **Common Pitfalls**
 
 ```cpp
-// ❌ Don't ignore initialization
+// ERROR: Don't ignore initialization
 uart.Transmit(data, length);  // May fail silently
 
-// ❌ Don't use mismatched baud rates
+// ERROR: Don't use mismatched baud rates
 // Both devices must use the same baud rate
 
-// ❌ Don't ignore buffer overflows
+// ERROR: Don't ignore buffer overflows
 // Check buffer space before large transfers
 
-// ❌ Don't use without error checking in critical applications
+// ERROR: Don't use without error checking in critical applications
 // Always check return values in safety-critical systems
 
-// ❌ Don't forget to handle flow control
+// ERROR: Don't forget to handle flow control
 // Some devices require hardware flow control
 
-// ❌ Don't assume all data formats are supported
+// ERROR: Don't assume all data formats are supported
 // Check capabilities before using specific formats
 ```
 

--- a/docs/api/BaseUart.md
+++ b/docs/api/BaseUart.md
@@ -16,9 +16,9 @@
 - [🏗️ **Class Hierarchy**](#️-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
-- [INFO: **Data Structures**](#-data-structures)
-- [INFO: **Usage Examples**](#-usage-examples)
-- [TEST: **Best Practices**](#-best-practices)
+- [📊 **Data Structures**](#-data-structures)
+- [📊 **Usage Examples**](#-usage-examples)
+- [🧪 **Best Practices**](#-best-practices)
 
 ---
 
@@ -31,7 +31,7 @@ The `BaseUart` class provides a comprehensive UART abstraction that serves as th
 - 📡 **Configurable Baud Rates** - Support for standard and custom baud rates
 - 🔧 **Flexible Data Formats** - Configurable data bits, stop bits, and parity
 - 🔄 **Flow Control** - Hardware and software flow control support
-- INFO: **DMA Support** - Hardware-accelerated data transfer
+- 📊 **DMA Support** - Hardware-accelerated data transfer
 - 🛡️ **Robust Error Handling** - Comprehensive validation and error reporting
 - 🏎️ **Performance Optimized** - Minimal overhead for critical applications
 - 🔌 **Platform Agnostic** - Works with various UART hardware implementations
@@ -78,19 +78,19 @@ classDiagram
 
 ## 📋 **Error Codes**
 
-### SUCCESS: **Success Codes**
+### ✅ **Success Codes**
 
 | Code | Value | Description |
 |------|-------|-------------|
-| `UART_SUCCESS` | 0 | SUCCESS: Operation completed successfully |
+| `UART_SUCCESS` | 0 | ✅ Operation completed successfully |
 
-### ERROR: **General Error Codes**
+### ❌ **General Error Codes**
 
 | Code | Value | Description | Resolution |
 |------|-------|-------------|------------|
-| `UART_ERR_FAILURE` | 1 | ERROR: General operation failure | Check hardware and configuration |
-| `UART_ERR_NOT_INITIALIZED` | 2 | WARNING: UART not initialized | Call Initialize() first |
-| `UART_ERR_ALREADY_INITIALIZED` | 3 | WARNING: UART already initialized | Check initialization state |
+| `UART_ERR_FAILURE` | 1 | ❌ General operation failure | Check hardware and configuration |
+| `UART_ERR_NOT_INITIALIZED` | 2 | ⚠️ UART not initialized | Call Initialize() first |
+| `UART_ERR_ALREADY_INITIALIZED` | 3 | ⚠️ UART already initialized | Check initialization state |
 | `UART_ERR_INVALID_PARAMETER` | 4 | 🚫 Invalid parameter | Validate input parameters |
 | `UART_ERR_NULL_POINTER` | 5 | 🚫 Null pointer provided | Check pointer validity |
 | `UART_ERR_OUT_OF_MEMORY` | 6 | 💾 Memory allocation failed | Check system memory |
@@ -101,9 +101,9 @@ classDiagram
 |------|-------|-------------|------------|
 | `UART_ERR_TRANSMIT_TIMEOUT` | 7 | ⏰ Transmit timeout | Check baud rate and flow control |
 | `UART_ERR_RECEIVE_TIMEOUT` | 8 | ⏰ Receive timeout | Check data source and timing |
-| `UART_ERR_TRANSMIT_FAILURE` | 9 | ERROR: Transmit failed | Check connections and device state |
-| `UART_ERR_RECEIVE_FAILURE` | 10 | ERROR: Receive failed | Check connections and device state |
-| `UART_ERR_FRAME_ERROR` | 11 | INFO: Frame error | Check baud rate and data format |
+| `UART_ERR_TRANSMIT_FAILURE` | 9 | ❌ Transmit failed | Check connections and device state |
+| `UART_ERR_RECEIVE_FAILURE` | 10 | ❌ Receive failed | Check connections and device state |
+| `UART_ERR_FRAME_ERROR` | 11 | 📊 Frame error | Check baud rate and data format |
 | `UART_ERR_PARITY_ERROR` | 12 | 🔍 Parity error | Check parity settings |
 
 ### ⚙️ **Configuration Error Codes**
@@ -203,7 +203,7 @@ virtual hf_uart_err_t Configure(const hf_uart_config_t &config) noexcept = 0;
  * @param config [out] Current configuration structure
  * @return hf_uart_err_t error code
  * 
- * INFO: Retrieves the current UART configuration.
+ * 📊 Retrieves the current UART configuration.
  */
 virtual hf_uart_err_t GetConfiguration(hf_uart_config_t &config) const noexcept = 0;
 ```
@@ -225,7 +225,7 @@ virtual hf_uart_err_t GetConfiguration(hf_uart_config_t &config) const noexcept 
  * hf_uart_err_t result = uart.Transmit(
  *     reinterpret_cast<const uint8_t*>(message), strlen(message));
  * if (result == hf_uart_err_t::UART_SUCCESS) {
- *     printf("SUCCESS: Message transmitted\n");
+ *     printf("✅ Message transmitted\n");
  * }
  */
 virtual hf_uart_err_t Transmit(const uint8_t *data, size_t length) noexcept = 0;
@@ -246,7 +246,7 @@ virtual hf_uart_err_t Transmit(const uint8_t *data, size_t length,
  * @brief Get number of bytes available for transmission
  * @return Number of bytes that can be transmitted
  * 
- * INFO: Returns the number of bytes that can be transmitted without blocking.
+ * 📊 Returns the number of bytes that can be transmitted without blocking.
  */
 virtual size_t GetTransmitSpace() const noexcept = 0;
 ```
@@ -288,7 +288,7 @@ virtual hf_uart_err_t Receive(uint8_t *data, size_t length,
  * @brief Get number of bytes available for reception
  * @return Number of bytes available to receive
  * 
- * INFO: Returns the number of bytes available to receive without blocking.
+ * 📊 Returns the number of bytes available to receive without blocking.
  */
 virtual size_t GetReceiveSpace() const noexcept = 0;
 
@@ -301,7 +301,7 @@ virtual size_t GetReceiveSpace() const noexcept = 0;
 virtual hf_uart_err_t FlushReceive() noexcept = 0;
 ```
 
-### INFO: **Status and Capabilities**
+### 📊 **Status and Capabilities**
 
 ```cpp
 /**
@@ -309,7 +309,7 @@ virtual hf_uart_err_t FlushReceive() noexcept = 0;
  * @param status [out] Status information structure
  * @return hf_uart_err_t error code
  * 
- * INFO: Retrieves comprehensive status information about UART.
+ * 📊 Retrieves comprehensive status information about UART.
  */
 virtual hf_uart_err_t GetStatus(hf_uart_status_t &status) const noexcept = 0;
 
@@ -325,7 +325,7 @@ virtual hf_uart_err_t GetCapabilities(hf_uart_capabilities_t &capabilities) cons
 
 ---
 
-## INFO: **Data Structures**
+## 📊 **Data Structures**
 
 ### ⚙️ **UART Configuration**
 
@@ -347,7 +347,7 @@ struct hf_uart_config_t {
 };
 ```
 
-### INFO: **UART Status**
+### 📊 **UART Status**
 
 ```cpp
 struct hf_uart_status_t {
@@ -403,7 +403,7 @@ struct hf_uart_statistics_t {
 
 ---
 
-## INFO: **Usage Examples**
+## 📊 **Usage Examples**
 
 ### 📡 **Basic Serial Communication**
 
@@ -419,7 +419,7 @@ public:
         uart_ = EspUart(UART_NUM_0);
         
         if (!uart_.EnsureInitialized()) {
-            printf("ERROR: UART initialization failed\n");
+            printf("❌ UART initialization failed\n");
             return false;
         }
         
@@ -441,11 +441,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("ERROR: UART configuration failed: %s\n", HfUartErrToString(result));
+            printf("❌ UART configuration failed: %s\n", HfUartErrToString(result));
             return false;
         }
         
-        printf("SUCCESS: Serial communicator initialized\n");
+        printf("✅ Serial communicator initialized\n");
         return true;
     }
     
@@ -457,7 +457,7 @@ public:
         if (result == hf_uart_err_t::UART_SUCCESS) {
             printf("📤 Sent: %s", message);
         } else {
-            printf("ERROR: Send failed: %s\n", HfUartErrToString(result));
+            printf("❌ Send failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -469,7 +469,7 @@ public:
             buffer[max_length] = '\0';  // Null terminate
             printf("📥 Received: %s", buffer);
         } else {
-            printf("ERROR: Receive failed: %s\n", HfUartErrToString(result));
+            printf("❌ Receive failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -536,11 +536,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("ERROR: GPS configuration failed\n");
+            printf("❌ GPS configuration failed\n");
             return false;
         }
         
-        printf("SUCCESS: GPS controller initialized\n");
+        printf("✅ GPS controller initialized\n");
         return true;
     }
     
@@ -559,7 +559,7 @@ public:
             printf("⏰ GPS timeout - no data received\n");
             return false;
         } else {
-            printf("ERROR: GPS read failed: %s\n", HfUartErrToString(result));
+            printf("❌ GPS read failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -600,7 +600,7 @@ public:
         if (result == hf_uart_err_t::UART_SUCCESS) {
             printf("📤 GPS Command: %s", command);
         } else {
-            printf("ERROR: GPS command failed: %s\n", HfUartErrToString(result));
+            printf("❌ GPS command failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -657,11 +657,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("ERROR: Bluetooth configuration failed\n");
+            printf("❌ Bluetooth configuration failed\n");
             return false;
         }
         
-        printf("SUCCESS: Bluetooth controller initialized\n");
+        printf("✅ Bluetooth controller initialized\n");
         return true;
     }
     
@@ -673,7 +673,7 @@ public:
         if (result == hf_uart_err_t::UART_SUCCESS) {
             printf("📤 BT Sent: %s", data);
         } else {
-            printf("ERROR: BT send failed: %s\n", HfUartErrToString(result));
+            printf("❌ BT send failed: %s\n", HfUartErrToString(result));
         }
     }
     
@@ -688,7 +688,7 @@ public:
         } else if (result == hf_uart_err_t::UART_ERR_RECEIVE_TIMEOUT) {
             return false;  // No data available
         } else {
-            printf("ERROR: BT receive failed: %s\n", HfUartErrToString(result));
+            printf("❌ BT receive failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -759,11 +759,11 @@ public:
         
         hf_uart_err_t result = uart_.Configure(config);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("ERROR: Modbus configuration failed\n");
+            printf("❌ Modbus configuration failed\n");
             return false;
         }
         
-        printf("SUCCESS: Modbus controller initialized\n");
+        printf("✅ Modbus controller initialized\n");
         return true;
     }
     
@@ -786,7 +786,7 @@ public:
         // Send request
         hf_uart_err_t result = uart_.Transmit(request, 8);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("ERROR: Modbus request failed: %s\n", HfUartErrToString(result));
+            printf("❌ Modbus request failed: %s\n", HfUartErrToString(result));
             return false;
         }
         
@@ -802,14 +802,14 @@ public:
                     data[i] = (modbus_buffer_[3 + i * 2] << 8) | 
                               modbus_buffer_[4 + i * 2];
                 }
-                printf("SUCCESS: Read %d holding registers\n", count);
+                printf("✅ Read %d holding registers\n", count);
                 return true;
             } else {
-                printf("ERROR: Invalid Modbus response\n");
+                printf("❌ Invalid Modbus response\n");
                 return false;
             }
         } else {
-            printf("ERROR: Modbus response failed: %s\n", HfUartErrToString(result));
+            printf("❌ Modbus response failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -832,7 +832,7 @@ public:
         // Send request
         hf_uart_err_t result = uart_.Transmit(request, 8);
         if (result != hf_uart_err_t::UART_SUCCESS) {
-            printf("ERROR: Modbus write request failed: %s\n", HfUartErrToString(result));
+            printf("❌ Modbus write request failed: %s\n", HfUartErrToString(result));
             return false;
         }
         
@@ -841,14 +841,14 @@ public:
         
         if (result == hf_uart_err_t::UART_SUCCESS) {
             if (memcmp(request, modbus_buffer_, 8) == 0) {
-                printf("SUCCESS: Wrote register 0x%04X = 0x%04X\n", addr, value);
+                printf("✅ Wrote register 0x%04X = 0x%04X\n", addr, value);
                 return true;
             } else {
-                printf("ERROR: Invalid Modbus write response\n");
+                printf("❌ Invalid Modbus write response\n");
                 return false;
             }
         } else {
-            printf("ERROR: Modbus write response failed: %s\n", HfUartErrToString(result));
+            printf("❌ Modbus write response failed: %s\n", HfUartErrToString(result));
             return false;
         }
     }
@@ -875,31 +875,31 @@ private:
 
 ---
 
-## TEST: **Best Practices**
+## 🧪 **Best Practices**
 
-### SUCCESS: **Recommended Patterns**
+### ✅ **Recommended Patterns**
 
 ```cpp
-// SUCCESS: Always check initialization
+// ✅ Always check initialization
 if (!uart.EnsureInitialized()) {
-    printf("ERROR: UART initialization failed\n");
+    printf("❌ UART initialization failed\n");
     return false;
 }
 
-// SUCCESS: Use appropriate baud rates
+// ✅ Use appropriate baud rates
 // Debug: 115200
 // GPS: 9600
 // Bluetooth: 115200
 // Modbus: 9600-115200
 
-// SUCCESS: Handle timeouts gracefully
+// ✅ Handle timeouts gracefully
 hf_uart_err_t result = uart.Receive(buffer, length, 1000);
 if (result == hf_uart_err_t::UART_ERR_RECEIVE_TIMEOUT) {
     printf("⏰ No data received within timeout\n");
     return false;
 }
 
-// SUCCESS: Check buffer space before operations
+// ✅ Check buffer space before operations
 if (uart.GetReceiveSpace() > 0) {
     // Data available to receive
 }
@@ -908,38 +908,38 @@ if (uart.GetTransmitSpace() >= length) {
     // Space available to transmit
 }
 
-// SUCCESS: Use appropriate data formats
+// ✅ Use appropriate data formats
 // Most applications: 8N1 (8 data bits, no parity, 1 stop bit)
 // Modbus: 8E1 (8 data bits, even parity, 1 stop bit)
 
-// SUCCESS: Monitor statistics for system health
+// ✅ Monitor statistics for system health
 hf_uart_statistics_t stats;
 if (uart.GetStatistics(stats) == hf_uart_err_t::UART_SUCCESS) {
     if (stats.frame_errors > 10) {
-        printf("WARNING: High frame error rate detected\n");
+        printf("⚠️ High frame error rate detected\n");
     }
 }
 ```
 
-### ERROR: **Common Pitfalls**
+### ❌ **Common Pitfalls**
 
 ```cpp
-// ERROR: Don't ignore initialization
+// ❌ Don't ignore initialization
 uart.Transmit(data, length);  // May fail silently
 
-// ERROR: Don't use mismatched baud rates
+// ❌ Don't use mismatched baud rates
 // Both devices must use the same baud rate
 
-// ERROR: Don't ignore buffer overflows
+// ❌ Don't ignore buffer overflows
 // Check buffer space before large transfers
 
-// ERROR: Don't use without error checking in critical applications
+// ❌ Don't use without error checking in critical applications
 // Always check return values in safety-critical systems
 
-// ERROR: Don't forget to handle flow control
+// ❌ Don't forget to handle flow control
 // Some devices require hardware flow control
 
-// ERROR: Don't assume all data formats are supported
+// ❌ Don't assume all data formats are supported
 // Check capabilities before using specific formats
 ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,8 +18,8 @@
 - [🏗️ **Architecture**](#️-architecture)
 - [📋 **Base Classes**](#-base-classes)
 - [🔧 **Core Principles**](#-core-principles)
-- [💡 **Getting Started**](#-getting-started)
-- [🧪 **Examples**](#-examples)
+- [INFO: **Getting Started**](#-getting-started)
+- [TEST: **Examples**](#-examples)
 
 ---
 
@@ -33,7 +33,7 @@ The **HardFOC Interface Wrapper** provides a unified, platform-agnostic abstract
 - 🛡️ **Type Safety** - Strongly typed interfaces with comprehensive error handling
 - ⚡ **Performance Optimized** - Minimal overhead with direct hardware access
 - 🔧 **Extensible** - Easy to add new hardware platforms and peripherals
-- 📊 **Observable** - Built-in statistics, diagnostics, and monitoring
+- INFO: **Observable** - Built-in statistics, diagnostics, and monitoring
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
 ### 🎯 **Target Applications**
@@ -167,7 +167,7 @@ printf("Total conversions: %u\n", stats.totalConversions);
 
 ---
 
-## 💡 **Getting Started**
+## INFO: **Getting Started**
 
 ### **1. Include the Headers**
 
@@ -215,7 +215,7 @@ if (result != hf_adc_err_t::ADC_SUCCESS) {
 
 ---
 
-## 🧪 **Examples**
+## TEST: **Examples**
 
 ### **Motor Control System**
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,8 +18,8 @@
 - [🏗️ **Architecture**](#️-architecture)
 - [📋 **Base Classes**](#-base-classes)
 - [🔧 **Core Principles**](#-core-principles)
-- [INFO: **Getting Started**](#-getting-started)
-- [TEST: **Examples**](#-examples)
+- [📊 **Getting Started**](#-getting-started)
+- [🧪 **Examples**](#-examples)
 
 ---
 
@@ -33,7 +33,7 @@ The **HardFOC Interface Wrapper** provides a unified, platform-agnostic abstract
 - 🛡️ **Type Safety** - Strongly typed interfaces with comprehensive error handling
 - ⚡ **Performance Optimized** - Minimal overhead with direct hardware access
 - 🔧 **Extensible** - Easy to add new hardware platforms and peripherals
-- INFO: **Observable** - Built-in statistics, diagnostics, and monitoring
+- 📊 **Observable** - Built-in statistics, diagnostics, and monitoring
 - 🧵 **Thread Safe** - Designed for multi-threaded applications
 
 ### 🎯 **Target Applications**
@@ -167,7 +167,7 @@ printf("Total conversions: %u\n", stats.totalConversions);
 
 ---
 
-## INFO: **Getting Started**
+## 📊 **Getting Started**
 
 ### **1. Include the Headers**
 
@@ -215,7 +215,7 @@ if (result != hf_adc_err_t::ADC_SUCCESS) {
 
 ---
 
-## TEST: **Examples**
+## 🧪 **Examples**
 
 ### **Motor Control System**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,11 +20,11 @@
 - [🎯 **Overview**](#-overview)
 - [🏗️ **Architecture**](#️-architecture) 
 - [🔧 **Type System**](#-type-system)
-- [READ: **API Reference**](#-api-reference)
+- [📖 **API Reference**](#-api-reference)
 - [🚀 **Quick Start**](#-quick-start)
 - [🗺️ **Component Map**](ComponentMap.md)
 - [📋 **User Guides**](#-user-guides)
-- [INFO: **Examples**](#-examples)
+- [📊 **Examples**](#-examples)
 - [🔧 **Development**](#-development)
 - [🕸️ **GitHub Pages**](guides/github-pages.md)
 
@@ -40,7 +40,7 @@ The **HardFOC Internal Interface Wrapper** provides a comprehensive, platform-ag
 - ⚡ **High Performance** - Optimized for real-time motor control applications  
 - 🔒 **Thread Safe** - Built-in synchronization for multi-threaded environments
 - 🔌 **Platform Agnostic** - Easy porting between different MCU families
-- INFO: **ESP32-C6 Optimized** - Full support for ESP32-C6 capabilities
+- 📊 **ESP32-C6 Optimized** - Full support for ESP32-C6 capabilities
 - 🛡️ **Robust Error Handling** - Comprehensive error codes and validation
 - 💾 **Memory Efficient** - Minimal overhead with lazy initialization
 
@@ -49,7 +49,7 @@ The **HardFOC Internal Interface Wrapper** provides a comprehensive, platform-ag
 | Component | Base Class | MCU Implementation | Thread-Safe Wrapper |
 |-----------|------------|-------------------|---------------------|
 | 🔌 **GPIO** | `BaseGpio` | `McuDigitalGpio` | `SfGpio` |
-| INFO: **ADC** | `BaseAdc` | `McuAdc` | `SfAdc` |
+| 📊 **ADC** | `BaseAdc` | `McuAdc` | `SfAdc` |
 | 🔄 **I2C** | `BaseI2c` | `McuI2c` | `SfI2cBus` |
 | ⚡ **SPI** | `BaseSpi` | `McuSpi` | `SfSpiBus` |
 | 📡 **UART** | `BaseUart` | `McuUart` | `SfUartDriver` |
@@ -142,7 +142,7 @@ The HardFOC Internal Interface Wrapper implements a comprehensive type wrapping 
 - **🎯 Clarity**: Clear distinction between platform types and wrapped types
 - **🛡️ Safety**: Prevents type mismatches and improves compile-time checking
 
-### INFO: **Type Definitions**
+### 📊 **Type Definitions**
 
 ```cpp
 // Integer type wrappers
@@ -167,18 +167,18 @@ using hf_frequency_hz_t = hf_u32_t; // Frequency in Hz
 
 For detailed information about the type wrapping system, see:
 - [🔧 **Type Wrapping System Guide**](TypeWrappingSystem.md) - Comprehensive guide with examples
-- [INFO: **HardwareTypes.h**](../inc/base/HardwareTypes.h) - Core type definitions
+- [📊 **HardwareTypes.h**](../inc/base/HardwareTypes.h) - Core type definitions
 
 ---
 
-## READ: **API Reference**
+## 📖 **API Reference**
 
 ### 🏛️ **Base Classes**
 
 | Class | Description | Key Features |
 |-------|-------------|--------------|
 | [`BaseGpio`](api/BaseGpio.md) | 🔌 GPIO abstraction | Dynamic mode switching, pull resistors, interrupts |
-| [`BaseAdc`](api/BaseAdc.md) | INFO: ADC abstraction | Multi-channel, calibration, voltage conversion |
+| [`BaseAdc`](api/BaseAdc.md) | 📊 ADC abstraction | Multi-channel, calibration, voltage conversion |
 | [`BaseI2c`](api/BaseI2c.md) | 🔄 I2C communication | Master mode, device scanning, error recovery |
 | [`BaseSpi`](api/BaseSpi.md) | ⚡ SPI communication | Full-duplex, configurable modes, DMA support |
 | [`BaseUart`](api/BaseUart.md) | 📡 UART communication | Async I/O, flow control, configurable parameters |
@@ -191,7 +191,7 @@ For detailed information about the type wrapping system, see:
 | Class | Description | Platform Support |
 |-------|-------------|------------------|
 | [`McuDigitalGpio`](api/McuDigitalGpio.md) | 🔌 ESP32-C6 GPIO | Native GPIO pins with validation |
-| [`McuAdc`](api/McuAdc.md) | INFO: ESP32-C6 ADC | ADC1/ADC2 with calibration |
+| [`McuAdc`](api/McuAdc.md) | 📊 ESP32-C6 ADC | ADC1/ADC2 with calibration |
 | [`McuI2c`](api/McuI2c.md) | 🔄 ESP32-C6 I2C | Hardware I2C controller |
 | [`McuSpi`](api/McuSpi.md) | ⚡ ESP32-C6 SPI | SPI2/SPI3 with DMA support |
 | [`McuUart`](api/McuUart.md) | 📡 ESP32-C6 UART | Hardware UART with DMA |
@@ -204,7 +204,7 @@ For detailed information about the type wrapping system, see:
 | Class | Description | Synchronization |
 |-------|-------------|-----------------|
 | [`SfGpio`](api/SfGpio.md) | 🔌 Thread-safe GPIO | Mutex protection |
-| [`SfAdc`](api/SfAdc.md) | INFO: Thread-safe ADC | Lock-free reads, batch operations |
+| [`SfAdc`](api/SfAdc.md) | 📊 Thread-safe ADC | Lock-free reads, batch operations |
 | [`SfI2cBus`](api/SfI2cBus.md) | 🔄 Thread-safe I2C | Transaction-level locking |
 | [`SfSpiBus`](api/SfSpiBus.md) | ⚡ Thread-safe SPI | Transfer-level locking |
 | [`SfUartDriver`](api/SfUartDriver.md) | 📡 Thread-safe UART | Buffer-level protection |
@@ -258,7 +258,7 @@ McuDigitalGpio led_pin(GPIO_NUM_2);
 led_pin.SetAsOutput();
 led_pin.SetHigh();
 
-// INFO: ADC Example  
+// 📊 ADC Example  
 McuAdc adc;
 uint16_t raw_value = adc.ReadRaw(ADC_UNIT_1, ADC_CHANNEL_0);
 float voltage = adc.ReadVoltage(ADC_UNIT_1, ADC_CHANNEL_0);
@@ -279,7 +279,7 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 | Guide | Description | Level |
 |-------|-------------|-------|
 | [🔌 **GPIO Operations**](guides/gpio-guide.md) | Complete GPIO usage guide | Beginner |
-| [INFO: **ADC & Voltage Measurement**](guides/adc-guide.md) | ADC configuration and calibration | Intermediate |
+| [📊 **ADC & Voltage Measurement**](guides/adc-guide.md) | ADC configuration and calibration | Intermediate |
 | [🔄 **I2C Communication**](guides/i2c-guide.md) | I2C device integration | Intermediate |
 | [⚡ **SPI Communication**](guides/spi-guide.md) | High-speed SPI operations | Intermediate |
 | [🚗 **CAN Bus Integration**](guides/can-guide.md) | Automotive CAN communication | Advanced |
@@ -292,19 +292,19 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 | Guide | Description | Audience |
 |-------|-------------|----------|
 | [🏗️ **Porting Guide**](guides/porting-guide.md) | Adding new MCU platforms | Developers |
-| [TEST: **Testing Framework**](guides/testing-guide.md) | Unit testing and validation | QA Engineers |
+| [🧪 **Testing Framework**](guides/testing-guide.md) | Unit testing and validation | QA Engineers |
 | [⚡ **Performance Optimization**](guides/performance-guide.md) | Real-time optimization | Advanced Users |
 | [🛡️ **Error Handling**](guides/error-handling.md) | Robust error management | All Users |
 | [🕸️ **GitHub Pages Workflow**](guides/github-pages.md) | Publish docs automatically | All Users |
 
 ---
 
-## INFO: **Examples**
+## 📊 **Examples**
 
 ### 🎯 **Basic Examples**
 
 - [🔌 **Simple GPIO Control**](examples/basic-gpio.md) - LED control and button reading
-- [INFO: **ADC Voltage Monitoring**](examples/basic-adc.md) - Sensor data acquisition
+- [📊 **ADC Voltage Monitoring**](examples/basic-adc.md) - Sensor data acquisition
 - [🔄 **I2C Device Communication**](examples/basic-i2c.md) - Temperature sensor integration
 
 ### 🚀 **Advanced Examples**
@@ -314,7 +314,7 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 - [📻 **WS2812 LED Control**](examples/ws2812-pio.md) - Programmable I/O for LED strips
 - [🔒 **Multi-threaded Sensor Hub**](examples/sensor-hub.md) - Thread-safe sensor management
 
-### TEST: **Integration Examples**
+### 🧪 **Integration Examples**
 
 - [🏭 **Industrial I/O Module**](examples/industrial-io.md) - Complete I/O system
 - [🚀 **Real-time Data Logger**](examples/data-logger.md) - High-speed data acquisition
@@ -337,11 +337,11 @@ idf.py build
 idf.py -p /dev/ttyUSB0 flash monitor
 ```
 
-### TEST: **Testing**
+### 🧪 **Testing**
 
 Unit tests are not included in this repository.
 
-### INFO: **Documentation Generation**
+### 📊 **Documentation Generation**
 
 ```bash
 # Generate Doxygen documentation
@@ -364,8 +364,8 @@ This project is licensed under the **GNU General Public License v3.0** - see the
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details on:
 
 - 📋 Code style and standards
-- TEST: Testing requirements  
-- READ: Documentation updates
+- 🧪 Testing requirements  
+- 📖 Documentation updates
 - 🐛 Bug reporting
 - ✨ Feature requests
 
@@ -373,7 +373,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 📞 **Support**
 
-- READ: **Documentation**: This comprehensive guide
+- 📖 **Documentation**: This comprehensive guide
 - 🐛 **Issues**: [GitHub Issues](../../issues)
 - 💬 **Discussions**: [GitHub Discussions](../../discussions)
 - 📧 **Email**: [support@hardfoc.com](mailto:support@hardfoc.com)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,11 +20,11 @@
 - [🎯 **Overview**](#-overview)
 - [🏗️ **Architecture**](#️-architecture) 
 - [🔧 **Type System**](#-type-system)
-- [📖 **API Reference**](#-api-reference)
+- [READ: **API Reference**](#-api-reference)
 - [🚀 **Quick Start**](#-quick-start)
 - [🗺️ **Component Map**](ComponentMap.md)
 - [📋 **User Guides**](#-user-guides)
-- [💡 **Examples**](#-examples)
+- [INFO: **Examples**](#-examples)
 - [🔧 **Development**](#-development)
 - [🕸️ **GitHub Pages**](guides/github-pages.md)
 
@@ -40,7 +40,7 @@ The **HardFOC Internal Interface Wrapper** provides a comprehensive, platform-ag
 - ⚡ **High Performance** - Optimized for real-time motor control applications  
 - 🔒 **Thread Safe** - Built-in synchronization for multi-threaded environments
 - 🔌 **Platform Agnostic** - Easy porting between different MCU families
-- 📊 **ESP32-C6 Optimized** - Full support for ESP32-C6 capabilities
+- INFO: **ESP32-C6 Optimized** - Full support for ESP32-C6 capabilities
 - 🛡️ **Robust Error Handling** - Comprehensive error codes and validation
 - 💾 **Memory Efficient** - Minimal overhead with lazy initialization
 
@@ -49,7 +49,7 @@ The **HardFOC Internal Interface Wrapper** provides a comprehensive, platform-ag
 | Component | Base Class | MCU Implementation | Thread-Safe Wrapper |
 |-----------|------------|-------------------|---------------------|
 | 🔌 **GPIO** | `BaseGpio` | `McuDigitalGpio` | `SfGpio` |
-| 📊 **ADC** | `BaseAdc` | `McuAdc` | `SfAdc` |
+| INFO: **ADC** | `BaseAdc` | `McuAdc` | `SfAdc` |
 | 🔄 **I2C** | `BaseI2c` | `McuI2c` | `SfI2cBus` |
 | ⚡ **SPI** | `BaseSpi` | `McuSpi` | `SfSpiBus` |
 | 📡 **UART** | `BaseUart` | `McuUart` | `SfUartDriver` |
@@ -142,7 +142,7 @@ The HardFOC Internal Interface Wrapper implements a comprehensive type wrapping 
 - **🎯 Clarity**: Clear distinction between platform types and wrapped types
 - **🛡️ Safety**: Prevents type mismatches and improves compile-time checking
 
-### 📊 **Type Definitions**
+### INFO: **Type Definitions**
 
 ```cpp
 // Integer type wrappers
@@ -167,18 +167,18 @@ using hf_frequency_hz_t = hf_u32_t; // Frequency in Hz
 
 For detailed information about the type wrapping system, see:
 - [🔧 **Type Wrapping System Guide**](TypeWrappingSystem.md) - Comprehensive guide with examples
-- [📊 **HardwareTypes.h**](../inc/base/HardwareTypes.h) - Core type definitions
+- [INFO: **HardwareTypes.h**](../inc/base/HardwareTypes.h) - Core type definitions
 
 ---
 
-## 📖 **API Reference**
+## READ: **API Reference**
 
 ### 🏛️ **Base Classes**
 
 | Class | Description | Key Features |
 |-------|-------------|--------------|
 | [`BaseGpio`](api/BaseGpio.md) | 🔌 GPIO abstraction | Dynamic mode switching, pull resistors, interrupts |
-| [`BaseAdc`](api/BaseAdc.md) | 📊 ADC abstraction | Multi-channel, calibration, voltage conversion |
+| [`BaseAdc`](api/BaseAdc.md) | INFO: ADC abstraction | Multi-channel, calibration, voltage conversion |
 | [`BaseI2c`](api/BaseI2c.md) | 🔄 I2C communication | Master mode, device scanning, error recovery |
 | [`BaseSpi`](api/BaseSpi.md) | ⚡ SPI communication | Full-duplex, configurable modes, DMA support |
 | [`BaseUart`](api/BaseUart.md) | 📡 UART communication | Async I/O, flow control, configurable parameters |
@@ -191,7 +191,7 @@ For detailed information about the type wrapping system, see:
 | Class | Description | Platform Support |
 |-------|-------------|------------------|
 | [`McuDigitalGpio`](api/McuDigitalGpio.md) | 🔌 ESP32-C6 GPIO | Native GPIO pins with validation |
-| [`McuAdc`](api/McuAdc.md) | 📊 ESP32-C6 ADC | ADC1/ADC2 with calibration |
+| [`McuAdc`](api/McuAdc.md) | INFO: ESP32-C6 ADC | ADC1/ADC2 with calibration |
 | [`McuI2c`](api/McuI2c.md) | 🔄 ESP32-C6 I2C | Hardware I2C controller |
 | [`McuSpi`](api/McuSpi.md) | ⚡ ESP32-C6 SPI | SPI2/SPI3 with DMA support |
 | [`McuUart`](api/McuUart.md) | 📡 ESP32-C6 UART | Hardware UART with DMA |
@@ -204,7 +204,7 @@ For detailed information about the type wrapping system, see:
 | Class | Description | Synchronization |
 |-------|-------------|-----------------|
 | [`SfGpio`](api/SfGpio.md) | 🔌 Thread-safe GPIO | Mutex protection |
-| [`SfAdc`](api/SfAdc.md) | 📊 Thread-safe ADC | Lock-free reads, batch operations |
+| [`SfAdc`](api/SfAdc.md) | INFO: Thread-safe ADC | Lock-free reads, batch operations |
 | [`SfI2cBus`](api/SfI2cBus.md) | 🔄 Thread-safe I2C | Transaction-level locking |
 | [`SfSpiBus`](api/SfSpiBus.md) | ⚡ Thread-safe SPI | Transfer-level locking |
 | [`SfUartDriver`](api/SfUartDriver.md) | 📡 Thread-safe UART | Buffer-level protection |
@@ -258,7 +258,7 @@ McuDigitalGpio led_pin(GPIO_NUM_2);
 led_pin.SetAsOutput();
 led_pin.SetHigh();
 
-// 📊 ADC Example  
+// INFO: ADC Example  
 McuAdc adc;
 uint16_t raw_value = adc.ReadRaw(ADC_UNIT_1, ADC_CHANNEL_0);
 float voltage = adc.ReadVoltage(ADC_UNIT_1, ADC_CHANNEL_0);
@@ -279,7 +279,7 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 | Guide | Description | Level |
 |-------|-------------|-------|
 | [🔌 **GPIO Operations**](guides/gpio-guide.md) | Complete GPIO usage guide | Beginner |
-| [📊 **ADC & Voltage Measurement**](guides/adc-guide.md) | ADC configuration and calibration | Intermediate |
+| [INFO: **ADC & Voltage Measurement**](guides/adc-guide.md) | ADC configuration and calibration | Intermediate |
 | [🔄 **I2C Communication**](guides/i2c-guide.md) | I2C device integration | Intermediate |
 | [⚡ **SPI Communication**](guides/spi-guide.md) | High-speed SPI operations | Intermediate |
 | [🚗 **CAN Bus Integration**](guides/can-guide.md) | Automotive CAN communication | Advanced |
@@ -292,19 +292,19 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 | Guide | Description | Audience |
 |-------|-------------|----------|
 | [🏗️ **Porting Guide**](guides/porting-guide.md) | Adding new MCU platforms | Developers |
-| [🧪 **Testing Framework**](guides/testing-guide.md) | Unit testing and validation | QA Engineers |
+| [TEST: **Testing Framework**](guides/testing-guide.md) | Unit testing and validation | QA Engineers |
 | [⚡ **Performance Optimization**](guides/performance-guide.md) | Real-time optimization | Advanced Users |
 | [🛡️ **Error Handling**](guides/error-handling.md) | Robust error management | All Users |
 | [🕸️ **GitHub Pages Workflow**](guides/github-pages.md) | Publish docs automatically | All Users |
 
 ---
 
-## 💡 **Examples**
+## INFO: **Examples**
 
 ### 🎯 **Basic Examples**
 
 - [🔌 **Simple GPIO Control**](examples/basic-gpio.md) - LED control and button reading
-- [📊 **ADC Voltage Monitoring**](examples/basic-adc.md) - Sensor data acquisition
+- [INFO: **ADC Voltage Monitoring**](examples/basic-adc.md) - Sensor data acquisition
 - [🔄 **I2C Device Communication**](examples/basic-i2c.md) - Temperature sensor integration
 
 ### 🚀 **Advanced Examples**
@@ -314,7 +314,7 @@ i2c_bus.ReadFrom(0x48, data, sizeof(data));
 - [📻 **WS2812 LED Control**](examples/ws2812-pio.md) - Programmable I/O for LED strips
 - [🔒 **Multi-threaded Sensor Hub**](examples/sensor-hub.md) - Thread-safe sensor management
 
-### 🧪 **Integration Examples**
+### TEST: **Integration Examples**
 
 - [🏭 **Industrial I/O Module**](examples/industrial-io.md) - Complete I/O system
 - [🚀 **Real-time Data Logger**](examples/data-logger.md) - High-speed data acquisition
@@ -337,11 +337,11 @@ idf.py build
 idf.py -p /dev/ttyUSB0 flash monitor
 ```
 
-### 🧪 **Testing**
+### TEST: **Testing**
 
 Unit tests are not included in this repository.
 
-### 📊 **Documentation Generation**
+### INFO: **Documentation Generation**
 
 ```bash
 # Generate Doxygen documentation
@@ -364,8 +364,8 @@ This project is licensed under the **GNU General Public License v3.0** - see the
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details on:
 
 - 📋 Code style and standards
-- 🧪 Testing requirements  
-- 📖 Documentation updates
+- TEST: Testing requirements  
+- READ: Documentation updates
 - 🐛 Bug reporting
 - ✨ Feature requests
 
@@ -373,7 +373,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 📞 **Support**
 
-- 📖 **Documentation**: This comprehensive guide
+- READ: **Documentation**: This comprehensive guide
 - 🐛 **Issues**: [GitHub Issues](../../issues)
 - 💬 **Discussions**: [GitHub Discussions](../../discussions)
 - 📧 **Email**: [support@hardfoc.com](mailto:support@hardfoc.com)

--- a/examples/esp32/main/advanced_pwm_example.cpp
+++ b/examples/esp32/main/advanced_pwm_example.cpp
@@ -45,23 +45,45 @@ static const char* TAG = "AdvancedPwmExample";
 // CONFIGURATION CONSTANTS
 //==============================================================================
 
-// PWM Configuration for different use cases
-static constexpr hf_u32_t LED_FREQUENCY_HZ = 1000;    ///< LED PWM frequency
-static constexpr hf_u32_t MOTOR_FREQUENCY_HZ = 20000; ///< Motor PWM frequency
-static constexpr hf_u32_t SERVO_FREQUENCY_HZ = 50;    ///< Servo PWM frequency
-static constexpr hf_u32_t AUDIO_FREQUENCY_HZ = 440;   ///< Audio PWM frequency
+// PWM Configuration for different use cases organized as arrays
+struct PwmChannelParams {
+    hf_u32_t frequency_hz;
+    hf_u8_t resolution_bits;
+};
 
-static constexpr hf_u8_t LED_RESOLUTION_BITS = 8;    ///< LED resolution
-static constexpr hf_u8_t MOTOR_RESOLUTION_BITS = 12; ///< Motor resolution
-static constexpr hf_u8_t SERVO_RESOLUTION_BITS = 16; ///< Servo resolution
-static constexpr hf_u8_t AUDIO_RESOLUTION_BITS = 10; ///< Audio resolution
+static constexpr std::array<PwmChannelParams, static_cast<size_t>(PwmPinType::PIN_COUNT)> PWM_CHANNEL_PARAMS = {{
+    {1000, 8},   // LED: 1kHz, 8-bit resolution
+    {20000, 12}, // MOTOR_A: 20kHz, 12-bit resolution  
+    {20000, 12}, // MOTOR_B: 20kHz, 12-bit resolution
+    {50, 16},    // SERVO: 50Hz, 16-bit resolution
+    {440, 10}    // AUDIO: 440Hz, 10-bit resolution
+}};
 
-// GPIO Pin assignments (ESP32-C6 specific)
-static constexpr hf_pin_num_t LED_PIN = 2;     ///< LED output pin
-static constexpr hf_pin_num_t MOTOR_A_PIN = 3; ///< Motor phase A
-static constexpr hf_pin_num_t MOTOR_B_PIN = 4; ///< Motor phase B
-static constexpr hf_pin_num_t SERVO_PIN = 5;   ///< Servo control pin
-static constexpr hf_pin_num_t AUDIO_PIN = 6;   ///< Audio output pin
+// GPIO Pin assignments (ESP32-C6 specific) organized as arrays
+enum class PwmPinType : size_t {
+    LED = 0,
+    MOTOR_A = 1,
+    MOTOR_B = 2,
+    SERVO = 3,
+    AUDIO = 4,
+    PIN_COUNT = 5
+};
+
+static constexpr std::array<hf_pin_num_t, static_cast<size_t>(PwmPinType::PIN_COUNT)> PWM_PINS = {
+    2, // LED output pin
+    3, // Motor phase A
+    4, // Motor phase B  
+    5, // Servo control pin
+    6  // Audio output pin
+};
+
+static constexpr std::array<const char*, static_cast<size_t>(PwmPinType::PIN_COUNT)> PWM_PIN_NAMES = {
+    "LED",
+    "MOTOR_A",
+    "MOTOR_B", 
+    "SERVO",
+    "AUDIO"
+};
 
 //==============================================================================
 // GLOBAL VARIABLES
@@ -175,9 +197,9 @@ bool ConfigureLedChannel(EspPwm& pwm) {
 
   // Configure LED channel
   hf_pwm_channel_config_t led_config;
-  led_config.output_pin = LED_PIN;
-  led_config.frequency_hz = LED_FREQUENCY_HZ;
-  led_config.resolution_bits = LED_RESOLUTION_BITS;
+  led_config.output_pin = PWM_PINS[static_cast<size_t>(PwmPinType::LED)];
+  led_config.frequency_hz = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::LED)].frequency_hz;
+  led_config.resolution_bits = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::LED)].resolution_bits;
   led_config.output_mode = hf_pwm_output_mode_t::Normal;
   led_config.alignment = hf_pwm_alignment_t::EdgeAligned;
   led_config.idle_state = hf_pwm_idle_state_t::Low;
@@ -203,9 +225,9 @@ bool ConfigureMotorChannels(EspPwm& pwm) {
 
   // Configure motor phase A
   hf_pwm_channel_config_t motor_a_config;
-  motor_a_config.output_pin = MOTOR_A_PIN;
-  motor_a_config.frequency_hz = MOTOR_FREQUENCY_HZ;
-  motor_a_config.resolution_bits = MOTOR_RESOLUTION_BITS;
+  motor_a_config.output_pin = PWM_PINS[static_cast<size_t>(PwmPinType::MOTOR_A)];
+  motor_a_config.frequency_hz = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::MOTOR_A)].frequency_hz;
+  motor_a_config.resolution_bits = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::MOTOR_A)].resolution_bits;
   motor_a_config.output_mode = hf_pwm_output_mode_t::Normal;
   motor_a_config.alignment = hf_pwm_alignment_t::EdgeAligned;
   motor_a_config.idle_state = hf_pwm_idle_state_t::Low;
@@ -219,9 +241,9 @@ bool ConfigureMotorChannels(EspPwm& pwm) {
 
   // Configure motor phase B
   hf_pwm_channel_config_t motor_b_config;
-  motor_b_config.output_pin = MOTOR_B_PIN;
-  motor_b_config.frequency_hz = MOTOR_FREQUENCY_HZ;
-  motor_b_config.resolution_bits = MOTOR_RESOLUTION_BITS;
+  motor_b_config.output_pin = PWM_PINS[static_cast<size_t>(PwmPinType::MOTOR_B)];
+  motor_b_config.frequency_hz = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::MOTOR_B)].frequency_hz;
+  motor_b_config.resolution_bits = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::MOTOR_B)].resolution_bits;
   motor_b_config.output_mode = hf_pwm_output_mode_t::Normal;
   motor_b_config.alignment = hf_pwm_alignment_t::EdgeAligned;
   motor_b_config.idle_state = hf_pwm_idle_state_t::Low;
@@ -253,9 +275,9 @@ bool ConfigureServoChannel(EspPwm& pwm) {
 
   // Configure servo channel
   hf_pwm_channel_config_t servo_config;
-  servo_config.output_pin = SERVO_PIN;
-  servo_config.frequency_hz = SERVO_FREQUENCY_HZ;
-  servo_config.resolution_bits = SERVO_RESOLUTION_BITS;
+  servo_config.output_pin = PWM_PINS[static_cast<size_t>(PwmPinType::SERVO)];
+  servo_config.frequency_hz = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::SERVO)].frequency_hz;
+  servo_config.resolution_bits = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::SERVO)].resolution_bits;
   servo_config.output_mode = hf_pwm_output_mode_t::Normal;
   servo_config.alignment = hf_pwm_alignment_t::EdgeAligned;
   servo_config.idle_state = hf_pwm_idle_state_t::Low;
@@ -281,9 +303,9 @@ bool ConfigureAudioChannel(EspPwm& pwm) {
 
   // Configure audio channel
   hf_pwm_channel_config_t audio_config;
-  audio_config.output_pin = AUDIO_PIN;
-  audio_config.frequency_hz = AUDIO_FREQUENCY_HZ;
-  audio_config.resolution_bits = AUDIO_RESOLUTION_BITS;
+  audio_config.output_pin = PWM_PINS[static_cast<size_t>(PwmPinType::AUDIO)];
+  audio_config.frequency_hz = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::AUDIO)].frequency_hz;
+  audio_config.resolution_bits = PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::AUDIO)].resolution_bits;
   audio_config.output_mode = hf_pwm_output_mode_t::Normal;
   audio_config.alignment = hf_pwm_alignment_t::EdgeAligned;
   audio_config.idle_state = hf_pwm_idle_state_t::Low;
@@ -457,7 +479,7 @@ void DemonstrateAudioGeneration(EspPwm& pwm) {
   }
 
   // Return to original frequency
-  if (pwm.SetFrequency(4, AUDIO_FREQUENCY_HZ) != hf_pwm_err_t::PWM_SUCCESS) {
+  if (pwm.SetFrequency(4, PWM_CHANNEL_PARAMS[static_cast<size_t>(PwmPinType::AUDIO)].frequency_hz) != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to restore audio frequency");
     return;
   }

--- a/examples/memory_utils_test.cpp
+++ b/examples/memory_utils_test.cpp
@@ -107,7 +107,7 @@ void testLargeAllocation() {
     ESP_LOGI(TAG, "=== Testing large allocation (should fail gracefully) ===");
     
     // Try to allocate an impossibly large amount of memory
-    constexpr size_t HUGE_SIZE = SIZE_MAX / 2;
+    constexpr size_t HUGE_SIZE = SIZE_MAX - 1;
     auto huge_buffer = hf::utils::make_unique_array_nothrow<char>(HUGE_SIZE);
     
     if (!huge_buffer) {

--- a/examples/memory_utils_test.cpp
+++ b/examples/memory_utils_test.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file memory_utils_test.cpp
+ * @brief Test program demonstrating make_unique_nothrow functionality
+ * 
+ * This example shows how to use the make_unique_nothrow template for
+ * exception-free memory allocation with unique_ptr.
+ * 
+ * @author HardFOC Team
+ * @date 2025
+ * @copyright HardFOC
+ */
+
+#include "utils/memory_utils.h"
+#include <iostream>
+#include <vector>
+
+// Test class with constructor parameters
+class TestDevice {
+private:
+    int id_;
+    std::string name_;
+    
+public:
+    TestDevice(int id, const std::string& name) : id_(id), name_(name) {
+        std::cout << "TestDevice created: ID=" << id_ << ", Name=" << name_ << std::endl;
+    }
+    
+    ~TestDevice() {
+        std::cout << "TestDevice destroyed: ID=" << id_ << ", Name=" << name_ << std::endl;
+    }
+    
+    int getId() const { return id_; }
+    const std::string& getName() const { return name_; }
+};
+
+// Function demonstrating make_unique_nothrow usage
+bool createAndTestDevice(int id, const std::string& name) {
+    std::cout << "\n=== Testing make_unique_nothrow for single object ===" << std::endl;
+    
+    // Create device using nothrow allocation
+    auto device = hf::utils::make_unique_nothrow<TestDevice>(id, name);
+    if (!device) {
+        std::cout << "❌ Failed to allocate memory for TestDevice" << std::endl;
+        return false;
+    }
+    
+    std::cout << "✅ Device created successfully" << std::endl;
+    std::cout << "   Device ID: " << device->getId() << std::endl;
+    std::cout << "   Device Name: " << device->getName() << std::endl;
+    
+    return true;
+    // device automatically destroyed when going out of scope
+}
+
+// Function demonstrating array allocation
+bool createAndTestArray(size_t size) {
+    std::cout << "\n=== Testing make_unique_array_nothrow ===" << std::endl;
+    
+    // Create array using nothrow allocation
+    auto buffer = hf::utils::make_unique_array_nothrow<int>(size);
+    if (!buffer) {
+        std::cout << "❌ Failed to allocate memory for array of size " << size << std::endl;
+        return false;
+    }
+    
+    std::cout << "✅ Array allocated successfully (size: " << size << ")" << std::endl;
+    
+    // Initialize array with some values
+    for (size_t i = 0; i < size; ++i) {
+        buffer[i] = static_cast<int>(i * 2);
+    }
+    
+    // Print first few values
+    std::cout << "   First few values: ";
+    for (size_t i = 0; i < std::min(size, size_t(5)); ++i) {
+        std::cout << buffer[i] << " ";
+    }
+    std::cout << std::endl;
+    
+    return true;
+    // buffer automatically destroyed when going out of scope
+}
+
+// Function demonstrating error handling for large allocations
+void testLargeAllocation() {
+    std::cout << "\n=== Testing large allocation (should fail gracefully) ===" << std::endl;
+    
+    // Try to allocate an impossibly large amount of memory
+    constexpr size_t HUGE_SIZE = SIZE_MAX / 2;
+    auto huge_buffer = hf::utils::make_unique_array_nothrow<char>(HUGE_SIZE);
+    
+    if (!huge_buffer) {
+        std::cout << "✅ Large allocation failed gracefully (as expected)" << std::endl;
+        std::cout << "   No exception thrown, returned nullptr instead" << std::endl;
+    } else {
+        std::cout << "⚠️  Unexpected: Large allocation succeeded" << std::endl;
+    }
+}
+
+// Function demonstrating vector of unique_ptrs
+void testVectorOfUniquePtr() {
+    std::cout << "\n=== Testing vector of unique_ptr ===" << std::endl;
+    
+    std::vector<std::unique_ptr<TestDevice>> devices;
+    
+    // Create multiple devices
+    for (int i = 1; i <= 3; ++i) {
+        auto device = hf::utils::make_unique_nothrow<TestDevice>(i, "Device_" + std::to_string(i));
+        if (device) {
+            devices.push_back(std::move(device));
+            std::cout << "✅ Added device " << i << " to vector" << std::endl;
+        } else {
+            std::cout << "❌ Failed to create device " << i << std::endl;
+        }
+    }
+    
+    std::cout << "📊 Vector contains " << devices.size() << " devices" << std::endl;
+    
+    // Devices will be automatically destroyed when vector goes out of scope
+}
+
+int main() {
+    std::cout << "🧪 HardFOC Memory Utils Test Program" << std::endl;
+    std::cout << "=====================================" << std::endl;
+    
+    // Test 1: Single object allocation
+    if (!createAndTestDevice(42, "TestSensor")) {
+        return 1;
+    }
+    
+    // Test 2: Array allocation
+    if (!createAndTestArray(10)) {
+        return 1;
+    }
+    
+    // Test 3: Large allocation (failure test)
+    testLargeAllocation();
+    
+    // Test 4: Vector of unique_ptrs
+    testVectorOfUniquePtr();
+    
+    std::cout << "\n🎉 All tests completed successfully!" << std::endl;
+    std::cout << "💡 No exceptions were thrown, all memory was managed safely" << std::endl;
+    
+    return 0;
+}

--- a/examples/wifi_bluetooth_example.cpp
+++ b/examples/wifi_bluetooth_example.cpp
@@ -84,27 +84,29 @@ public:
      WiFiBluetoothDemo() : m_demo_running(false) {
      ESP_LOGI(TAG_MAIN, "=== HardFOC WiFi & Bluetooth Demo ===");
     
-    // Create ESP32-specific advanced configurations
-    EspWifiAdvancedConfig wifi_config = {};
-    wifi_config.enable_power_save = true;
-    wifi_config.power_save_type = WIFI_PS_MIN_MODEM;
-    wifi_config.tx_power = 15; // 15 dBm
-    wifi_config.bandwidth = WIFI_BW_HT20;
-    wifi_config.enable_wpa3_transition = true;
-    wifi_config.enable_11k = true;
-    wifi_config.enable_11r = true;
-    wifi_config.enable_11v = true;
+    // Create ESP32-specific advanced configurations using designated initializers
+    constexpr EspWifiAdvancedConfig wifi_config = {
+        .enable_power_save = true,
+        .power_save_type = WIFI_PS_MIN_MODEM,
+        .tx_power = 15, // 15 dBm
+        .bandwidth = WIFI_BW_HT20,
+        .enable_wpa3_transition = true,
+        .enable_11k = true,
+        .enable_11r = true,
+        .enable_11v = true
+    };
     
-    EspBluetoothAdvancedConfig bt_config = {};
-    bt_config.enable_power_save = true;
-    bt_config.tx_power_level = ESP_PWR_LVL_P3; // +3 dBm
-    bt_config.max_connections = 4;
-    bt_config.enable_gatt_server = true;
-    bt_config.enable_gatt_client = true;
-    bt_config.enable_spp = true;
-    bt_config.enable_secure_connections = true;
-    bt_config.enable_privacy = true;
-    bt_config.io_capability = ESP_IO_CAP_NO;
+    constexpr EspBluetoothAdvancedConfig bt_config = {
+        .enable_power_save = true,
+        .tx_power_level = ESP_PWR_LVL_P3, // +3 dBm
+        .max_connections = 4,
+        .enable_gatt_server = true,
+        .enable_gatt_client = true,
+        .enable_spp = true,
+        .enable_secure_connections = true,
+        .enable_privacy = true,
+        .io_capability = ESP_IO_CAP_NO
+    };
     
          // Create instances with advanced configurations using nothrow allocation
      m_wifi = hf::utils::make_unique_nothrow<EspWifi>(&wifi_config);

--- a/examples/wifi_bluetooth_example.cpp
+++ b/examples/wifi_bluetooth_example.cpp
@@ -30,6 +30,7 @@
 #include "BaseBluetooth.h"
 #include "mcu/esp32/EspWifi.h"
 #include "mcu/esp32/EspBluetooth.h"
+#include "utils/memory_utils.h"
 
 // ESP-IDF headers
 #ifdef __cplusplus
@@ -105,10 +106,18 @@ public:
     bt_config.enable_privacy = true;
     bt_config.io_capability = ESP_IO_CAP_NO;
     
-         // Create instances with advanced configurations
-     m_wifi = std::make_unique<EspWifi>(&wifi_config);
+         // Create instances with advanced configurations using nothrow allocation
+     m_wifi = hf::utils::make_unique_nothrow<EspWifi>(&wifi_config);
+     if (!m_wifi) {
+         ESP_LOGE(TAG_MAIN, "Failed to allocate memory for WiFi instance");
+         return;
+     }
      
-     m_bluetooth = std::make_unique<EspBluetooth>(&bt_config);
+     m_bluetooth = hf::utils::make_unique_nothrow<EspBluetooth>(&bt_config);
+     if (!m_bluetooth) {
+         ESP_LOGE(TAG_MAIN, "Failed to allocate memory for Bluetooth instance");
+         return;
+     }
      
      ESP_LOGI(TAG_MAIN, "WiFi and Bluetooth instances created successfully!");
   }

--- a/inc/utils/memory_utils.h
+++ b/inc/utils/memory_utils.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <memory>
+#include <new>
+#include <utility>
+
+namespace hf {
+namespace utils {
+
+/**
+ * @brief Creates a unique_ptr using nothrow new for exception-free design
+ * 
+ * This function template provides a safe alternative to std::make_unique
+ * for environments that require no-exception guarantees. It uses nothrow
+ * new to allocate memory and returns nullptr on allocation failure instead
+ * of throwing std::bad_alloc.
+ * 
+ * @tparam T The type to create
+ * @tparam Args Parameter pack for constructor arguments
+ * @param args Arguments to forward to T's constructor
+ * @return std::unique_ptr<T> Valid pointer on success, nullptr on allocation failure
+ * 
+ * @example
+ * @code
+ * auto ptr = make_unique_nothrow<MyClass>(arg1, arg2);
+ * if (!ptr) {
+ *     // Handle allocation failure
+ *     return false;
+ * }
+ * // Use ptr safely
+ * @endcode
+ */
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique_nothrow(Args&&... args) {
+    T* raw_ptr = new(std::nothrow) T(std::forward<Args>(args)...);
+    if (!raw_ptr) {
+        return nullptr;
+    }
+    return std::unique_ptr<T>(raw_ptr);
+}
+
+/**
+ * @brief Creates a unique_ptr for arrays using nothrow new
+ * 
+ * Specialized version for creating arrays with nothrow allocation.
+ * 
+ * @tparam T The array element type
+ * @param size Number of elements to allocate
+ * @return std::unique_ptr<T[]> Valid pointer on success, nullptr on allocation failure
+ * 
+ * @example
+ * @code
+ * auto arr = make_unique_array_nothrow<int>(1000);
+ * if (!arr) {
+ *     // Handle allocation failure
+ *     return false;
+ * }
+ * // Use arr safely
+ * @endcode
+ */
+template<typename T>
+std::unique_ptr<T[]> make_unique_array_nothrow(size_t size) {
+    T* raw_ptr = new(std::nothrow) T[size];
+    if (!raw_ptr) {
+        return nullptr;
+    }
+    return std::unique_ptr<T[]>(raw_ptr);
+}
+
+} // namespace utils
+} // namespace hf

--- a/src/mcu/esp32/EspI2c.cpp
+++ b/src/mcu/esp32/EspI2c.cpp
@@ -160,7 +160,10 @@ int EspI2cBus::CreateDevice(const hf_i2c_device_config_t& device_config) noexcep
     auto device = hf::utils::make_unique_nothrow<EspI2cDevice>(this, dev_handle, device_config);
     if (!device) {
         ESP_LOGE(TAG, "Failed to allocate memory for EspI2cDevice");
-        i2c_master_bus_rm_device(dev_handle);
+        esp_err_t cleanup_err = i2c_master_bus_rm_device(dev_handle);
+        if (cleanup_err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to remove I2C device during cleanup: %s", esp_err_to_name(cleanup_err));
+        }
         return -1;
     }
     

--- a/src/mcu/esp32/EspSpi.cpp
+++ b/src/mcu/esp32/EspSpi.cpp
@@ -140,7 +140,10 @@ int EspSpiBus::CreateDevice(const hf_spi_device_config_t& device_config) noexcep
   auto device = hf::utils::make_unique_nothrow<EspSpiDevice>(this, handle, device_config);
   if (!device) {
     ESP_LOGE(TAG, "Failed to allocate memory for EspSpiDevice");
-    spi_bus_remove_device(handle);
+    esp_err_t remove_err = spi_bus_remove_device(handle);
+    if (remove_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to remove SPI device: %s", esp_err_to_name(remove_err));
+    }
     return -1;
   }
   


### PR DESCRIPTION
Introduce `make_unique_nothrow` templates and refactor `unique_ptr` and raw `new` allocations to ensure a no-exception memory management design.

The standard `std::make_unique` throws `std::bad_alloc` on memory allocation failure, which is undesirable in embedded or no-exception environments. This PR provides a safe alternative that returns `nullptr` on failure, allowing for explicit error handling without relying on exceptions.
