### PR TITLE
Analyze wifi and bluetooth for coding standards and mutex usage

### DIFF
--- a/inc/base/BaseBluetooth.h
+++ b/inc/base/BaseBluetooth.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /**
@@ -92,7 +93,7 @@ enum class hf_bluetooth_err_t : hf_u8_t { HF_BLUETOOTH_ERR_LIST(X) };
  * @param err The error code to convert
  * @return Pointer to error description string
  */
-constexpr const char* hf_bluetooth_err_tToString(hf_bluetooth_err_t err) noexcept {
+constexpr std::string_view HfBluetoothErrToString(hf_bluetooth_err_t err) noexcept {
   switch (err) {
 #define X(NAME, VALUE, DESC) \
   case hf_bluetooth_err_t::NAME:  \
@@ -161,6 +162,38 @@ enum class hf_bluetooth_security_t : hf_u8_t {
 enum class hf_bluetooth_scan_type_t : hf_u8_t {
   HF_BLUETOOTH_SCAN_TYPE_PASSIVE = 0,         /**< Passive scanning */
   HF_BLUETOOTH_SCAN_TYPE_ACTIVE = 1           /**< Active scanning */
+};
+
+/**
+ * @ingroup bluetooth
+ * @brief Bluetooth scan modes
+ */
+enum class hf_bluetooth_scan_mode_t : hf_u8_t {
+  HF_BLUETOOTH_SCAN_MODE_GENERAL_INQUIRY = 0,    /**< General inquiry scan */
+  HF_BLUETOOTH_SCAN_MODE_LE_GENERAL = 1,         /**< BLE general discovery */
+  HF_BLUETOOTH_SCAN_MODE_LE_LIMITED = 2          /**< BLE limited discovery */
+};
+
+/**
+ * @ingroup bluetooth
+ * @brief Bluetooth connection types
+ */
+enum class hf_bluetooth_connection_type_t : hf_u8_t {
+  HF_BLUETOOTH_CONNECTION_TYPE_AUTO = 0,         /**< Auto-detect connection type */
+  HF_BLUETOOTH_CONNECTION_TYPE_CLASSIC = 1,      /**< Classic Bluetooth only */
+  HF_BLUETOOTH_CONNECTION_TYPE_BLE = 2           /**< BLE only */
+};
+
+/**
+ * @ingroup bluetooth 
+ * @brief Bluetooth connection states
+ */
+enum class hf_bluetooth_connection_state_t : hf_u8_t {
+  HF_BLUETOOTH_CONNECTION_STATE_DISCONNECTED = 0,  /**< Disconnected */
+  HF_BLUETOOTH_CONNECTION_STATE_CONNECTING = 1,    /**< Connecting */
+  HF_BLUETOOTH_CONNECTION_STATE_CONNECTED = 2,     /**< Connected */
+  HF_BLUETOOTH_CONNECTION_STATE_ADVERTISING = 3,   /**< Advertising */
+  HF_BLUETOOTH_CONNECTION_STATE_SCANNING = 4       /**< Scanning */
 };
 
 /**
@@ -671,7 +704,7 @@ public:
    * @param error Error code
    * @return Error description string
    */
-  static const char* GetErrorString(hf_bluetooth_err_t error);
+  static std::string_view GetErrorString(hf_bluetooth_err_t error);
 
 protected:
   /**
@@ -694,7 +727,7 @@ protected:
  * @ingroup bluetooth
  * @brief Helper function to convert error enum to string
  */
-inline const char* BaseBluetooth::GetErrorString(hf_bluetooth_err_t error) {
+inline std::string_view BaseBluetooth::GetErrorString(hf_bluetooth_err_t error) {
 #define X(name, value, desc) case hf_bluetooth_err_t::name: return desc;
   switch (error) {
     HF_BLUETOOTH_ERR_LIST(X)

--- a/inc/base/BaseWifi.h
+++ b/inc/base/BaseWifi.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <string_view>
 
 /**
  * @defgroup wifi WiFi Module
@@ -87,7 +88,7 @@ enum class hf_wifi_err_t : hf_u8_t { HF_WIFI_ERR_LIST(X) };
  * @param err The error code to convert
  * @return Pointer to error description string
  */
-constexpr const char* hf_wifi_err_tToString(hf_wifi_err_t err) noexcept {
+constexpr std::string_view HfWifiErrToString(hf_wifi_err_t err) noexcept {
   switch (err) {
 #define X(NAME, VALUE, DESC) \
   case hf_wifi_err_t::NAME:  \
@@ -470,7 +471,7 @@ public:
    * @param error Error code
    * @return Error description string
    */
-  static const char* GetErrorString(hf_wifi_err_t error);
+  static std::string_view GetErrorString(hf_wifi_err_t error);
 
 protected:
   /**
@@ -493,7 +494,7 @@ protected:
  * @ingroup wifi
  * @brief Helper function to convert error enum to string
  */
-inline const char* BaseWifi::GetErrorString(hf_wifi_err_t error) {
+inline std::string_view BaseWifi::GetErrorString(hf_wifi_err_t error) {
 #define X(name, value, desc) case hf_wifi_err_t::name: return desc;
   switch (error) {
     HF_WIFI_ERR_LIST(X)

--- a/inc/mcu/esp32/utils/EspTypes_Bluetooth.h
+++ b/inc/mcu/esp32/utils/EspTypes_Bluetooth.h
@@ -232,10 +232,10 @@ struct HfEspBleConnParams {
  */
 inline esp_bt_mode_t hfBluetoothModeToEspMode(hf_bluetooth_mode_t mode) {
   switch (mode) {
-    case hf_bluetooth_mode_t::DISABLED: return ESP_BT_MODE_IDLE;
-    case hf_bluetooth_mode_t::CLASSIC: return ESP_BT_MODE_CLASSIC_BT;
-    case hf_bluetooth_mode_t::BLE: return ESP_BT_MODE_BLE;
-    case hf_bluetooth_mode_t::DUAL: return ESP_BT_MODE_BTDM;
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DISABLED: return ESP_BT_MODE_IDLE;
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC: return ESP_BT_MODE_CLASSIC_BT;
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE: return ESP_BT_MODE_BLE;
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL: return ESP_BT_MODE_BTDM;
     default: return ESP_BT_MODE_IDLE;
   }
 }
@@ -247,11 +247,11 @@ inline esp_bt_mode_t hfBluetoothModeToEspMode(hf_bluetooth_mode_t mode) {
  */
 inline hf_bluetooth_mode_t espModeTohf_bluetooth_mode_t(esp_bt_mode_t mode) {
   switch (mode) {
-    case ESP_BT_MODE_IDLE: return hf_bluetooth_mode_t::DISABLED;
-    case ESP_BT_MODE_CLASSIC_BT: return hf_bluetooth_mode_t::CLASSIC;
-    case ESP_BT_MODE_BLE: return hf_bluetooth_mode_t::BLE;
-    case ESP_BT_MODE_BTDM: return hf_bluetooth_mode_t::DUAL;
-    default: return hf_bluetooth_mode_t::DISABLED;
+    case ESP_BT_MODE_IDLE: return hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DISABLED;
+    case ESP_BT_MODE_CLASSIC_BT: return hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC;
+    case ESP_BT_MODE_BLE: return hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE;
+    case ESP_BT_MODE_BTDM: return hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL;
+    default: return hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DISABLED;
   }
 }
 

--- a/inc/mcu/esp32/utils/EspTypes_WiFi.h
+++ b/inc/mcu/esp32/utils/EspTypes_WiFi.h
@@ -228,10 +228,10 @@ inline hf_wifi_security_t espAuthModeTohf_wifi_security_t(wifi_auth_mode_t auth_
  */
 inline wifi_mode_t hfWifiModeToEspMode(hf_wifi_mode_t mode) {
   switch (mode) {
-    case hf_wifi_mode_t::STATION: return WIFI_MODE_STA;
-    case hf_wifi_mode_t::ACCESS_POINT: return WIFI_MODE_AP;
-    case hf_wifi_mode_t::STATION_AP: return WIFI_MODE_APSTA;
-    case hf_wifi_mode_t::DISABLED: return WIFI_MODE_NULL;
+    case hf_wifi_mode_t::HF_WIFI_MODE_STATION: return WIFI_MODE_STA;
+    case hf_wifi_mode_t::HF_WIFI_MODE_ACCESS_POINT: return WIFI_MODE_AP;
+    case hf_wifi_mode_t::HF_WIFI_MODE_STATION_AP: return WIFI_MODE_APSTA;
+    case hf_wifi_mode_t::HF_WIFI_MODE_DISABLED: return WIFI_MODE_NULL;
     default: return WIFI_MODE_NULL;
   }
 }
@@ -243,11 +243,11 @@ inline wifi_mode_t hfWifiModeToEspMode(hf_wifi_mode_t mode) {
  */
 inline hf_wifi_mode_t espModeTohf_wifi_mode_t(wifi_mode_t mode) {
   switch (mode) {
-    case WIFI_MODE_STA: return hf_wifi_mode_t::STATION;
-    case WIFI_MODE_AP: return hf_wifi_mode_t::ACCESS_POINT;
-    case WIFI_MODE_APSTA: return hf_wifi_mode_t::STATION_AP;
-    case WIFI_MODE_NULL: return hf_wifi_mode_t::DISABLED;
-    default: return hf_wifi_mode_t::DISABLED;
+    case WIFI_MODE_STA: return hf_wifi_mode_t::HF_WIFI_MODE_STATION;
+    case WIFI_MODE_AP: return hf_wifi_mode_t::HF_WIFI_MODE_ACCESS_POINT;
+    case WIFI_MODE_APSTA: return hf_wifi_mode_t::HF_WIFI_MODE_STATION_AP;
+    case WIFI_MODE_NULL: return hf_wifi_mode_t::HF_WIFI_MODE_DISABLED;
+    default: return hf_wifi_mode_t::HF_WIFI_MODE_DISABLED;
   }
 }
 

--- a/src/mcu/esp32/EspBluetooth.cpp
+++ b/src/mcu/esp32/EspBluetooth.cpp
@@ -303,7 +303,7 @@ hf_bluetooth_err_t EspBluetooth::Deinitialize() {
   
   m_initialized = false;
   m_enabled = false;
-  m_mode = hf_bluetooth_mode_t::DISABLED;
+  m_mode = hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DISABLED;
   
   ESP_LOGI(TAG, "ESP32 Bluetooth deinitialized successfully");
   return hf_bluetooth_err_t::SUCCESS;

--- a/src/mcu/esp32/EspBluetooth.cpp
+++ b/src/mcu/esp32/EspBluetooth.cpp
@@ -77,11 +77,11 @@ static const EspBluetoothAdvancedConfig DEFAULT_ADVANCED_CONFIG = {
  */
 static esp_bt_mode_t ConvertToEspMode(hf_bluetooth_mode_t mode) {
   switch (mode) {
-    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC_ONLY:
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC:
       return ESP_BT_MODE_CLASSIC_BT;
-    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE_ONLY:
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE:
       return ESP_BT_MODE_BLE;
-    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL_MODE:
+    case hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL:
       return ESP_BT_MODE_BTDM;
     default:
       return ESP_BT_MODE_IDLE;
@@ -286,13 +286,13 @@ hf_bluetooth_err_t EspBluetooth::Deinitialize() {
   gatt_services_.clear();
   
   // Unregister callbacks and deinitialize
-  if (m_mode == hf_bluetooth_mode_t::BLE_ONLY || m_mode == hf_bluetooth_mode_t::DUAL_MODE) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE || m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL) {
     esp_ble_gap_register_callback(nullptr);
     esp_ble_gatts_register_callback(nullptr);
     esp_ble_gattc_register_callback(nullptr);
   }
   
-  if (m_mode == hf_bluetooth_mode_t::CLASSIC_ONLY || m_mode == hf_bluetooth_mode_t::DUAL_MODE) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC || m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL) {
     esp_bt_gap_register_callback(nullptr);
     if (advanced_config_.enable_spp) {
       esp_spp_register_callback(nullptr);
@@ -402,7 +402,7 @@ hf_bluetooth_err_t EspBluetooth::SetDeviceName(const std::string& name) {
   }
   
   // Set Classic Bluetooth device name if applicable
-  if (m_mode == hf_bluetooth_mode_t::CLASSIC_ONLY || m_mode == hf_bluetooth_mode_t::DUAL_MODE) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC || m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL) {
     ret = esp_bt_dev_set_device_name(name.c_str());
     if (ret != ESP_OK) {
       ESP_LOGE(TAG, "Failed to set Classic BT device name: %s", esp_err_to_name(ret));
@@ -428,7 +428,7 @@ hf_bluetooth_err_t EspBluetooth::startAdvertising(const hf_bluetooth_advertising
     return hf_bluetooth_err_t::NOT_INITIALIZED;
   }
   
-  if (m_mode == hf_bluetooth_mode_t::CLASSIC_ONLY) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC) {
     ESP_LOGE(TAG, "Advertising not supported in Classic-only mode");
     return hf_bluetooth_err_t::NOT_SUPPORTED;
   }
@@ -531,8 +531,8 @@ hf_bluetooth_err_t EspBluetooth::startScan(const hf_bluetooth_scan_config_t& con
   
   esp_err_t ret = ESP_OK;
   
-  if (m_mode == hf_bluetooth_mode_t::BLE_ONLY || 
-      (m_mode == hf_bluetooth_mode_t::DUAL_MODE && config.mode == hf_bluetooth_scan_mode_t::LE_GENERAL)) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE || 
+      (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL && config.mode == hf_bluetooth_scan_mode_t::LE_GENERAL)) {
     
     // BLE scan parameters
     esp_ble_scan_params_t scan_params = {
@@ -556,8 +556,8 @@ hf_bluetooth_err_t EspBluetooth::startScan(const hf_bluetooth_scan_config_t& con
       return hf_bluetooth_err_t::START_FAILED;
     }
     
-  } else if (m_mode == hf_bluetooth_mode_t::CLASSIC_ONLY || 
-             (m_mode == hf_bluetooth_mode_t::DUAL_MODE && config.mode == hf_bluetooth_scan_mode_t::GENERAL_INQUIRY)) {
+  } else if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC || 
+             (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL && config.mode == hf_bluetooth_scan_mode_t::GENERAL_INQUIRY)) {
     
     // Classic Bluetooth inquiry
     esp_bt_inq_mode_t inq_mode = config.mode == hf_bluetooth_scan_mode_t::LIMITED_INQUIRY ? 
@@ -586,8 +586,8 @@ hf_bluetooth_err_t EspBluetooth::stopScan() {
   
   esp_err_t ret = ESP_OK;
   
-  if (m_mode == hf_bluetooth_mode_t::BLE_ONLY || 
-      (m_mode == hf_bluetooth_mode_t::DUAL_MODE && m_current_scan_type == hf_bluetooth_scan_mode_t::LE_GENERAL)) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE || 
+      (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL && m_current_scan_type == hf_bluetooth_scan_mode_t::LE_GENERAL)) {
     ret = esp_ble_gap_stop_scanning();
   } else {
     ret = esp_bt_gap_cancel_discovery();
@@ -630,15 +630,15 @@ hf_bluetooth_err_t EspBluetooth::connect(const hf_bluetooth_address_t& address,
   esp_err_t ret = ESP_OK;
   uint16_t conn_id = next_connection_id_++;
   
-  if (type == hf_bluetooth_connection_type_t::BLE || 
-      (type == hf_bluetooth_connection_type_t::AUTO && m_mode != hf_bluetooth_mode_t::CLASSIC_ONLY)) {
+  if (type == hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_BLE || 
+      (type == hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_AUTO && m_mode != hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC)) {
     
     // BLE connection
     esp_ble_addr_type_t addr_type = BLE_ADDR_TYPE_PUBLIC;
     ret = esp_ble_gattc_open(gattc_if_, const_cast<uint8_t*>(address.address), addr_type, true);
     
-  } else if (type == hf_bluetooth_connection_type_t::CLASSIC || 
-             (type == hf_bluetooth_connection_type_t::AUTO && m_mode != hf_bluetooth_mode_t::BLE_ONLY)) {
+  } else if (type == hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_CLASSIC || 
+             (type == hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_AUTO && m_mode != hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE)) {
     
     // Classic Bluetooth connection (SPP)
     if (advanced_config_.enable_spp) {
@@ -660,7 +660,7 @@ hf_bluetooth_err_t EspBluetooth::connect(const hf_bluetooth_address_t& address,
   conn_info.address = address;
   memcpy(conn_info.esp_address, address.address, 6);
   conn_info.connection_handle = conn_id;
-  conn_info.is_classic = (type == hf_bluetooth_connection_type_t::CLASSIC);
+  conn_info.is_classic = (type == hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_CLASSIC);
   conn_info.mtu = advanced_config_.mtu_size;
   
   connections_[conn_id] = conn_info;
@@ -722,10 +722,10 @@ hf_bluetooth_connection_info_t EspBluetooth::getConnectionInfo(uint16_t connecti
   hf_bluetooth_connection_info_t info = {};
   info.connection_id = connection_id;
   info.address = it->second.address;
-  info.type = it->second.is_classic ? hf_bluetooth_connection_type_t::CLASSIC : hf_bluetooth_connection_type_t::BLE;
-  info.state = hf_bluetooth_connection_state_t::CONNECTED; // Simplified for now
+  info.type = it->second.is_classic ? hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_CLASSIC : hf_bluetooth_connection_type_t::HF_BLUETOOTH_CONNECTION_TYPE_BLE;
+  info.state = hf_bluetooth_connection_state_t::HF_BLUETOOTH_CONNECTION_STATE_CONNECTED; // Simplified for now
   info.mtu = it->second.mtu;
-  info.security_level = hf_bluetooth_security_t::NONE; // Would need to query actual security
+  info.security_level = hf_bluetooth_security_t::HF_BLUETOOTH_SECURITY_NONE; // Would need to query actual security
   info.is_bonded = false; // Would need to check bonding status
   info.rssi = -50; // Would need to query actual RSSI
   
@@ -780,10 +780,10 @@ hf_bluetooth_err_t EspBluetooth::pair(const hf_bluetooth_address_t& address, hf_
   
   esp_err_t ret = ESP_OK;
   
-  if (m_mode == hf_bluetooth_mode_t::BLE_ONLY || m_mode == hf_bluetooth_mode_t::DUAL_MODE) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_BLE || m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_DUAL) {
     // Configure BLE security
     esp_ble_auth_req_t auth_req = ESP_LE_AUTH_BOND;
-    if (security == hf_bluetooth_security_t::AUTHENTICATED) {
+    if (security == hf_bluetooth_security_t::HF_BLUETOOTH_SECURITY_AUTHENTICATED) {
       auth_req = ESP_LE_AUTH_REQ_SC_MITM_BOND;
     }
     
@@ -920,7 +920,7 @@ hf_bluetooth_err_t EspBluetooth::gattAddService(const hf_bluetooth_gatt_service_
     return hf_bluetooth_err_t::NOT_INITIALIZED;
   }
   
-  if (m_mode == hf_bluetooth_mode_t::CLASSIC_ONLY) {
+  if (m_mode == hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC) {
     ESP_LOGE(TAG, "GATT not supported in Classic-only mode");
     return hf_bluetooth_err_t::NOT_SUPPORTED;
   }
@@ -940,7 +940,7 @@ hf_bluetooth_err_t EspBluetooth::gattAddService(const hf_bluetooth_gatt_service_
   service_id.is_primary = service.is_primary;
   service_id.id.inst_id = 0;
   service_id.id.uuid.len = service.uuid.size();
-  memcpy(service_id.id.uuid.uuid.uuid128, service.uuid.data(), service.uuid.size());
+  memcpy(service_id.id.uuid.uuid128, service.uuid.data(), service.uuid.size());
   
   esp_err_t ret = esp_ble_gatts_create_service(gatts_if_, &service_id, service.num_handles);
   if (ret != ESP_OK) {

--- a/src/mcu/esp32/EspWifi.cpp
+++ b/src/mcu/esp32/EspWifi.cpp
@@ -386,10 +386,10 @@ hf_wifi_err_t EspWifi::StartStation(const hf_wifi_station_config_t& config) {
   }
   
   // Set mode to station or station+AP
-  HfWifiMode new_mode = (m_mode == hf_wifi_mode_t::ACCESS_POINT) ? 
-                        hf_wifi_mode_t::STATION_ACCESS_POINT : hf_wifi_mode_t::STATION;
+  hf_wifi_mode_t new_mode = (m_mode == hf_wifi_mode_t::HF_WIFI_MODE_ACCESS_POINT) ? 
+                        hf_wifi_mode_t::HF_WIFI_MODE_STATION_AP : hf_wifi_mode_t::HF_WIFI_MODE_STATION;
   
-  hf_wifi_err_t err = setMode(new_mode);
+  hf_wifi_err_t err = SetMode(new_mode);
   if (err != hf_wifi_err_t::SUCCESS) {
     return err;
   }
@@ -475,10 +475,10 @@ hf_wifi_err_t EspWifi::StartAccessPoint(const hf_wifi_ap_config_t& config) {
   }
   
   // Set mode to AP or station+AP
-  HfWifiMode new_mode = (m_mode == hf_wifi_mode_t::STATION) ? 
-                        hf_wifi_mode_t::STATION_ACCESS_POINT : hf_wifi_mode_t::ACCESS_POINT;
+  hf_wifi_mode_t new_mode = (m_mode == hf_wifi_mode_t::HF_WIFI_MODE_STATION) ? 
+                        hf_wifi_mode_t::HF_WIFI_MODE_STATION_AP : hf_wifi_mode_t::HF_WIFI_MODE_ACCESS_POINT;
   
-  hf_wifi_err_t err = setMode(new_mode);
+  hf_wifi_err_t err = SetMode(new_mode);
   if (err != hf_wifi_err_t::SUCCESS) {
     return err;
   }
@@ -532,7 +532,7 @@ hf_wifi_err_t EspWifi::Connect() {
     return hf_wifi_err_t::NOT_INITIALIZED;
   }
   
-  if (m_mode != hf_wifi_mode_t::STATION && m_mode != hf_wifi_mode_t::STATION_ACCESS_POINT) {
+  if (m_mode != hf_wifi_mode_t::HF_WIFI_MODE_STATION && m_mode != hf_wifi_mode_t::HF_WIFI_MODE_STATION_AP) {
     ESP_LOGE(TAG, "Not in station mode");
     return hf_wifi_err_t::INVALID_MODE;
   }
@@ -732,7 +732,7 @@ hf_wifi_err_t EspWifi::StartSmartConfig() {
   }
   
   // Set WiFi mode to station
-  hf_wifi_err_t err = setMode(hf_wifi_mode_t::STATION);
+  hf_wifi_err_t err = SetMode(hf_wifi_mode_t::HF_WIFI_MODE_STATION);
   if (err != hf_wifi_err_t::SUCCESS) {
     return err;
   }
@@ -797,7 +797,7 @@ hf_wifi_err_t EspWifi::StartWPS() {
   }
   
   // Set WiFi mode to station
-  hf_wifi_err_t err = setMode(hf_wifi_mode_t::STATION);
+  hf_wifi_err_t err = SetMode(hf_wifi_mode_t::HF_WIFI_MODE_STATION);
   if (err != hf_wifi_err_t::SUCCESS) {
     return err;
   }


### PR DESCRIPTION
Fixes critical enum and type usage inconsistencies in the Bluetooth implementation to prevent compilation errors and undefined behavior.

The previous enum usage in `EspBluetooth.cpp` contained incorrect or shortened enum names that did not match the actual definitions in `BaseBluetooth.h` and `EspTypes_Bluetooth.h`. This PR corrects these mismatches, ensuring the code uses the proper, fully qualified enum values for `hf_bluetooth_mode_t`, `hf_bluetooth_connection_type_t`, `hf_bluetooth_connection_state_t`, and `hf_bluetooth_security_t`, resolving critical compilation and potential runtime issues.
