### PR TITLE
Fix cmake include path for github actions

### DIFF
--- a/examples/esp32/main/CMakeLists.txt
+++ b/examples/esp32/main/CMakeLists.txt
@@ -50,9 +50,23 @@ endif()
 
 message(STATUS "Using source file: ${SOURCE_FILE_PATH}")
 
+# Determine include paths based on environment
+# In CI, inc is copied to ../inc, in development it's at ../../../inc
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../inc")
+    # CI environment - inc is at project level
+    set(INC_BASE_PATH "../inc")
+elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../../inc")
+    # Development environment - inc is at workspace root
+    set(INC_BASE_PATH "../../../inc")
+else()
+    message(FATAL_ERROR "Cannot find inc directory. Checked ../inc and ../../../inc")
+endif()
+
+message(STATUS "Using include base path: ${INC_BASE_PATH}")
+
 idf_component_register(
     SRCS "${MAIN_SOURCE}"
-    INCLUDE_DIRS "." "../../../inc" "../../../inc/base" "../../../inc/mcu/esp32"
+    INCLUDE_DIRS "." "${INC_BASE_PATH}" "${INC_BASE_PATH}/base" "${INC_BASE_PATH}/mcu/esp32"
     REQUIRES driver esp_timer freertos iid-espidf
 )
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Dynamically adjust CMake include paths for the `inc` directory to support both CI and development builds.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous hardcoded relative include paths for the `inc` directory (`../../../inc`) worked for local development builds but failed in the CI environment. In CI, the `inc` directory is copied to a different relative location (`../inc`) within the build context. This change adds logic to detect the correct relative path for `inc` based on the environment, ensuring successful builds in both CI and development.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b7938ec-b1eb-4da0-8e32-75c3d1f26545">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b7938ec-b1eb-4da0-8e32-75c3d1f26545">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>