### PR TITLE
Format temperature config macros

### DIFF
--- a/inc/base/BaseTemperature.h
+++ b/inc/base/BaseTemperature.h
@@ -325,19 +325,19 @@ using hf_temp_error_callback_t =
 /**
  * @brief Default temperature sensor configuration
  */
-#define HF_TEMP_CONFIG_DEFAULT()               \
-  {.range_min_celsius = -40.0f,                \
-   .range_max_celsius = 125.0f,                \
-   .resolution = 0.1f,                         \
-   .sample_rate_hz = 0,                        \
-   .enable_threshold_monitoring = false,       \
-   .high_threshold_celsius = 100.0f,           \
-   .low_threshold_celsius = -20.0f,            \
-   .enable_power_management = false,           \
-   .enable_calibration = false,                \
-   .timeout_ms = 1000,                         \
-   .sensor_type = HF_TEMP_SENSOR_TYPE_UNKNOWN, \
-   .capabilities = HF_TEMP_CAP_NONE}
+#define HF_TEMP_CONFIG_DEFAULT() \
+  { .range_min_celsius = -40.0f, \
+    .range_max_celsius = 125.0f, \
+    .resolution = 0.1f, \
+    .sample_rate_hz = 0, \
+    .enable_threshold_monitoring = false, \
+    .high_threshold_celsius = 100.0f, \
+    .low_threshold_celsius = -20.0f, \
+    .enable_power_management = false, \
+    .enable_calibration = false, \
+    .timeout_ms = 1000, \
+    .sensor_type = HF_TEMP_SENSOR_TYPE_UNKNOWN, \
+    .capabilities = HF_TEMP_CAP_NONE }
 
 /**
  * @brief Get error description string

--- a/inc/mcu/esp32/EspTemperature.h
+++ b/inc/mcu/esp32/EspTemperature.h
@@ -610,15 +610,15 @@ private:
 /**
  * @brief Default ESP32-C6 temperature sensor configuration
  */
-#define ESP_TEMP_CONFIG_DEFAULT()                     \
-  {.range = ESP_TEMP_RANGE_NEG10_80,                  \
-   .calibration_offset = 0.0f,                        \
-   .enable_threshold_monitoring = false,              \
-   .high_threshold_celsius = 80.0f,                   \
-   .low_threshold_celsius = -10.0f,                   \
-   .enable_continuous_monitoring = false,             \
-   .sample_rate_hz = ESP_TEMP_DEFAULT_SAMPLE_RATE_HZ, \
-   .allow_power_down = true,                          \
-   .clk_src = 0}
+#define ESP_TEMP_CONFIG_DEFAULT() \
+  { .range = ESP_TEMP_RANGE_NEG10_80, \
+    .calibration_offset = 0.0f, \
+    .enable_threshold_monitoring = false, \
+    .high_threshold_celsius = 80.0f, \
+    .low_threshold_celsius = -10.0f, \
+    .enable_continuous_monitoring = false, \
+    .sample_rate_hz = ESP_TEMP_DEFAULT_SAMPLE_RATE_HZ, \
+    .allow_power_down = true, \
+    .clk_src = 0 }
 
 // #endif // HF_MCU_FAMILY_ESP32


### PR DESCRIPTION
## Summary
- eliminate extra spacing in ESP temperature sensor macro
- tidy base temperature configuration macro formatting

## Testing
- `clang-format-14 inc/mcu/esp32/EspTemperature.h | diff -u - inc/mcu/esp32/EspTemperature.h | head -n 20`
- `clang-format-14 inc/base/BaseTemperature.h | diff -u - inc/base/BaseTemperature.h | head -n 20`