### PR TITLE
Fix formatting across headers and examples

### DIFF
--- a/examples/common/DummyDevice.hpp
+++ b/examples/common/DummyDevice.hpp
@@ -87,13 +87,7 @@ public:
   }
 
 private:
-<<<<<<< Current (Your changes)
-  EspI2cBus& bus_;           ///< Reference to I2C bus
-  uint8_t address_;          ///< Device I2C address
-  int device_index_;         ///< Device index on the bus (-1 if not initialized)
-=======
   EspI2cBus& bus_;   ///< Reference to I2C bus
   uint8_t address_;  ///< Device I2C address
   int device_index_; ///< Device index on the bus (-1 if not initialized)
->>>>>>> Incoming (Background Agent changes)
 };

--- a/examples/esp32/main/AsciiArtExample.cpp
+++ b/examples/esp32/main/AsciiArtExample.cpp
@@ -34,7 +34,7 @@ void DemonstrateCustomCharacters() {
   AsciiArtGenerator generator;
 
   // Add custom character
-  std::vector<std::string> custom_char = {"  ___  ", " /   \\", "|     |",
+  std::vector<std::string> custom_char = {"  ___  ", " /   \\",  "|     |",
                                           "|     |", " \\___/ ", "       "};
 
   generator.AddCustomCharacter('@', custom_char);

--- a/inc/base/BasePeriodicTimer.h
+++ b/inc/base/BasePeriodicTimer.h
@@ -341,8 +341,8 @@ protected:
    * @param user_data User data passed to callback
    */
   explicit BasePeriodicTimer(hf_timer_callback_t callback, void* user_data = nullptr) noexcept
-      : callback_(callback), user_data_(user_data), initialized_(false), running_(false),
-        statistics_{}, diagnostics_{} {}
+      : callback_(callback), user_data_(user_data), initialized_(false),
+        running_(false), statistics_{}, diagnostics_{} {}
 
   /**
    * @brief Set the initialized state.

--- a/inc/base/BaseTemperature.h
+++ b/inc/base/BaseTemperature.h
@@ -299,14 +299,14 @@ using hf_temp_error_callback_t =
  * @param celsius Temperature in Celsius
  * @return Temperature in Fahrenheit
  */
-#define HF_TEMP_CELSIUS_TO_FAHRENHEIT(celsius) ((celsius) * 9.0f / 5.0f + 32.0f)
+#define HF_TEMP_CELSIUS_TO_FAHRENHEIT(celsius) ((celsius)*9.0f / 5.0f + 32.0f)
 
 /**
  * @brief Convert Fahrenheit to Celsius
  * @param fahrenheit Temperature in Fahrenheit
  * @return Temperature in Celsius
  */
-#define HF_TEMP_FAHRENHEIT_TO_CELSIUS(fahrenheit) (((fahrenheit) - 32.0f) * 5.0f / 9.0f)
+#define HF_TEMP_FAHRENHEIT_TO_CELSIUS(fahrenheit) (((fahrenheit)-32.0f) * 5.0f / 9.0f)
 
 /**
  * @brief Convert Celsius to Kelvin
@@ -320,24 +320,19 @@ using hf_temp_error_callback_t =
  * @param kelvin Temperature in Kelvin
  * @return Temperature in Celsius
  */
-#define HF_TEMP_KELVIN_TO_CELSIUS(kelvin) ((kelvin) - 273.15f)
+#define HF_TEMP_KELVIN_TO_CELSIUS(kelvin) ((kelvin)-273.15f)
 
 /**
  * @brief Default temperature sensor configuration
  */
-#define HF_TEMP_CONFIG_DEFAULT()               \
-  {.range_min_celsius = -40.0f,                \
-   .range_max_celsius = 125.0f,                \
-   .resolution = 0.1f,                         \
-   .sample_rate_hz = 0,                        \
-   .enable_threshold_monitoring = false,       \
-   .high_threshold_celsius = 100.0f,           \
-   .low_threshold_celsius = -20.0f,            \
-   .enable_power_management = false,           \
-   .enable_calibration = false,                \
-   .timeout_ms = 1000,                         \
-   .sensor_type = HF_TEMP_SENSOR_TYPE_UNKNOWN, \
-   .capabilities = HF_TEMP_CAP_NONE}
+#define HF_TEMP_CONFIG_DEFAULT()                                                                 \
+  {                                                                                              \
+    .range_min_celsius = -40.0f, .range_max_celsius = 125.0f, .resolution = 0.1f,                \
+    .sample_rate_hz = 0, .enable_threshold_monitoring = false, .high_threshold_celsius = 100.0f, \
+    .low_threshold_celsius = -20.0f, .enable_power_management = false,                           \
+    .enable_calibration = false, .timeout_ms = 1000, .sensor_type = HF_TEMP_SENSOR_TYPE_UNKNOWN, \
+    .capabilities = HF_TEMP_CAP_NONE                                                             \
+  }
 
 /**
  * @brief Get error description string

--- a/inc/mcu/esp32/EspTemperature.h
+++ b/inc/mcu/esp32/EspTemperature.h
@@ -610,15 +610,12 @@ private:
 /**
  * @brief Default ESP32-C6 temperature sensor configuration
  */
-#define ESP_TEMP_CONFIG_DEFAULT()                     \
-  {.range = ESP_TEMP_RANGE_NEG10_80,                  \
-   .calibration_offset = 0.0f,                        \
-   .enable_threshold_monitoring = false,              \
-   .high_threshold_celsius = 80.0f,                   \
-   .low_threshold_celsius = -10.0f,                   \
-   .enable_continuous_monitoring = false,             \
-   .sample_rate_hz = ESP_TEMP_DEFAULT_SAMPLE_RATE_HZ, \
-   .allow_power_down = true,                          \
-   .clk_src = 0}
+#define ESP_TEMP_CONFIG_DEFAULT()                                                             \
+  {                                                                                           \
+    .range = ESP_TEMP_RANGE_NEG10_80, .calibration_offset = 0.0f,                             \
+    .enable_threshold_monitoring = false, .high_threshold_celsius = 80.0f,                    \
+    .low_threshold_celsius = -10.0f, .enable_continuous_monitoring = false,                   \
+    .sample_rate_hz = ESP_TEMP_DEFAULT_SAMPLE_RATE_HZ, .allow_power_down = true, .clk_src = 0 \
+  }
 
 // #endif // HF_MCU_FAMILY_ESP32

--- a/inc/mcu/esp32/utils/EspTypes_Base.h
+++ b/inc/mcu/esp32/utils/EspTypes_Base.h
@@ -49,9 +49,9 @@ static constexpr size_t HF_ADC_DMA_BUFFER_SIZE_DEFAULT = 1024U;
  * @return RTOS ticks (implementation-specific)
  */
 #define HF_TICKS_FROM_MS(ms) (pdMS_TO_TICKS(ms))
-#define HF_MS_FROM_TICKS(ticks) ((ticks) * portTICK_PERIOD_MS)
+#define HF_MS_FROM_TICKS(ticks) ((ticks)*portTICK_PERIOD_MS)
 #define HF_US_TO_TICKS(us) ((us) / (portTICK_PERIOD_MS * 1000))
-#define HF_TICKS_TO_US(ticks) ((ticks) * portTICK_PERIOD_MS * 1000)
+#define HF_TICKS_TO_US(ticks) ((ticks)*portTICK_PERIOD_MS * 1000)
 
 //==============================================================================
 // ESP32 POWER MANAGEMENT AND TIMING TYPES

--- a/src/mcu/esp32/EspAdc.cpp
+++ b/src/mcu/esp32/EspAdc.cpp
@@ -89,10 +89,10 @@ static esp_err_t AdcChannelToGpio(adc_unit_t unit_id, adc_channel_t channel, int
 EspAdc::EspAdc(const hf_adc_unit_config_t& config) noexcept
     : BaseAdc(), config_(config), continuous_running_(false),
       last_error_(hf_adc_err_t::ADC_SUCCESS), config_mutex_(), stats_mutex_(),
-      oneshot_handle_(nullptr), continuous_handle_(nullptr), calibration_handles_{},
-      filter_handles_{}, monitor_handles_{}, continuous_callback_(nullptr),
-      continuous_user_data_(nullptr), monitor_callbacks_{}, monitor_user_data_{}, statistics_{},
-      diagnostics_{} {
+      oneshot_handle_(nullptr),
+      continuous_handle_(nullptr), calibration_handles_{}, filter_handles_{}, monitor_handles_{},
+      continuous_callback_(nullptr), continuous_user_data_(nullptr), monitor_callbacks_{},
+      monitor_user_data_{}, statistics_{}, diagnostics_{} {
   // Initialize arrays to nullptr
   std::fill(calibration_handles_.begin(), calibration_handles_.end(), nullptr);
   std::fill(filter_handles_.begin(), filter_handles_.end(), nullptr);

--- a/src/mcu/esp32/EspCan.cpp
+++ b/src/mcu/esp32/EspCan.cpp
@@ -50,8 +50,8 @@ static const char* TAG = "EspCan";
 
 EspCan::EspCan(const hf_esp_can_config_t& config) noexcept
     : BaseCan(), config_(config), is_initialized_(false), is_started_(false), config_mutex_(),
-      stats_mutex_(), twai_handle_(nullptr), receive_callback_(nullptr), statistics_{},
-      diagnostics_{} {
+      stats_mutex_(), twai_handle_(nullptr),
+      receive_callback_(nullptr), statistics_{}, diagnostics_{} {
   // **LAZY INITIALIZATION** - Store configuration but do NOT initialize hardware
   // This follows the exact same pattern as EspAdc
   ESP_LOGD(TAG, "Creating EspCan for controller %d - LAZY INIT",

--- a/src/mcu/esp32/EspGpio.cpp
+++ b/src/mcu/esp32/EspGpio.cpp
@@ -133,8 +133,9 @@ EspGpio::EspGpio(hf_pin_num_t pin_num, hf_gpio_direction_t direction,
       interrupt_callback_(nullptr), interrupt_user_data_(nullptr), interrupt_enabled_(false),
       interrupt_count_(0), platform_semaphore_(nullptr), drive_capability_(drive_capability),
       glitch_filter_type_(hf_gpio_glitch_filter_type_t::HF_GPIO_GLITCH_FILTER_NONE),
-      pin_glitch_filter_enabled_(false), flex_glitch_filter_enabled_(false), flex_filter_config_{},
-      sleep_config_{}, hold_enabled_(false), rtc_gpio_enabled_(false), wakeup_config_{},
+      pin_glitch_filter_enabled_(false),
+      flex_glitch_filter_enabled_(false), flex_filter_config_{}, sleep_config_{},
+      hold_enabled_(false), rtc_gpio_enabled_(false), wakeup_config_{},
       glitch_filter_handle_(nullptr), rtc_gpio_handle_(nullptr), initialized_(false) {
   // Validate pin number for target platform
   if (!HF_GPIO_IS_VALID_GPIO(pin_num)) {
@@ -325,7 +326,7 @@ hf_u8_t EspGpio::GetMaxPins() const noexcept {
 #ifdef HF_MCU_ESP32C6
   return HF_MCU_GPIO_PIN_COUNT;
 #else
-  return 32; // Generic default
+  return 32;                     // Generic default
 #endif
 }
 


### PR DESCRIPTION
## Summary
- run clang-format-14 across source, headers, and examples
- resolve merge conflict markers in DummyDevice example

## Testing
- `find inc/ \( -name "*.h" -o -name "*.hpp" \) -print0 | xargs -0 -r clang-format-14 --dry-run --Werror`
- `find src/ \( -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" \) -print0 | xargs -0 -r clang-format-14 --dry-run --Werror`
- `find examples/ \( -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" \) -print0 | xargs -0 -r clang-format-14 --dry-run --Werror`
- `cmake -S . -B build` *(fails: Unknown CMake command "idf_component_register")*

------
https://chatgpt.com/codex/tasks/task_e_6891ed03e2f88328abb1ec0422848e6a