### PR TITLE
Fix formatting for example files

### DIFF
--- a/examples/common/DummyDevice.hpp
+++ b/examples/common/DummyDevice.hpp
@@ -87,13 +87,7 @@ public:
   }
 
 private:
-<<<<<<< Current (Your changes)
-  EspI2cBus& bus_;           ///< Reference to I2C bus
-  uint8_t address_;          ///< Device I2C address
-  int device_index_;         ///< Device index on the bus (-1 if not initialized)
-=======
   EspI2cBus& bus_;   ///< Reference to I2C bus
   uint8_t address_;  ///< Device I2C address
   int device_index_; ///< Device index on the bus (-1 if not initialized)
->>>>>>> Incoming (Background Agent changes)
 };

--- a/examples/esp32/main/AsciiArtExample.cpp
+++ b/examples/esp32/main/AsciiArtExample.cpp
@@ -34,7 +34,7 @@ void DemonstrateCustomCharacters() {
   AsciiArtGenerator generator;
 
   // Add custom character
-  std::vector<std::string> custom_char = {"  ___  ", " /   \\", "|     |",
+  std::vector<std::string> custom_char = {"  ___  ", " /   \\",  "|     |",
                                           "|     |", " \\___/ ", "       "};
 
   generator.AddCustomCharacter('@', custom_char);


### PR DESCRIPTION
## Summary
- clang-format DummyDevice example
- clang-format ASCII art example

## Testing
- `clang-format --dry-run --Werror examples/esp32/main/AsciiArtExample.cpp examples/common/DummyDevice.hpp`
- `cmake -S . -B build` *(fails: Unknown CMake command "idf_component_register")*


------
https://chatgpt.com/codex/tasks/task_e_68920c86277c8328800b8519733fa9bd