### PR TITLE
Check workflow files with actionlint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Building documentation with Doxygen..."
           echo "Current directory: $(pwd)"
           echo "Input directories exist check:"
-          ls -la inc/ src/ examples/ 2>/dev/null || echo "Some input directories missing"
+          find inc/ src/ examples/ -maxdepth 1 -type d 2>/dev/null || echo "Some input directories missing"
           
           echo "Running Doxygen..."
           doxygen Doxyfile
@@ -56,14 +56,14 @@ jobs:
           echo "Checking generated files..."
           echo "Output directory structure:"
           find docs/ -type d 2>/dev/null || echo "docs/ directory structure:"
-          ls -la docs/ 2>/dev/null || echo "docs/ directory not found"
+          find docs/ -maxdepth 1 2>/dev/null || echo "docs/ directory not found"
           
           if [ -d "docs/doxygen" ]; then
             echo "docs/doxygen contents:"
-            ls -la docs/doxygen/
+            find docs/doxygen/ -maxdepth 1 2>/dev/null
             if [ -d "docs/doxygen/html" ]; then
               echo "docs/doxygen/html contents:"
-              ls -la docs/doxygen/html/ | head -10
+              find docs/doxygen/html/ -maxdepth 1 2>/dev/null | head -10
               echo "HTML files found: $(find docs/doxygen/html -name "*.html" | wc -l)"
             else
               echo "docs/doxygen/html directory not found!"


### PR DESCRIPTION
Replace `ls` commands with `find` in `docs.yml` to resolve `shellcheck` SC2012 warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-326b89ac-afc2-48c5-babb-02ab28621818">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-326b89ac-afc2-48c5-babb-02ab28621818">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

