### PR TITLE
Clang format entire codebase

### DIFF
--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -14,10 +14,10 @@
  * @copyright HardFOC
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "base/BaseAdc.h"
 #include "mcu/esp32/EspAdc.h"
@@ -38,23 +38,23 @@ bool test_adc_continuous_mode() noexcept;
 
 bool test_adc_initialization() noexcept {
   ESP_LOGI(TAG, "Testing ADC initialization...");
-  
+
   hf_adc_unit_config_t adc_cfg = {};
   adc_cfg.unit_id = 0;
   EspAdc test_adc(adc_cfg);
-  
+
   if (!test_adc.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize ADC");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] ADC initialization successful");
   return true;
 }
 
 bool test_adc_basic_conversion() noexcept {
   ESP_LOGI(TAG, "Testing basic ADC conversion...");
-  
+
   // Placeholder for ADC conversion tests
   ESP_LOGI(TAG, "Basic ADC conversion test completed (placeholder)");
   return true;
@@ -62,7 +62,7 @@ bool test_adc_basic_conversion() noexcept {
 
 bool test_adc_calibration() noexcept {
   ESP_LOGI(TAG, "Testing ADC calibration...");
-  
+
   // Placeholder for ADC calibration tests
   ESP_LOGI(TAG, "ADC calibration test completed (placeholder)");
   return true;
@@ -70,35 +70,33 @@ bool test_adc_calibration() noexcept {
 
 bool test_adc_continuous_mode() noexcept {
   ESP_LOGI(TAG, "Testing ADC continuous mode...");
-  
+
   // Placeholder for continuous mode tests
   ESP_LOGI(TAG, "ADC continuous mode test completed (placeholder)");
   return true;
 }
-
-
 
 extern "C" void app_main(void) {
   ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
   ESP_LOGI(TAG, "║                    ESP32-C6 ADC COMPREHENSIVE TEST SUITE                    ║");
   ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   RUN_TEST(test_adc_initialization);
   RUN_TEST(test_adc_basic_conversion);
   RUN_TEST(test_adc_calibration);
   RUN_TEST(test_adc_continuous_mode);
-  
+
   print_test_summary(g_test_results, "ADC", TAG);
-  
+
   if (g_test_results.failed_tests == 0) {
     ESP_LOGI(TAG, "[SUCCESS] ALL ADC TESTS PASSED!");
   } else {
     ESP_LOGE(TAG, "[FAILED] Some tests failed.");
   }
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/BluetoothComprehensiveTest.cpp
+++ b/examples/esp32/main/BluetoothComprehensiveTest.cpp
@@ -14,10 +14,10 @@
  * @copyright HardFOC
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include <vector>
 
 #include "base/BaseBluetooth.h"
@@ -83,7 +83,7 @@ bool test_bluetooth_cleanup() noexcept;
 
 bool test_bluetooth_initialization() noexcept {
   ESP_LOGI(TAG, "Testing Bluetooth initialization...");
-  
+
   // Register event callback
   hf_bluetooth_err_t ret = bluetooth_instance.RegisterEventCallback(bluetooth_event_callback);
   if (ret != hf_bluetooth_err_t::BLUETOOTH_SUCCESS) {
@@ -242,7 +242,8 @@ bool test_bluetooth_state_management() noexcept {
   ESP_LOGI(TAG, "[SUCCESS] Current Bluetooth mode: %d", static_cast<int>(mode));
 
   // Test mode setting (should remain BLE for ESP32C6)
-  hf_bluetooth_err_t ret = bluetooth_instance.SetMode(hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC);
+  hf_bluetooth_err_t ret =
+      bluetooth_instance.SetMode(hf_bluetooth_mode_t::HF_BLUETOOTH_MODE_CLASSIC);
   if (ret != hf_bluetooth_err_t::BLUETOOTH_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] Correctly rejected Classic mode for ESP32C6");
   } else {
@@ -312,20 +313,20 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "║                ESP32-C6 BLUETOOTH COMPREHENSIVE TEST SUITE                 ║");
   ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   ESP_LOGI(TAG, "Target: %s", CONFIG_IDF_TARGET);
   ESP_LOGI(TAG, "ESP-IDF Version: %s", IDF_VER);
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   RUN_TEST(test_bluetooth_initialization);
   RUN_TEST(test_bluetooth_basic_operations);
   RUN_TEST(test_bluetooth_scanning);
   RUN_TEST(test_bluetooth_state_management);
   RUN_TEST(test_bluetooth_cleanup);
-  
+
   print_test_summary(g_test_results, "BLUETOOTH", TAG);
-  
+
   if (g_test_results.failed_tests == 0) {
     ESP_LOGI(TAG, "[SUCCESS] ALL BLUETOOTH TESTS PASSED!");
     ESP_LOGI(TAG, "==================================================");
@@ -342,7 +343,7 @@ extern "C" void app_main(void) {
   } else {
     ESP_LOGE(TAG, "[FAILED] Some tests failed.");
   }
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -3,11 +3,11 @@
  * @brief Comprehensive CAN testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "base/BaseCan.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BaseCan.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspCan.h"
 
 #include "TestFramework.h"
@@ -18,19 +18,19 @@ static TestResults g_test_results;
 
 bool test_can_initialization() noexcept {
   ESP_LOGI(TAG, "Testing CAN bus initialization...");
-  
+
   hf_esp_can_config_t can_cfg = {};
   can_cfg.controller_id = hf_can_controller_id_t::HF_CAN_CONTROLLER_0;
   can_cfg.tx_pin = 7;
   can_cfg.rx_pin = 6;
   can_cfg.tx_queue_len = 8;
   EspCan test_can(can_cfg);
-  
+
   if (!test_can.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize CAN");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] CAN initialization successful");
   return true;
 }
@@ -42,6 +42,8 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_can_initialization);
   print_test_summary(g_test_results, "CAN", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -31,8 +31,8 @@ extern "C" {
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "esp_sleep.h"
-#include "esp_timer.h"
 #include "esp_system.h"
+#include "esp_timer.h"
 
 #ifdef __cplusplus
 }
@@ -65,27 +65,27 @@ static TestResults g_test_results;
 
 // ESP32-C6 DevKit-M-1 Safe Test Pins
 namespace TestPins {
-  // Safe pins for ESP32-C6 DevKit-M-1 (avoiding strapping, USB-JTAG, SPI flash pins)
-  static constexpr hf_pin_num_t LED_OUTPUT = 14;        // General purpose output
-  static constexpr hf_pin_num_t DIGITAL_OUT_1 = 10;     // General purpose output
-  static constexpr hf_pin_num_t DIGITAL_OUT_2 = 11;     // General purpose output
-  static constexpr hf_pin_num_t DIGITAL_IN_1 = 2;       // General purpose input 
-  static constexpr hf_pin_num_t DIGITAL_IN_2 = 3;       // General purpose input
-  static constexpr hf_pin_num_t INTERRUPT_PIN = 2;      // Interrupt testing
-  static constexpr hf_pin_num_t PULL_TEST_PIN = 3;      // Pull resistor testing
-  static constexpr hf_pin_num_t DRIVE_TEST_PIN = 16;    // Drive capability testing
-  static constexpr hf_pin_num_t RTC_GPIO_PIN = 7;       // RTC GPIO (LP_IO 7)
-  static constexpr hf_pin_num_t ANALOG_PIN = 6;         // ADC capable pin
-  static constexpr hf_pin_num_t LOOPBACK_OUT = 20;      // Output for loopback testing
-  static constexpr hf_pin_num_t LOOPBACK_IN = 21;       // Input for loopback testing
-  static constexpr hf_pin_num_t STRESS_TEST_PIN = 23;   // Stress testing
-  
-  // Pins to avoid (strapping, flash, USB-JTAG)
-  // GPIO 9  - Boot strapping pin
-  // GPIO 15 - Boot strapping pin  
-  // GPIO 12, 13 - USB-JTAG (D-, D+)
-  // GPIO 24-30 - SPI flash pins
-}
+// Safe pins for ESP32-C6 DevKit-M-1 (avoiding strapping, USB-JTAG, SPI flash pins)
+static constexpr hf_pin_num_t LED_OUTPUT = 14;      // General purpose output
+static constexpr hf_pin_num_t DIGITAL_OUT_1 = 10;   // General purpose output
+static constexpr hf_pin_num_t DIGITAL_OUT_2 = 11;   // General purpose output
+static constexpr hf_pin_num_t DIGITAL_IN_1 = 2;     // General purpose input
+static constexpr hf_pin_num_t DIGITAL_IN_2 = 3;     // General purpose input
+static constexpr hf_pin_num_t INTERRUPT_PIN = 2;    // Interrupt testing
+static constexpr hf_pin_num_t PULL_TEST_PIN = 3;    // Pull resistor testing
+static constexpr hf_pin_num_t DRIVE_TEST_PIN = 16;  // Drive capability testing
+static constexpr hf_pin_num_t RTC_GPIO_PIN = 7;     // RTC GPIO (LP_IO 7)
+static constexpr hf_pin_num_t ANALOG_PIN = 6;       // ADC capable pin
+static constexpr hf_pin_num_t LOOPBACK_OUT = 20;    // Output for loopback testing
+static constexpr hf_pin_num_t LOOPBACK_IN = 21;     // Input for loopback testing
+static constexpr hf_pin_num_t STRESS_TEST_PIN = 23; // Stress testing
+
+// Pins to avoid (strapping, flash, USB-JTAG)
+// GPIO 9  - Boot strapping pin
+// GPIO 15 - Boot strapping pin
+// GPIO 12, 13 - USB-JTAG (D-, D+)
+// GPIO 24-30 - SPI flash pins
+} // namespace TestPins
 
 static TestResults g_test_results;
 
@@ -118,38 +118,36 @@ bool test_gpio_power_consumption() noexcept;
  */
 bool test_basic_gpio_functionality() noexcept {
   ESP_LOGI(TAG, "=== Testing Basic GPIO Functionality ===");
-  
+
   // Test 1: Basic constructor and initialization
-  EspGpio led_gpio(TestPins::LED_OUTPUT, 
-                   hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+  EspGpio led_gpio(TestPins::LED_OUTPUT, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                    hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!led_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize LED GPIO");
     return false;
   }
-  
+
   // Test 2: Pin information
-  ESP_LOGI(TAG, "LED GPIO Pin: %d, Max Pins: %d", 
-           led_gpio.GetPin(), led_gpio.GetMaxPins());
+  ESP_LOGI(TAG, "LED GPIO Pin: %d, Max Pins: %d", led_gpio.GetPin(), led_gpio.GetMaxPins());
   ESP_LOGI(TAG, "GPIO Description: %s", led_gpio.GetDescription());
   ESP_LOGI(TAG, "Pin Available: %s", led_gpio.IsPinAvailable() ? "YES" : "NO");
-  
+
   // Test 3: Basic state operations
   auto result = led_gpio.SetActive();
   if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set GPIO active");
     return false;
   }
-  
+
   vTaskDelay(pdMS_TO_TICKS(100));
-  
+
   result = led_gpio.SetInactive();
   if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set GPIO inactive");
     return false;
   }
-  
+
   // Test 4: State verification
   bool is_active;
   result = led_gpio.IsActive(is_active);
@@ -157,9 +155,9 @@ bool test_basic_gpio_functionality() noexcept {
     ESP_LOGE(TAG, "Failed to read GPIO state");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "GPIO state after SetInactive: %s", is_active ? "ACTIVE" : "INACTIVE");
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Basic GPIO functionality test passed");
   return true;
 }
@@ -169,46 +167,41 @@ bool test_basic_gpio_functionality() noexcept {
  */
 bool test_gpio_initialization_and_configuration() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Initialization and Configuration ===");
-  
+
   // Test different GPIO configurations
-  const hf_pin_num_t test_pins[] = {TestPins::DIGITAL_OUT_1, TestPins::DIGITAL_OUT_2, TestPins::DIGITAL_IN_1, TestPins::DIGITAL_IN_2};
+  const hf_pin_num_t test_pins[] = {TestPins::DIGITAL_OUT_1, TestPins::DIGITAL_OUT_2,
+                                    TestPins::DIGITAL_IN_1, TestPins::DIGITAL_IN_2};
   const hf_gpio_direction_t test_directions[] = {
-    hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
-    hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
-    hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
-    hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT
-  };
+      hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+      hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT, hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT};
   const hf_gpio_active_state_t test_active_states[] = {
-    hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
-    hf_gpio_active_state_t::HF_GPIO_ACTIVE_LOW,
-    hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
-    hf_gpio_active_state_t::HF_GPIO_ACTIVE_LOW
-  };
+      hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH, hf_gpio_active_state_t::HF_GPIO_ACTIVE_LOW,
+      hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH, hf_gpio_active_state_t::HF_GPIO_ACTIVE_LOW};
   const hf_gpio_output_mode_t test_output_modes[] = {
-    hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
-    hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_OPEN_DRAIN,
-    hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
-    hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL
-  };
-  
+      hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
+      hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_OPEN_DRAIN,
+      hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
+      hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL};
+
   const size_t num_configs = sizeof(test_pins) / sizeof(test_pins[0]);
-  
+
   for (size_t i = 0; i < num_configs; i++) {
     auto pin = test_pins[i];
     auto direction = test_directions[i];
     auto active_state = test_active_states[i];
     auto output_mode = test_output_modes[i];
-    
-    ESP_LOGI(TAG, "Testing configuration: Pin=%d, Dir=%d, Active=%d, Output=%d", 
-             pin, static_cast<int>(direction), static_cast<int>(active_state), static_cast<int>(output_mode));
-    
+
+    ESP_LOGI(TAG, "Testing configuration: Pin=%d, Dir=%d, Active=%d, Output=%d", pin,
+             static_cast<int>(direction), static_cast<int>(active_state),
+             static_cast<int>(output_mode));
+
     EspGpio test_gpio(pin, direction, active_state, output_mode);
-    
+
     if (!test_gpio.EnsureInitialized()) {
       ESP_LOGE(TAG, "Failed to initialize GPIO pin %d", pin);
       return false;
     }
-    
+
     // Verify configuration
     hf_gpio_direction_t read_direction;
     auto result = test_gpio.GetDirection(read_direction);
@@ -216,15 +209,15 @@ bool test_gpio_initialization_and_configuration() noexcept {
       ESP_LOGE(TAG, "Direction mismatch for pin %d", pin);
       return false;
     }
-    
+
     if (test_gpio.GetActiveState() != active_state) {
       ESP_LOGE(TAG, "Active state mismatch for pin %d", pin);
       return false;
     }
-    
+
     ESP_LOGI(TAG, "[SUCCESS] Configuration verified for pin %d", pin);
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO initialization and configuration test passed");
   return true;
 }
@@ -234,27 +227,23 @@ bool test_gpio_initialization_and_configuration() noexcept {
  */
 bool test_gpio_input_output_operations() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Input/Output Operations ===");
-  
+
   // Test output operations
-  EspGpio output_gpio(TestPins::DIGITAL_OUT_1, 
-                      hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+  EspGpio output_gpio(TestPins::DIGITAL_OUT_1, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                       hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!output_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize output GPIO");
     return false;
   }
-  
+
   // Test various output states
   const hf_gpio_state_t test_states[] = {
-    hf_gpio_state_t::HF_GPIO_STATE_ACTIVE,
-    hf_gpio_state_t::HF_GPIO_STATE_INACTIVE,
-    hf_gpio_state_t::HF_GPIO_STATE_ACTIVE,
-    hf_gpio_state_t::HF_GPIO_STATE_INACTIVE
-  };
-  
+      hf_gpio_state_t::HF_GPIO_STATE_ACTIVE, hf_gpio_state_t::HF_GPIO_STATE_INACTIVE,
+      hf_gpio_state_t::HF_GPIO_STATE_ACTIVE, hf_gpio_state_t::HF_GPIO_STATE_INACTIVE};
+
   const size_t num_states = sizeof(test_states) / sizeof(test_states[0]);
-  
+
   for (size_t i = 0; i < num_states; i++) {
     auto state = test_states[i];
     auto result = output_gpio.Write(state);
@@ -262,7 +251,7 @@ bool test_gpio_input_output_operations() noexcept {
       ESP_LOGE(TAG, "Failed to write state %d", static_cast<int>(state));
       return false;
     }
-    
+
     // Verify the written state
     hf_gpio_state_t read_state;
     result = output_gpio.Read(read_state);
@@ -270,26 +259,23 @@ bool test_gpio_input_output_operations() noexcept {
       ESP_LOGE(TAG, "Failed to read GPIO state");
       return false;
     }
-    
+
     if (read_state != state) {
-      ESP_LOGE(TAG, "State mismatch: wrote %d, read %d", 
-               static_cast<int>(state), static_cast<int>(read_state));
+      ESP_LOGE(TAG, "State mismatch: wrote %d, read %d", static_cast<int>(state),
+               static_cast<int>(read_state));
       return false;
     }
-    
+
     vTaskDelay(pdMS_TO_TICKS(50));
   }
-  
+
   // Test pin level operations
   const hf_gpio_level_t test_levels[] = {
-    hf_gpio_level_t::HF_GPIO_LEVEL_HIGH,
-    hf_gpio_level_t::HF_GPIO_LEVEL_LOW,
-    hf_gpio_level_t::HF_GPIO_LEVEL_HIGH,
-    hf_gpio_level_t::HF_GPIO_LEVEL_LOW
-  };
-  
+      hf_gpio_level_t::HF_GPIO_LEVEL_HIGH, hf_gpio_level_t::HF_GPIO_LEVEL_LOW,
+      hf_gpio_level_t::HF_GPIO_LEVEL_HIGH, hf_gpio_level_t::HF_GPIO_LEVEL_LOW};
+
   const size_t num_levels = sizeof(test_levels) / sizeof(test_levels[0]);
-  
+
   for (size_t i = 0; i < num_levels; i++) {
     auto level = test_levels[i];
     auto result = output_gpio.SetPinLevel(level);
@@ -297,23 +283,23 @@ bool test_gpio_input_output_operations() noexcept {
       ESP_LOGE(TAG, "Failed to set pin level %d", static_cast<int>(level));
       return false;
     }
-    
+
     hf_gpio_level_t read_level;
     result = output_gpio.GetPinLevel(read_level);
     if (result != hf_gpio_err_t::GPIO_SUCCESS) {
       ESP_LOGE(TAG, "Failed to read pin level");
       return false;
     }
-    
+
     if (read_level != level) {
-      ESP_LOGE(TAG, "Level mismatch: set %d, read %d", 
-               static_cast<int>(level), static_cast<int>(read_level));
+      ESP_LOGE(TAG, "Level mismatch: set %d, read %d", static_cast<int>(level),
+               static_cast<int>(read_level));
       return false;
     }
-    
+
     vTaskDelay(pdMS_TO_TICKS(50));
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO input/output operations test passed");
   return true;
 }
@@ -323,26 +309,22 @@ bool test_gpio_input_output_operations() noexcept {
  */
 bool test_gpio_pull_resistors() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Pull Resistors ===");
-  
-  EspGpio pull_test_gpio(TestPins::PULL_TEST_PIN, 
-                         hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
+
+  EspGpio pull_test_gpio(TestPins::PULL_TEST_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
                          hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!pull_test_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize pull test GPIO");
     return false;
   }
-  
+
   // Test different pull modes
   const hf_gpio_pull_mode_t pull_modes[] = {
-    hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_FLOATING,
-    hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_UP,
-    hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_DOWN,
-    hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_FLOATING
-  };
-  
+      hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_FLOATING, hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_UP,
+      hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_DOWN, hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_FLOATING};
+
   const size_t num_modes = sizeof(pull_modes) / sizeof(pull_modes[0]);
-  
+
   for (size_t i = 0; i < num_modes; i++) {
     auto pull_mode = pull_modes[i];
     auto result = pull_test_gpio.SetPullMode(pull_mode);
@@ -350,27 +332,26 @@ bool test_gpio_pull_resistors() noexcept {
       ESP_LOGE(TAG, "Failed to set pull mode %d", static_cast<int>(pull_mode));
       return false;
     }
-    
+
     // Verify pull mode
     auto read_pull_mode = pull_test_gpio.GetPullMode();
     if (read_pull_mode != pull_mode) {
-      ESP_LOGE(TAG, "Pull mode mismatch: set %d, read %d", 
-               static_cast<int>(pull_mode), static_cast<int>(read_pull_mode));
+      ESP_LOGE(TAG, "Pull mode mismatch: set %d, read %d", static_cast<int>(pull_mode),
+               static_cast<int>(read_pull_mode));
       return false;
     }
-    
+
     // Read the pin state and log it
     hf_gpio_level_t level;
     result = pull_test_gpio.GetPinLevel(level);
     if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-      ESP_LOGI(TAG, "Pull mode %d -> Pin level: %s", 
-               static_cast<int>(pull_mode), 
+      ESP_LOGI(TAG, "Pull mode %d -> Pin level: %s", static_cast<int>(pull_mode),
                level == hf_gpio_level_t::HF_GPIO_LEVEL_HIGH ? "HIGH" : "LOW");
     }
-    
+
     vTaskDelay(pdMS_TO_TICKS(100));
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO pull resistors test passed");
   return true;
 }
@@ -380,28 +361,27 @@ bool test_gpio_pull_resistors() noexcept {
  */
 bool test_gpio_interrupt_functionality() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Interrupt Functionality ===");
-  
-  EspGpio interrupt_gpio(TestPins::INTERRUPT_PIN, 
-                         hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
+
+  EspGpio interrupt_gpio(TestPins::INTERRUPT_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
                          hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!interrupt_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize interrupt GPIO");
     return false;
   }
-  
+
   // Check if interrupts are supported
   auto interrupt_support = interrupt_gpio.SupportsInterrupts();
   if (interrupt_support != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGW(TAG, "Interrupts not supported or not implemented");
     return true; // Skip test gracefully
   }
-  
+
   ESP_LOGI(TAG, "Interrupt support verified");
-  
+
   // Test basic interrupt operations without actual callback for simplicity
   // In a real test, you would set up interrupts and trigger them
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO interrupt functionality test completed");
   return true;
 }
@@ -411,35 +391,36 @@ bool test_gpio_interrupt_functionality() noexcept {
  */
 bool test_gpio_advanced_features() noexcept {
   ESP_LOGI(TAG, "=== Testing Advanced GPIO Features ===");
-  
-  EspGpio advanced_gpio(TestPins::DRIVE_TEST_PIN,
-                        hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+
+  EspGpio advanced_gpio(TestPins::DRIVE_TEST_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                         hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!advanced_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize advanced GPIO");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Testing hardware verification...");
-  
+
   // Test hardware verification functions
   hf_gpio_direction_t verified_direction;
   auto result = advanced_gpio.VerifyDirection(verified_direction);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-    ESP_LOGI(TAG, "[SUCCESS] Direction verification successful: %d", static_cast<int>(verified_direction));
+    ESP_LOGI(TAG, "[SUCCESS] Direction verification successful: %d",
+             static_cast<int>(verified_direction));
   } else {
     ESP_LOGW(TAG, "Direction verification not available");
   }
-  
+
   hf_gpio_output_mode_t verified_mode;
   result = advanced_gpio.VerifyOutputMode(verified_mode);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
-    ESP_LOGI(TAG, "[SUCCESS] Output mode verification successful: %d", static_cast<int>(verified_mode));
+    ESP_LOGI(TAG, "[SUCCESS] Output mode verification successful: %d",
+             static_cast<int>(verified_mode));
   } else {
     ESP_LOGW(TAG, "Output mode verification not available");
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Advanced GPIO features test completed");
   return true;
 }
@@ -449,34 +430,33 @@ bool test_gpio_advanced_features() noexcept {
  */
 bool test_gpio_rtc_functionality() noexcept {
   ESP_LOGI(TAG, "=== Testing RTC GPIO Functionality ===");
-  
+
   // Use a pin that supports RTC GPIO (LP_IO)
-  EspGpio rtc_gpio(TestPins::RTC_GPIO_PIN, 
-                   hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+  EspGpio rtc_gpio(TestPins::RTC_GPIO_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                    hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!rtc_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize RTC GPIO");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Testing basic RTC GPIO operations...");
-  
+
   // Test basic operations on RTC-capable pin
   auto result = rtc_gpio.SetActive();
   if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set RTC GPIO active");
     return false;
   }
-  
+
   vTaskDelay(pdMS_TO_TICKS(100));
-  
+
   result = rtc_gpio.SetInactive();
   if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set RTC GPIO inactive");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] RTC GPIO functionality test completed");
   return true;
 }
@@ -486,24 +466,23 @@ bool test_gpio_rtc_functionality() noexcept {
  */
 bool test_gpio_glitch_filters() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Glitch Filters ===");
-  
+
   // Use interrupt pin for glitch filter testing
-  EspGpio filter_gpio(TestPins::INTERRUPT_PIN, 
-                      hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
+  EspGpio filter_gpio(TestPins::INTERRUPT_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
                       hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!filter_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize glitch filter test GPIO");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Testing pin-specific glitch filter...");
-  
+
   // Test pin-specific glitch filter configuration
   auto result = filter_gpio.ConfigurePinGlitchFilter(true);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] Pin glitch filter enabled successfully");
-    
+
     // Test with filter disabled
     result = filter_gpio.ConfigurePinGlitchFilter(false);
     if (result == hf_gpio_err_t::GPIO_SUCCESS) {
@@ -512,102 +491,102 @@ bool test_gpio_glitch_filters() noexcept {
       ESP_LOGW(TAG, "[FAILURE] Failed to disable pin glitch filter: %d", static_cast<int>(result));
     }
   } else {
-    ESP_LOGW(TAG, "[FAILURE] Pin glitch filter not supported or failed: %d", static_cast<int>(result));
+    ESP_LOGW(TAG, "[FAILURE] Pin glitch filter not supported or failed: %d",
+             static_cast<int>(result));
   }
-  
+
   ESP_LOGI(TAG, "Testing flexible glitch filter...");
-  
+
   // Test flexible glitch filter with correct struct
   hf_gpio_flex_filter_config_t flex_config = {
-    .window_width_ns = 100,           // 100 ns width
-    .window_threshold_ns = 1000,      // 1 microsecond threshold
-    .clk_src = hf_gpio_glitch_filter_clk_src_t::HF_GLITCH_FILTER_CLK_SRC_APB,
-    .enable_on_init = true
-  };
-  
+      .window_width_ns = 100,      // 100 ns width
+      .window_threshold_ns = 1000, // 1 microsecond threshold
+      .clk_src = hf_gpio_glitch_filter_clk_src_t::HF_GLITCH_FILTER_CLK_SRC_APB,
+      .enable_on_init = true};
+
   result = filter_gpio.ConfigureFlexGlitchFilter(flex_config);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] Flexible glitch filter configured successfully");
-    ESP_LOGI(TAG, "   Window width: %lu ns, Threshold: %lu ns", 
-             flex_config.window_width_ns, flex_config.window_threshold_ns);
+    ESP_LOGI(TAG, "   Window width: %lu ns, Threshold: %lu ns", flex_config.window_width_ns,
+             flex_config.window_threshold_ns);
   } else {
-    ESP_LOGW(TAG, "[FAILURE] Flexible glitch filter not supported or failed: %d", static_cast<int>(result));
+    ESP_LOGW(TAG, "[FAILURE] Flexible glitch filter not supported or failed: %d",
+             static_cast<int>(result));
   }
-  
+
   ESP_LOGI(TAG, "Testing pin glitch filter configuration...");
-  
+
   // Test pin glitch filter with correct signature
-  result = filter_gpio.ConfigureGlitchFilter(hf_gpio_glitch_filter_type_t::HF_GPIO_GLITCH_FILTER_PIN);
+  result =
+      filter_gpio.ConfigureGlitchFilter(hf_gpio_glitch_filter_type_t::HF_GPIO_GLITCH_FILTER_PIN);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] Pin glitch filter configured successfully");
   } else {
     ESP_LOGW(TAG, "[FAILURE] Pin glitch filter configuration failed: %d", static_cast<int>(result));
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO glitch filters test completed");
   return true;
 }
 
 bool test_gpio_sleep_and_wakeup() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Sleep and Wake-up ===");
-  
+
   // Use RTC GPIO pin for sleep/wakeup testing
-  EspGpio sleep_gpio(TestPins::RTC_GPIO_PIN, 
-                     hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
+  EspGpio sleep_gpio(TestPins::RTC_GPIO_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
                      hf_gpio_active_state_t::HF_GPIO_ACTIVE_LOW);
-  
+
   if (!sleep_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize sleep test GPIO");
     return false;
   }
-  
+
   // Check if pin supports RTC functionality
   if (!sleep_gpio.SupportsRtcGpio()) {
-    ESP_LOGW(TAG, "Pin %d does not support RTC GPIO, using alternative sleep test", TestPins::RTC_GPIO_PIN);
+    ESP_LOGW(TAG, "Pin %d does not support RTC GPIO, using alternative sleep test",
+             TestPins::RTC_GPIO_PIN);
   } else {
     ESP_LOGI(TAG, "[SUCCESS] Pin %d supports RTC GPIO functionality", TestPins::RTC_GPIO_PIN);
   }
-  
+
   ESP_LOGI(TAG, "Testing sleep mode configuration...");
-  
+
   // Test sleep mode configuration with correct field names
   hf_gpio_sleep_config_t sleep_config = {
-    .sleep_mode = hf_gpio_mode_t::HF_GPIO_MODE_INPUT,
-    .sleep_direction = hf_gpio_mode_t::HF_GPIO_MODE_INPUT,
-    .sleep_pull_mode = hf_gpio_pull_t::HF_GPIO_PULL_UP,
-    .sleep_drive_strength = hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_0,
-    .sleep_output_enable = false,
-    .sleep_input_enable = true,
-    .hold_during_sleep = false,
-    .rtc_domain_enable = true,
-    .slp_sel_enable = true,
-    .enable_sleep_retain = false
-  };
-  
+      .sleep_mode = hf_gpio_mode_t::HF_GPIO_MODE_INPUT,
+      .sleep_direction = hf_gpio_mode_t::HF_GPIO_MODE_INPUT,
+      .sleep_pull_mode = hf_gpio_pull_t::HF_GPIO_PULL_UP,
+      .sleep_drive_strength = hf_gpio_drive_cap_t::HF_GPIO_DRIVE_CAP_0,
+      .sleep_output_enable = false,
+      .sleep_input_enable = true,
+      .hold_during_sleep = false,
+      .rtc_domain_enable = true,
+      .slp_sel_enable = true,
+      .enable_sleep_retain = false};
+
   auto result = sleep_gpio.ConfigureSleep(sleep_config);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] Sleep mode configured successfully");
   } else {
     ESP_LOGW(TAG, "[FAILURE] Sleep mode configuration failed: %d", static_cast<int>(result));
   }
-  
+
   ESP_LOGI(TAG, "Testing wakeup configuration...");
-  
+
   // Test wakeup configuration with correct field names
   hf_gpio_wakeup_config_t wakeup_config = {
-    .wake_trigger = hf_gpio_intr_type_t::HF_GPIO_INTR_LOW_LEVEL,
-    .enable_rtc_wake = true,
-    .enable_ext1_wake = false,
-    .wake_level = 0,  // LOW level wake
-    .internal_pullup_enable = true,
-    .internal_pulldown_enable = false,
-    .iso_en = false
-  };
-  
+      .wake_trigger = hf_gpio_intr_type_t::HF_GPIO_INTR_LOW_LEVEL,
+      .enable_rtc_wake = true,
+      .enable_ext1_wake = false,
+      .wake_level = 0, // LOW level wake
+      .internal_pullup_enable = true,
+      .internal_pulldown_enable = false,
+      .iso_en = false};
+
   result = sleep_gpio.ConfigureWakeUp(wakeup_config);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] Wake-up configured successfully (LOW level trigger)");
-    
+
     // Test with HIGH level trigger
     wakeup_config.wake_trigger = hf_gpio_intr_type_t::HF_GPIO_INTR_HIGH_LEVEL;
     wakeup_config.wake_level = 1;
@@ -615,7 +594,7 @@ bool test_gpio_sleep_and_wakeup() noexcept {
     if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       ESP_LOGI(TAG, "[SUCCESS] Wake-up reconfigured successfully (HIGH level trigger)");
     }
-    
+
     // Disable wakeup
     wakeup_config.enable_rtc_wake = false;
     result = sleep_gpio.ConfigureWakeUp(wakeup_config);
@@ -625,7 +604,7 @@ bool test_gpio_sleep_and_wakeup() noexcept {
   } else {
     ESP_LOGW(TAG, "[FAILURE] Wake-up configuration failed: %d", static_cast<int>(result));
   }
-  
+
   ESP_LOGI(TAG, "Note: Actual sleep/wakeup would require deep sleep mode");
   ESP_LOGI(TAG, "[SUCCESS] GPIO sleep and wake-up test completed");
   return true;
@@ -633,38 +612,37 @@ bool test_gpio_sleep_and_wakeup() noexcept {
 
 bool test_gpio_hold_functionality() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Hold Functionality ===");
-  
+
   // Use LED pin for hold testing (visible feedback)
-  EspGpio hold_gpio(TestPins::LED_OUTPUT, 
-                    hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+  EspGpio hold_gpio(TestPins::LED_OUTPUT, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                     hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!hold_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize hold test GPIO");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Testing GPIO hold configuration...");
-  
+
   // Set pin active before testing hold
   auto result = hold_gpio.SetActive();
   if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set GPIO active before hold test");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Pin set active, testing hold enable...");
   vTaskDelay(pdMS_TO_TICKS(500));
-  
+
   // Test hold configuration
   result = hold_gpio.ConfigureHold(true);
   if (result == hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGI(TAG, "[SUCCESS] GPIO hold enabled successfully");
     ESP_LOGI(TAG, "Pin state should be maintained even during sleep");
-    
+
     // Brief delay to demonstrate hold
     vTaskDelay(pdMS_TO_TICKS(1000));
-    
+
     // Test hold disable
     result = hold_gpio.ConfigureHold(false);
     if (result == hf_gpio_err_t::GPIO_SUCCESS) {
@@ -675,117 +653,107 @@ bool test_gpio_hold_functionality() noexcept {
   } else {
     ESP_LOGW(TAG, "[FAILURE] GPIO hold not supported or failed: %d", static_cast<int>(result));
   }
-  
+
   // Clean up - set pin inactive
   hold_gpio.SetInactive();
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO hold functionality test completed");
   return true;
 }
 
 bool test_gpio_drive_capabilities() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Drive Capabilities ===");
-  
+
   // Use the dedicated drive test pin
-  EspGpio drive_gpio(TestPins::DRIVE_TEST_PIN, 
-                     hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+  EspGpio drive_gpio(TestPins::DRIVE_TEST_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                      hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!drive_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize drive test GPIO");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Testing different drive capability settings...");
-  
+
   // Test all available drive capabilities
   hf_gpio_drive_capability_t capabilities[] = {
-    hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_0,   // ~5mA
-    hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_1,   // ~10mA
-    hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_2,   // ~20mA
-    hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_3    // ~40mA
+      hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_0, // ~5mA
+      hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_1, // ~10mA
+      hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_2, // ~20mA
+      hf_gpio_drive_capability_t::HF_GPIO_DRIVE_CAP_3  // ~40mA
   };
-  
+
   const char* cap_names[] = {"5mA", "10mA", "20mA", "40mA"};
-  
+
   for (size_t i = 0; i < sizeof(capabilities) / sizeof(capabilities[0]); i++) {
     ESP_LOGI(TAG, "Setting drive capability to %s...", cap_names[i]);
-    
+
     auto result = drive_gpio.SetDriveCapability(capabilities[i]);
     if (result == hf_gpio_err_t::GPIO_SUCCESS) {
       ESP_LOGI(TAG, "[SUCCESS] Drive capability %s set successfully", cap_names[i]);
-      
+
       // Test output at this drive level
       drive_gpio.SetActive();
       vTaskDelay(pdMS_TO_TICKS(100));
-      drive_gpio.SetInactive(); 
+      drive_gpio.SetInactive();
       vTaskDelay(pdMS_TO_TICKS(100));
     } else {
-      ESP_LOGW(TAG, "[FAILURE] Failed to set drive capability %s: %d", cap_names[i], static_cast<int>(result));
+      ESP_LOGW(TAG, "[FAILURE] Failed to set drive capability %s: %d", cap_names[i],
+               static_cast<int>(result));
     }
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO drive capabilities test completed");
   return true;
 }
 
 bool test_gpio_diagnostics_and_statistics() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Diagnostics and Statistics ===");
-  
+
   // Test diagnostics on multiple pin types
-  hf_pin_num_t test_pins[] = {
-    TestPins::LED_OUTPUT,
-    TestPins::DIGITAL_IN_1,
-    TestPins::RTC_GPIO_PIN,
-    TestPins::ANALOG_PIN
-  };
-  
-  const char* pin_names[] = {
-    "LED_OUTPUT",
-    "DIGITAL_IN_1", 
-    "RTC_GPIO_PIN",
-    "ANALOG_PIN"
-  };
-  
+  hf_pin_num_t test_pins[] = {TestPins::LED_OUTPUT, TestPins::DIGITAL_IN_1, TestPins::RTC_GPIO_PIN,
+                              TestPins::ANALOG_PIN};
+
+  const char* pin_names[] = {"LED_OUTPUT", "DIGITAL_IN_1", "RTC_GPIO_PIN", "ANALOG_PIN"};
+
   for (size_t i = 0; i < sizeof(test_pins) / sizeof(test_pins[0]); i++) {
     ESP_LOGI(TAG, "Testing diagnostics for %s (pin %d)...", pin_names[i], test_pins[i]);
-    
-    EspGpio diag_gpio(test_pins[i], 
-                      hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+
+    EspGpio diag_gpio(test_pins[i], hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                       hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-    
+
     if (!diag_gpio.EnsureInitialized()) {
       ESP_LOGW(TAG, "Failed to initialize GPIO for diagnostics test on pin %d", test_pins[i]);
       continue;
     }
-    
+
     // Test configuration dump
     ESP_LOGI(TAG, "Getting configuration dump for pin %d...", test_pins[i]);
     auto config_dump = diag_gpio.GetConfigurationDump();
     ESP_LOGI(TAG, "[SUCCESS] Configuration dump: %s", config_dump.c_str());
-    
+
     // Test pin capabilities
     ESP_LOGI(TAG, "Getting pin capabilities for pin %d...", test_pins[i]);
     auto capabilities = diag_gpio.GetPinCapabilities();
     ESP_LOGI(TAG, "[SUCCESS] Pin capabilities: %s", capabilities.c_str());
-    
+
     // Test RTC GPIO support
     if (diag_gpio.SupportsRtcGpio()) {
       ESP_LOGI(TAG, "[SUCCESS] Pin %d supports RTC GPIO functionality", test_pins[i]);
     } else {
       ESP_LOGI(TAG, "[INFO] Pin %d does not support RTC GPIO", test_pins[i]);
     }
-    
-    // Test dedicated GPIO support  
+
+    // Test dedicated GPIO support
     if (diag_gpio.SupportsDedicatedGpio()) {
       ESP_LOGI(TAG, "[SUCCESS] Pin %d supports dedicated GPIO functionality", test_pins[i]);
     } else {
       ESP_LOGI(TAG, "[INFO] Pin %d does not support dedicated GPIO", test_pins[i]);
     }
-    
+
     ESP_LOGI(TAG, "");
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO diagnostics and statistics test completed");
   return true;
 }
@@ -810,37 +778,35 @@ bool test_gpio_pin_validation() noexcept {
 
 bool test_gpio_loopback_operations() noexcept {
   ESP_LOGI(TAG, "=== Testing GPIO Loopback Operations ===");
-  ESP_LOGI(TAG, "Connect pin %d (output) to pin %d (input) for loopback test", 
+  ESP_LOGI(TAG, "Connect pin %d (output) to pin %d (input) for loopback test",
            TestPins::LOOPBACK_OUT, TestPins::LOOPBACK_IN);
-  
+
   // Initialize output pin
-  EspGpio output_gpio(TestPins::LOOPBACK_OUT, 
-                      hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+  EspGpio output_gpio(TestPins::LOOPBACK_OUT, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
                       hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   // Initialize input pin
-  EspGpio input_gpio(TestPins::LOOPBACK_IN, 
-                     hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
+  EspGpio input_gpio(TestPins::LOOPBACK_IN, hf_gpio_direction_t::HF_GPIO_DIRECTION_INPUT,
                      hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
-  
+
   if (!output_gpio.EnsureInitialized() || !input_gpio.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize loopback test GPIOs");
     return false;
   }
-  
+
   // Configure input with pulldown to ensure clean test
   auto result = input_gpio.SetPullMode(hf_gpio_pull_mode_t::HF_GPIO_PULL_DOWN);
   if (result != hf_gpio_err_t::GPIO_SUCCESS) {
     ESP_LOGW(TAG, "Failed to set pulldown on input pin");
   }
-  
+
   bool test_passed = true;
-  
+
   ESP_LOGI(TAG, "Testing loopback pattern: HIGH->LOW->HIGH->LOW");
-  
+
   // Test pattern: HIGH->LOW->HIGH->LOW
   bool test_values[] = {true, false, true, false, true};
-  
+
   for (size_t i = 0; i < sizeof(test_values) / sizeof(test_values[0]); i++) {
     // Set output
     if (test_values[i]) {
@@ -848,16 +814,16 @@ bool test_gpio_loopback_operations() noexcept {
     } else {
       result = output_gpio.SetInactive();
     }
-    
+
     if (result != hf_gpio_err_t::GPIO_SUCCESS) {
       ESP_LOGE(TAG, "Failed to set output to %s", test_values[i] ? "HIGH" : "LOW");
       test_passed = false;
       break;
     }
-    
+
     // Allow signal to settle
     vTaskDelay(pdMS_TO_TICKS(50));
-    
+
     // Read input
     bool input_active;
     result = input_gpio.IsActive(input_active);
@@ -866,29 +832,29 @@ bool test_gpio_loopback_operations() noexcept {
       test_passed = false;
       break;
     }
-    
+
     // Verify loopback
     if (input_active == test_values[i]) {
-      ESP_LOGI(TAG, "[SUCCESS] Loopback test %zu: Output=%s, Input=%s - PASS", 
-               i + 1, test_values[i] ? "HIGH" : "LOW", input_active ? "HIGH" : "LOW");
+      ESP_LOGI(TAG, "[SUCCESS] Loopback test %zu: Output=%s, Input=%s - PASS", i + 1,
+               test_values[i] ? "HIGH" : "LOW", input_active ? "HIGH" : "LOW");
     } else {
-      ESP_LOGE(TAG, "[FAILURE] Loopback test %zu: Output=%s, Input=%s - FAIL", 
-               i + 1, test_values[i] ? "HIGH" : "LOW", input_active ? "HIGH" : "LOW");
+      ESP_LOGE(TAG, "[FAILURE] Loopback test %zu: Output=%s, Input=%s - FAIL", i + 1,
+               test_values[i] ? "HIGH" : "LOW", input_active ? "HIGH" : "LOW");
       test_passed = false;
     }
   }
-  
+
   // Clean up - set output low
   output_gpio.SetInactive();
-  
+
   if (test_passed) {
     ESP_LOGI(TAG, "[SUCCESS] GPIO loopback operations test completed successfully");
   } else {
     ESP_LOGI(TAG, "[FAILURE] GPIO loopback operations test completed with failures");
-    ESP_LOGI(TAG, "Note: Ensure pins %d and %d are physically connected for this test", 
+    ESP_LOGI(TAG, "Note: Ensure pins %d and %d are physically connected for this test",
              TestPins::LOOPBACK_OUT, TestPins::LOOPBACK_IN);
   }
-  
+
   return test_passed;
 }
 
@@ -923,50 +889,50 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "║ Architecture: noexcept (no exception handling)                             ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
   ESP_LOGI(TAG, "\n");
-  
+
   // Wait a moment for system stabilization
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   ESP_LOGI(TAG, "Starting comprehensive GPIO testing...\n");
-  
+
   // Core GPIO functionality tests
   RUN_TEST(test_basic_gpio_functionality);
   RUN_TEST(test_gpio_initialization_and_configuration);
   RUN_TEST(test_gpio_input_output_operations);
   RUN_TEST(test_gpio_pull_resistors);
-  
+
   // Advanced functionality tests
   RUN_TEST(test_gpio_interrupt_functionality);
   RUN_TEST(test_gpio_advanced_features);
   RUN_TEST(test_gpio_drive_capabilities);
-  
+
   // ESP32-C6 specific tests
   RUN_TEST(test_gpio_rtc_functionality);
   RUN_TEST(test_gpio_glitch_filters);
   RUN_TEST(test_gpio_sleep_and_wakeup);
   RUN_TEST(test_gpio_hold_functionality);
-  
+
   // Robustness and performance tests
   RUN_TEST(test_gpio_error_handling);
   RUN_TEST(test_gpio_pin_validation);
   RUN_TEST(test_gpio_stress_testing);
   RUN_TEST(test_gpio_concurrent_operations);
-  
+
   // Specialized tests
   RUN_TEST(test_gpio_loopback_operations);
   RUN_TEST(test_gpio_diagnostics_and_statistics);
   RUN_TEST(test_gpio_power_consumption);
-  
+
   // Print final results
   print_test_summary(g_test_results, "GPIO", TAG);
-  
+
   ESP_LOGI(TAG, "GPIO comprehensive testing completed.");
   ESP_LOGI(TAG, "System will continue running. Press RESET to restart tests.");
-  
+
   // Keep the system running for monitoring
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
-    ESP_LOGI(TAG, "GPIO test system heartbeat - %lu seconds uptime", 
+    ESP_LOGI(TAG, "GPIO test system heartbeat - %lu seconds uptime",
              esp_timer_get_time() / 1000000);
   }
 }

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -3,11 +3,11 @@
  * @brief Comprehensive I2C testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "base/BaseI2c.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BaseI2c.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspI2c.h"
 
 #include "TestFramework.h"
@@ -16,22 +16,21 @@ static const char* TAG = "I2C_Test";
 
 static TestResults g_test_results;
 
-
 bool test_i2c_initialization() noexcept {
   ESP_LOGI(TAG, "Testing I2C initialization...");
-  
+
   hf_i2c_master_bus_config_t i2c_cfg = {};
   i2c_cfg.i2c_port = I2C_NUM_0;
   i2c_cfg.sda_io_num = 21;
   i2c_cfg.scl_io_num = 22;
   i2c_cfg.enable_internal_pullup = true;
   EspI2cBus test_i2c_bus(i2c_cfg);
-  
+
   if (!test_i2c_bus.IsInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize I2C bus");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] I2C initialization successful");
   return true;
 }
@@ -43,5 +42,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_i2c_initialization);
   print_test_summary(g_test_results, "I2C", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/NvsComprehensiveTest.cpp
+++ b/examples/esp32/main/NvsComprehensiveTest.cpp
@@ -3,11 +3,11 @@
  * @brief Comprehensive NVS (Non-Volatile Storage) testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "base/BaseNvs.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BaseNvs.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspNvs.h"
 
 #include "TestFramework.h"
@@ -18,16 +18,16 @@ static TestResults g_test_results;
 
 bool test_nvs_initialization() noexcept {
   ESP_LOGI(TAG, "Testing NVS initialization...");
-  
+
   // NVS configuration is handled internally by EspNvs
   EspNvs test_nvs("hardfoc");
   auto nvs_init = test_nvs.IsInitialized();
-  
+
   if (!nvs_init) {
     ESP_LOGE(TAG, "Failed to initialize NVS");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] NVS initialization successful");
   return true;
 }
@@ -39,5 +39,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_nvs_initialization);
   print_test_summary(g_test_results, "NVS", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -3,11 +3,11 @@
  * @brief Comprehensive PWM testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "base/BasePwm.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BasePwm.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspPwm.h"
 
 #include "TestFramework.h"
@@ -18,7 +18,7 @@ static TestResults g_test_results;
 
 bool test_pwm_initialization() noexcept {
   ESP_LOGI(TAG, "Testing PWM initialization...");
-  
+
   hf_pwm_unit_config_t pwm_cfg = {};
   pwm_cfg.unit_id = 0;
   pwm_cfg.mode = hf_pwm_mode_t::HF_PWM_MODE_FADE;
@@ -27,12 +27,12 @@ bool test_pwm_initialization() noexcept {
   pwm_cfg.enable_fade = true;
   pwm_cfg.enable_interrupts = true;
   EspPwm test_pwm(pwm_cfg);
-  
+
   if (!test_pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] PWM initialization successful");
   return true;
 }
@@ -44,5 +44,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_pwm_initialization);
   print_test_summary(g_test_results, "PWM", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/SpiComprehensiveTest.cpp
+++ b/examples/esp32/main/SpiComprehensiveTest.cpp
@@ -14,11 +14,11 @@
  * @copyright HardFOC
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "driver/spi_master.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "driver/spi_master.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "base/BaseSpi.h"
 #include "mcu/esp32/EspSpi.h"
@@ -38,28 +38,28 @@ bool test_spi_performance() noexcept;
 
 bool test_spi_bus_initialization() noexcept {
   ESP_LOGI(TAG, "Testing SPI bus initialization...");
-  
+
   hf_spi_bus_config_t spi_bus_cfg = {};
   spi_bus_cfg.mosi_pin = 10;
   spi_bus_cfg.miso_pin = 9;
   spi_bus_cfg.sclk_pin = 11;
   spi_bus_cfg.clock_speed_hz = 1000000;
   spi_bus_cfg.host = SPI2_HOST;
-  
+
   EspSpiBus test_spi_bus(spi_bus_cfg);
-  
+
   if (!test_spi_bus.Initialize()) {
     ESP_LOGE(TAG, "Failed to initialize SPI bus");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] SPI bus initialization successful");
   return true;
 }
 
 bool test_spi_device_operations() noexcept {
   ESP_LOGI(TAG, "Testing SPI device operations...");
-  
+
   // Create SPI bus first
   hf_spi_bus_config_t spi_bus_cfg = {};
   spi_bus_cfg.mosi_pin = 10;
@@ -67,33 +67,33 @@ bool test_spi_device_operations() noexcept {
   spi_bus_cfg.sclk_pin = 11;
   spi_bus_cfg.clock_speed_hz = 1000000;
   spi_bus_cfg.host = SPI2_HOST;
-  
+
   EspSpiBus test_spi_bus(spi_bus_cfg);
-  
+
   if (!test_spi_bus.Initialize()) {
     ESP_LOGE(TAG, "Failed to initialize SPI bus for device test");
     return false;
   }
-  
+
   // Create SPI device on the bus
   hf_spi_device_config_t spi_dev_cfg = {};
   spi_dev_cfg.clock_speed_hz = 1000000;
   spi_dev_cfg.mode = hf_spi_mode_t::HF_SPI_MODE_0;
   spi_dev_cfg.cs_pin = 12;
   int device_index = test_spi_bus.CreateDevice(spi_dev_cfg);
-  
+
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create SPI device");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] SPI device created with index: %d", device_index);
   return true;
 }
 
 bool test_spi_transfer_modes() noexcept {
   ESP_LOGI(TAG, "Testing SPI transfer modes...");
-  
+
   // Placeholder for transfer mode tests
   ESP_LOGI(TAG, "SPI transfer modes test completed (placeholder)");
   return true;
@@ -101,7 +101,7 @@ bool test_spi_transfer_modes() noexcept {
 
 bool test_spi_performance() noexcept {
   ESP_LOGI(TAG, "Testing SPI performance...");
-  
+
   // Placeholder for performance tests
   ESP_LOGI(TAG, "SPI performance test completed (placeholder)");
   return true;
@@ -112,16 +112,16 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "║                    ESP32-C6 SPI COMPREHENSIVE TEST SUITE                    ║");
   ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   RUN_TEST(test_spi_bus_initialization);
   RUN_TEST(test_spi_device_operations);
   RUN_TEST(test_spi_transfer_modes);
   RUN_TEST(test_spi_performance);
-  
+
   print_test_summary(g_test_results, "SPI", TAG);
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/TemperatureComprehensiveTest.cpp
+++ b/examples/esp32/main/TemperatureComprehensiveTest.cpp
@@ -3,11 +3,11 @@
  * @brief Comprehensive Temperature sensor testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "base/BaseTemperature.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BaseTemperature.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspTemperature.h"
 
 #include "TestFramework.h"
@@ -18,17 +18,17 @@ static TestResults g_test_results;
 
 bool test_temperature_sensor_initialization() noexcept {
   ESP_LOGI(TAG, "Testing temperature sensor initialization...");
-  
+
   EspTemperature test_temp;
   auto temp_init = test_temp.IsInitialized();
-  
+
   if (temp_init != hf_temp_err_t::TEMP_SUCCESS) {
     ESP_LOGE(TAG, "Failed to initialize temperature sensor");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Temperature sensor initialization successful");
-  
+
   // Read temperature if initialized successfully
   hf_temp_reading_t temp_reading = {};
   auto temp_read = test_temp.ReadTemperature(&temp_reading);
@@ -37,7 +37,7 @@ bool test_temperature_sensor_initialization() noexcept {
   } else {
     ESP_LOGW(TAG, "Could not read temperature, but initialization was successful");
   }
-  
+
   return true;
 }
 
@@ -48,5 +48,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_temperature_sensor_initialization);
   print_test_summary(g_test_results, "TEMPERATURE", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/TestFramework.h
+++ b/examples/esp32/main/TestFramework.h
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 /**
  * @brief Test execution tracking and results accumulation
@@ -26,7 +26,7 @@ struct TestResults {
   int passed_tests = 0;
   int failed_tests = 0;
   uint64_t total_execution_time_us = 0;
-  
+
   /**
    * @brief Add test result and update statistics
    * @param passed Whether the test passed
@@ -41,7 +41,7 @@ struct TestResults {
       failed_tests++;
     }
   }
-  
+
   /**
    * @brief Calculate success percentage
    * @return Success percentage (0.0 to 100.0)
@@ -49,7 +49,7 @@ struct TestResults {
   double get_success_percentage() const noexcept {
     return total_tests > 0 ? (static_cast<double>(passed_tests) / total_tests * 100.0) : 0.0;
   }
-  
+
   /**
    * @brief Get total execution time in milliseconds
    * @return Total execution time in milliseconds
@@ -61,52 +61,52 @@ struct TestResults {
 
 /**
  * @brief Standardized test execution macro with timing and result tracking
- * 
+ *
  * This macro provides:
  * - Consistent test execution format
  * - Automatic timing measurement
  * - Result tracking and logging
  * - Standardized success/failure reporting
- * 
+ *
  * @param test_func The test function to execute (must return bool)
- * 
+ *
  * Requirements:
  * - TAG must be defined as const char* for logging
  * - g_test_results must be defined as TestResults instance
  * - test_func must be a function returning bool (true = pass, false = fail)
  */
-#define RUN_TEST(test_func) do { \
-  ESP_LOGI(TAG, "\n" \
-    "╔══════════════════════════════════════════════════════════════════════════════╗\n" \
-    "║ Running: " #test_func "                                                    ║\n" \
-    "╚══════════════════════════════════════════════════════════════════════════════╝"); \
-  uint64_t start_time = esp_timer_get_time(); \
-  bool result = test_func(); \
-  uint64_t end_time = esp_timer_get_time(); \
-  uint64_t execution_time = end_time - start_time; \
-  g_test_results.add_result(result, execution_time); \
-  if (result) { \
-    ESP_LOGI(TAG, "[SUCCESS] PASSED: " #test_func " (%.2f ms)", execution_time / 1000.0); \
-  } else { \
-    ESP_LOGE(TAG, "[FAILED] FAILED: " #test_func " (%.2f ms)", execution_time / 1000.0); \
-  } \
-  vTaskDelay(pdMS_TO_TICKS(100)); \
-} while(0)
+#define RUN_TEST(test_func)                                                                       \
+  do {                                                                                            \
+    ESP_LOGI(TAG,                                                                                 \
+             "\n"                                                                                 \
+             "╔══════════════════════════════════════════════════════════════════════════════╗\n" \
+             "║ Running: " #test_func "                                                    ║\n"   \
+             "╚══════════════════════════════════════════════════════════════════════════════╝"); \
+    uint64_t start_time = esp_timer_get_time();                                                   \
+    bool result = test_func();                                                                    \
+    uint64_t end_time = esp_timer_get_time();                                                     \
+    uint64_t execution_time = end_time - start_time;                                              \
+    g_test_results.add_result(result, execution_time);                                            \
+    if (result) {                                                                                 \
+      ESP_LOGI(TAG, "[SUCCESS] PASSED: " #test_func " (%.2f ms)", execution_time / 1000.0);       \
+    } else {                                                                                      \
+      ESP_LOGE(TAG, "[FAILED] FAILED: " #test_func " (%.2f ms)", execution_time / 1000.0);        \
+    }                                                                                             \
+    vTaskDelay(pdMS_TO_TICKS(100));                                                               \
+  } while (0)
 
 /**
  * @brief Print standardized test summary
  * @param test_results The TestResults instance to summarize
  * @param test_suite_name Name of the test suite for logging
  */
-inline void print_test_summary(const TestResults& test_results, const char* test_suite_name, const char* tag) noexcept {
+inline void print_test_summary(const TestResults& test_results, const char* test_suite_name,
+                               const char* tag) noexcept {
   ESP_LOGI(tag, "\n=== %s TEST SUMMARY ===", test_suite_name);
-  ESP_LOGI(tag, "Total: %d, Passed: %d, Failed: %d, Success: %.2f%%, Time: %.2f ms", 
-           test_results.total_tests, 
-           test_results.passed_tests, 
-           test_results.failed_tests,
-           test_results.get_success_percentage(),
-           test_results.get_total_time_ms());
-  
+  ESP_LOGI(tag, "Total: %d, Passed: %d, Failed: %d, Success: %.2f%%, Time: %.2f ms",
+           test_results.total_tests, test_results.passed_tests, test_results.failed_tests,
+           test_results.get_success_percentage(), test_results.get_total_time_ms());
+
   if (test_results.failed_tests == 0) {
     ESP_LOGI(tag, "[SUCCESS] ALL %s TESTS PASSED!", test_suite_name);
   } else {

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -3,11 +3,11 @@
  * @brief Comprehensive Periodic Timer testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "base/BasePeriodicTimer.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BasePeriodicTimer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspPeriodicTimer.h"
 
 #include "TestFramework.h"
@@ -18,7 +18,7 @@ static TestResults g_test_results;
 
 bool test_timer_initialization() noexcept {
   ESP_LOGI(TAG, "Testing periodic timer initialization...");
-  
+
   auto timer_callback = [](void* user_data) {
     static int count = 0;
     count++;
@@ -26,17 +26,17 @@ bool test_timer_initialization() noexcept {
       ESP_LOGI("Timer", "Timer callback executed %d times", count);
     }
   };
-  
+
   EspPeriodicTimer test_timer(timer_callback, nullptr);
   auto timer_init = test_timer.IsInitialized();
-  
+
   if (!timer_init) {
     ESP_LOGE(TAG, "Failed to initialize periodic timer");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Periodic timer initialization successful");
-  
+
   // Test starting the timer
   if (test_timer.Start(1000000)) { // 1 second interval
     ESP_LOGI(TAG, "[SUCCESS] Periodic timer started with 1-second interval");
@@ -46,7 +46,7 @@ bool test_timer_initialization() noexcept {
   } else {
     ESP_LOGW(TAG, "Could not start timer, but initialization was successful");
   }
-  
+
   return true;
 }
 
@@ -57,5 +57,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_timer_initialization);
   print_test_summary(g_test_results, "TIMER", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -14,10 +14,10 @@
  * @copyright HardFOC
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "base/BaseUart.h"
 #include "mcu/esp32/EspUart.h"
@@ -37,26 +37,26 @@ bool test_uart_flow_control() noexcept;
 
 bool test_uart_initialization() noexcept {
   ESP_LOGI(TAG, "Testing UART initialization...");
-  
+
   hf_uart_config_t uart_cfg = {};
-  uart_cfg.port_number = 0;  // Use UART0 for testing
+  uart_cfg.port_number = 0; // Use UART0 for testing
   uart_cfg.baud_rate = 115200;
   uart_cfg.tx_pin = 21;
   uart_cfg.rx_pin = 20;
   EspUart test_uart(uart_cfg);
-  
+
   if (!test_uart.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize UART");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] UART initialization successful");
   return true;
 }
 
 bool test_uart_basic_communication() noexcept {
   ESP_LOGI(TAG, "Testing basic UART communication...");
-  
+
   // Placeholder for UART communication tests
   ESP_LOGI(TAG, "Basic UART communication test completed (placeholder)");
   return true;
@@ -64,7 +64,7 @@ bool test_uart_basic_communication() noexcept {
 
 bool test_uart_async_operations() noexcept {
   ESP_LOGI(TAG, "Testing UART async operations...");
-  
+
   // Placeholder for async operation tests
   ESP_LOGI(TAG, "UART async operations test completed (placeholder)");
   return true;
@@ -72,35 +72,33 @@ bool test_uart_async_operations() noexcept {
 
 bool test_uart_flow_control() noexcept {
   ESP_LOGI(TAG, "Testing UART flow control...");
-  
+
   // Placeholder for flow control tests
   ESP_LOGI(TAG, "UART flow control test completed (placeholder)");
   return true;
 }
-
-
 
 extern "C" void app_main(void) {
   ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
   ESP_LOGI(TAG, "║                   ESP32-C6 UART COMPREHENSIVE TEST SUITE                    ║");
   ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   RUN_TEST(test_uart_initialization);
   RUN_TEST(test_uart_basic_communication);
   RUN_TEST(test_uart_async_operations);
   RUN_TEST(test_uart_flow_control);
-  
+
   print_test_summary(g_test_results, "UART", TAG);
-  
+
   if (g_test_results.failed_tests == 0) {
     ESP_LOGI(TAG, "[SUCCESS] ALL UART TESTS PASSED!");
   } else {
     ESP_LOGE(TAG, "[FAILED] Some tests failed.");
   }
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/UtilsComprehensiveTest.cpp
+++ b/examples/esp32/main/UtilsComprehensiveTest.cpp
@@ -14,10 +14,10 @@
  * @copyright HardFOC
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include <memory>
 
 #include "base/HardwareTypes.h"
@@ -38,9 +38,9 @@ bool test_hardware_types() noexcept;
 
 bool test_ascii_art_generator() noexcept {
   ESP_LOGI(TAG, "Testing ASCII Art Generator...");
-  
+
   AsciiArtGenerator art_gen;
-  
+
   // Test basic generation
   std::string hardfoc_art = art_gen.Generate("HardFOC");
   if (hardfoc_art.empty()) {
@@ -48,7 +48,7 @@ bool test_ascii_art_generator() noexcept {
     return false;
   }
   ESP_LOGI(TAG, "[SUCCESS] Generated ASCII art for HardFOC:\n%s", hardfoc_art.c_str());
-  
+
   // Test with different text
   std::string esp32_art = art_gen.Generate("ESP32-C6");
   if (esp32_art.empty()) {
@@ -56,7 +56,7 @@ bool test_ascii_art_generator() noexcept {
     return false;
   }
   ESP_LOGI(TAG, "[SUCCESS] Generated ASCII art for ESP32-C6:\n%s", esp32_art.c_str());
-  
+
   // Test completion message
   std::string complete_art = art_gen.Generate("UTILS TESTS COMPLETE");
   if (complete_art.empty()) {
@@ -64,78 +64,79 @@ bool test_ascii_art_generator() noexcept {
     return false;
   }
   ESP_LOGI(TAG, "[SUCCESS] Generated completion ASCII art:\n%s", complete_art.c_str());
-  
+
   return true;
 }
 
 bool test_memory_utilities() noexcept {
   ESP_LOGI(TAG, "Testing memory utilities...");
-  
+
   // Test make_unique_nothrow with int
   auto unique_int = hf::utils::make_unique_nothrow<int>(42);
   if (!unique_int) {
     ESP_LOGE(TAG, "Failed to create unique_ptr<int>");
     return false;
   }
-  
+
   if (*unique_int != 42) {
     ESP_LOGE(TAG, "Unique int value mismatch: expected 42, got %d", *unique_int);
     return false;
   }
   ESP_LOGI(TAG, "[SUCCESS] make_unique_nothrow created int with value: %d", *unique_int);
-  
+
   // Test make_unique with array
   auto unique_array = std::make_unique<int[]>(10);
   if (!unique_array) {
     ESP_LOGE(TAG, "Failed to create unique_ptr<int[]>");
     return false;
   }
-  
+
   // Initialize and test array
   for (int i = 0; i < 10; i++) {
     unique_array[i] = i * i;
   }
-  
+
   // Verify values
   for (int i = 0; i < 10; i++) {
     if (unique_array[i] != i * i) {
-      ESP_LOGE(TAG, "Array value mismatch at index %d: expected %d, got %d", i, i * i, unique_array[i]);
+      ESP_LOGE(TAG, "Array value mismatch at index %d: expected %d, got %d", i, i * i,
+               unique_array[i]);
       return false;
     }
   }
   ESP_LOGI(TAG, "[SUCCESS] make_unique created array, element[5] = %d", unique_array[5]);
-  
+
   return true;
 }
 
 bool test_hardware_types() noexcept {
   ESP_LOGI(TAG, "Testing hardware types...");
-  
+
   // Test basic hardware type definitions
   hf_pin_num_t test_pin = 5;
   hf_port_num_t test_port = 0;
   hf_frequency_hz_t test_freq = 1000000;
   hf_timestamp_us_t test_timestamp = 12345678;
   uint32_t test_voltage = 3300;
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Pin: %d, Port: %d, Freq: %lu Hz", test_pin, test_port, test_freq);
   ESP_LOGI(TAG, "[SUCCESS] Timestamp: %llu us, Voltage: %d mV", test_timestamp, test_voltage);
-  
+
   // Test GPIO state enum
   hf_gpio_state_t test_state = hf_gpio_state_t::HF_GPIO_STATE_ACTIVE;
   if (test_state != hf_gpio_state_t::HF_GPIO_STATE_ACTIVE) {
     ESP_LOGE(TAG, "GPIO state test failed");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] GPIO state: %s",
            test_state == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE ? "ACTIVE" : "INACTIVE");
-  
+
   // Test state toggle
   test_state = hf_gpio_state_t::HF_GPIO_STATE_INACTIVE;
   ESP_LOGI(TAG, "[SUCCESS] GPIO state toggled: %s",
            test_state == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE ? "ACTIVE" : "INACTIVE");
-  
+
   return true;
 }
 
@@ -144,21 +145,21 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "║                  ESP32-C6 UTILITIES COMPREHENSIVE TEST SUITE                ║");
   ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   RUN_TEST(test_ascii_art_generator);
   RUN_TEST(test_memory_utilities);
   RUN_TEST(test_hardware_types);
-  
+
   print_test_summary(g_test_results, "UTILITIES", TAG);
-  
+
   if (g_test_results.failed_tests == 0) {
     ESP_LOGI(TAG, "[SUCCESS] ALL UTILITIES TESTS PASSED!");
   } else {
     ESP_LOGE(TAG, "[FAILED] Some tests failed.");
   }
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/WifiComprehensiveTest.cpp
+++ b/examples/esp32/main/WifiComprehensiveTest.cpp
@@ -3,13 +3,13 @@
  * @brief Comprehensive WiFi testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+#include "TestFramework.h"
+#include "base/BaseWifi.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "base/BaseWifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "mcu/esp32/EspWifi.h"
-#include "TestFramework.h"
 
 static const char* TAG = "WIFI_Test";
 
@@ -17,15 +17,15 @@ static TestResults g_test_results;
 
 bool test_wifi_initialization() noexcept {
   ESP_LOGI(TAG, "Testing WiFi initialization...");
-  
+
   EspWifi test_wifi;
   auto wifi_init = test_wifi.IsInitialized();
-  
+
   if (!wifi_init) {
     ESP_LOGE(TAG, "Failed to initialize WiFi");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] WiFi initialization successful");
   return true;
 }
@@ -37,5 +37,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_wifi_initialization);
   print_test_summary(g_test_results, "WIFI", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }


### PR DESCRIPTION
Apply clang-format to the codebase to enforce consistent code style.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9b6b888-e624-48ef-aaf1-2ddc77b499eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9b6b888-e624-48ef-aaf1-2ddc77b499eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

