### PR TITLE
Investigate and fix gpio test failures

### DIFF
--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -732,12 +732,7 @@ bool test_gpio_diagnostics_and_statistics() noexcept {
       ESP_LOGI(TAG, "[INFO] Pin %d does not support RTC GPIO", test_pins[i]);
     }
 
-    // Test dedicated GPIO support
-    if (diag_gpio.SupportsDedicatedGpio()) {
-      ESP_LOGI(TAG, "[SUCCESS] Pin %d supports dedicated GPIO functionality", test_pins[i]);
-    } else {
-      ESP_LOGI(TAG, "[INFO] Pin %d does not support dedicated GPIO", test_pins[i]);
-    }
+    // Note: Dedicated GPIO support removed from EspGpio implementation
 
     ESP_LOGI(TAG, "");
   }

--- a/inc/mcu/esp32/EspGpio.h
+++ b/inc/mcu/esp32/EspGpio.h
@@ -430,53 +430,6 @@ public:
    */
   hf_gpio_err_t GetStatusInfo(hf_gpio_status_info_t& status) const noexcept;
 
-  //==============================================================//
-  // DEDICATED GPIO SUPPORT (ESP32C6 ESP-IDF v5.5+)
-  //==============================================================//
-
-  /**
-   * @brief Check if pin supports dedicated GPIO functionality.
-   * @return true if pin supports dedicated GPIO
-   * @details Dedicated GPIO provides high-speed bit-banging capabilities.
-   */
-  [[nodiscard]] bool SupportsDedicatedGpio() const noexcept;
-
-  /**
-   * @brief Create a dedicated GPIO bundle for high-speed operations.
-   * @param config Dedicated GPIO bundle configuration
-   * @param bundle_handle Output handle for the created bundle
-   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
-   * @details Dedicated GPIO bundles enable high-speed bit-banging operations
-   *          with minimal CPU overhead, perfect for custom protocols.
-   */
-  static hf_gpio_err_t CreateDedicatedBundle(const hf_dedic_gpio_bundle_config_t& config,
-                                             hf_dedic_gpio_bundle_handle_t& bundle_handle) noexcept;
-
-  /**
-   * @brief Delete a dedicated GPIO bundle.
-   * @param bundle_handle Handle of the bundle to delete
-   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
-   */
-  static hf_gpio_err_t DeleteDedicatedBundle(hf_dedic_gpio_bundle_handle_t bundle_handle) noexcept;
-
-  /**
-   * @brief Read data from a dedicated GPIO bundle.
-   * @param bundle_handle Handle of the bundle to read from
-   * @param data Output data from the bundle
-   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
-   */
-  static hf_gpio_err_t ReadDedicatedBundle(hf_dedic_gpio_bundle_handle_t bundle_handle,
-                                           hf_dedic_gpio_bundle_data_t& data) noexcept;
-
-  /**
-   * @brief Write data to a dedicated GPIO bundle.
-   * @param bundle_handle Handle of the bundle to write to
-   * @param data Data to write to the bundle
-   * @return hf_gpio_err_t::GPIO_SUCCESS if successful, error code otherwise
-   */
-  static hf_gpio_err_t WriteDedicatedBundle(hf_dedic_gpio_bundle_handle_t bundle_handle,
-                                            hf_dedic_gpio_bundle_data_t data) noexcept;
-
   /**
    * @brief Get total interrupt count across all GPIO instances.
    * @return Total number of GPIO interrupts that have occurred

--- a/inc/mcu/esp32/utils/EspTypes_GPIO.h
+++ b/inc/mcu/esp32/utils/EspTypes_GPIO.h
@@ -115,43 +115,7 @@ enum class hf_gpio_glitch_filter_clk_src_t : uint8_t {
   HF_GLITCH_FILTER_CLK_SRC_XTAL = 2     ///< XTAL clock (40MHz typically)
 };
 
-/**
- * @brief Dedicated GPIO bundle configuration flags.
- * @details Control flags for dedicated GPIO bundle behavior.
- */
-struct hf_dedic_gpio_bundle_flags_t {
-  uint32_t in_en : 1;      ///< Enable input capability
-  uint32_t in_invert : 1;  ///< Invert input signals
-  uint32_t out_en : 1;     ///< Enable output capability
-  uint32_t out_invert : 1; ///< Invert output signals
-  uint32_t reserved : 28;  ///< Reserved for future use
-};
 
-/**
- * @brief Dedicated GPIO bundle handle type.
- * @details Platform-specific handle for dedicated GPIO bundle operations.
- */
-#ifdef dedic_gpio_bundle_handle_t
-using hf_dedic_gpio_bundle_handle_t = dedic_gpio_bundle_handle_t;
-#else
-using hf_dedic_gpio_bundle_handle_t = void*; // Fallback for older ESP-IDF versions
-#endif
-
-/**
- * @brief Dedicated GPIO bundle configuration structure.
- * @details Complete configuration for creating dedicated GPIO bundles.
- */
-struct hf_dedic_gpio_bundle_config_t {
-  const int* gpio_array;              ///< Array of GPIO numbers
-  size_t array_size;                  ///< Number of GPIOs in array
-  hf_dedic_gpio_bundle_flags_t flags; ///< Bundle configuration flags
-};
-
-/**
- * @brief Dedicated GPIO bundle read/write data type.
- * @details Data type for reading from or writing to dedicated GPIO bundles.
- */
-using hf_dedic_gpio_bundle_data_t = uint32_t;
 
 /**
  * @brief Low-Power IO configuration for ultra-low power operation.
@@ -261,8 +225,6 @@ struct hf_gpio_status_info_t {
   bool glitch_filter_enabled;               ///< Glitch filter enabled
   uint32_t interrupt_count;                 ///< Number of interrupts occurred
   bool is_wake_source;                      ///< Pin configured as wake source
-  bool is_dedicated_gpio;                   ///< Pin used in dedicated GPIO bundle
-  uint8_t dedicated_channel;                ///< Dedicated GPIO channel number (if applicable)
   bool sleep_hold_active;                   ///< Sleep hold currently active
   uint32_t last_interrupt_time_us;          ///< Last interrupt timestamp (microseconds)
 };
@@ -342,9 +304,6 @@ typedef struct {
 
 #define HF_GPIO_SUPPORTS_OPEN_DRAIN(gpio_num) (HF_GPIO_IS_VALID_OUTPUT_GPIO(gpio_num))
 
-#define HF_GPIO_SUPPORTS_DEDICATED_GPIO(gpio_num) \
-  (HF_GPIO_IS_VALID_GPIO(gpio_num) && !HF_GPIO_IS_SPI_FLASH_PIN(gpio_num))
-
 /**
  * @brief ESP32 GPIO to ADC channel mapping.
  */
@@ -377,13 +336,7 @@ typedef struct {
  */
 using hf_gpio_isr_callback_t = void (*)(uint32_t gpio_num, void* user_data);
 
-/**
- * @brief GPIO bundle operations callback type for dedicated GPIO.
- * @param bundle_handle Handle to the GPIO bundle
- * @param mask GPIO mask within the bundle
- * @param user_data User-provided data
- */
-using hf_gpio_bundle_callback_t = void (*)(void* bundle_handle, uint32_t mask, void* user_data);
+
 
 /**
  * @brief GPIO configuration validation result.

--- a/inc/utils/McuSelect.h
+++ b/inc/utils/McuSelect.h
@@ -196,7 +196,6 @@
 #define HF_MCU_GPIO_LP_IO_PIN_COUNT 8       ///< LP_IO pins (LP_GPIO0-LP_GPIO7)
 #define HF_MCU_GPIO_ADC_PIN_COUNT 7         ///< ADC capable pins (GPIO0-GPIO6)
 #define HF_MCU_GPIO_FLEX_FILTER_COUNT 8     ///< Number of flexible glitch filters
-#define HF_MCU_GPIO_DEDIC_BUNDLE_MAX_SIZE 8 ///< Maximum GPIOs per dedicated bundle
 #define HF_MCU_GPIO_TOUCH_PIN_COUNT 0       ///< ESP32C6 has no touch pins
 #define HF_MCU_GPIO_DAC_PIN_COUNT 0         ///< ESP32C6 has no DAC pins
 #define HF_MCU_GPIO_ETM_CHANNEL_COUNT 50    ///< Number of ETM channels available
@@ -215,7 +214,6 @@
 
 // ESP32-C6 GPIO Feature Support Flags
 #define HF_MCU_GPIO_HAS_GLITCH_FILTER 1  ///< Hardware glitch filtering support
-#define HF_MCU_GPIO_HAS_DEDICATED_GPIO 1 ///< Dedicated GPIO bundle support
 #define HF_MCU_GPIO_HAS_RTC_GPIO 1       ///< RTC GPIO domain support
 #define HF_MCU_GPIO_HAS_LP_IO 1          ///< Low-power IO domain support
 #define HF_MCU_GPIO_HAS_ETM 1            ///< Event Task Matrix support

--- a/src/mcu/esp32/EspGpio.cpp
+++ b/src/mcu/esp32/EspGpio.cpp
@@ -1346,8 +1346,7 @@ hf_gpio_status_info_t EspGpio::GetConfigurationDump() const noexcept {
   dump.glitch_filter_enabled = pin_glitch_filter_enabled_ || flex_glitch_filter_enabled_;
   dump.interrupt_count = interrupt_count_.load();
   dump.is_wake_source = false;     // Set as appropriate
-  dump.is_dedicated_gpio = false;  // Set as appropriate
-  dump.dedicated_channel = 0;      // Set as appropriate
+
   dump.sleep_hold_active = false;  // Set as appropriate
   dump.last_interrupt_time_us = 0; // Set as appropriate
 #endif


### PR DESCRIPTION
Remove unimplemented dedicated GPIO support to resolve linking errors and clean up the codebase.
