### PR TITLE
fix hardware types

### DIFF
--- a/inc/base/HardwareTypes.h
+++ b/inc/base/HardwareTypes.h
@@ -173,6 +173,11 @@ using hf_timeout_ms_t = hf_time_t;
  */
 using hf_timeout_us_t = hf_time_t;
 
+/**
+ * @brief Timestamp value in microseconds.
+ */
+using hf_timestamp_us_t = hf_u64_t;
+
 //==============================================================================
 // TIMEOUT CONSTANTS
 //==============================================================================


### PR DESCRIPTION
Add `hf_timestamp_us_t` type definition to resolve a compilation error in `UtilsComprehensiveTest.cpp`.
