### PR TITLE
Apply clang format to source files

### DIFF
--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -23,8 +23,8 @@
 
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "freertos/queue.h"
+#include "freertos/task.h"
 
 #include "base/BaseAdc.h"
 #include "mcu/esp32/EspAdc.h"
@@ -53,8 +53,8 @@ static constexpr uint32_t CONTINUOUS_MAX_STORE_FRAMES = 4;
 
 // Global test data for continuous mode
 struct adc_queue_message_t {
-    uint32_t sample_count;
-    uint64_t timestamp;
+  uint32_t sample_count;
+  uint64_t timestamp;
 };
 
 static QueueHandle_t adc_data_queue = nullptr;
@@ -91,127 +91,130 @@ bool continuous_callback(const hf_adc_continuous_data_t* data, void* user_data) 
  * @brief Initialize ADC for testing with proper configuration
  */
 bool initialize_test_adc(EspAdc& adc) noexcept {
-    if (!adc.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize ADC");
-        return false;
-    }
+  if (!adc.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize ADC");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "ADC initialized successfully");
-    return true;
+  ESP_LOGI(TAG, "ADC initialized successfully");
+  return true;
 }
 
 /**
  * @brief Configure test channels with appropriate settings
  */
 bool configure_test_channels(EspAdc& adc) noexcept {
-    // Configure test channels with 12dB attenuation for full 3.3V range
-    hf_adc_err_t result;
+  // Configure test channels with 12dB attenuation for full 3.3V range
+  hf_adc_err_t result;
 
-    // Channel 0 (GPIO0)
-    result = adc.ConfigureChannel(TEST_CHANNEL_1, hf_adc_atten_t::ATTEN_DB_12, 
-                                  hf_adc_bitwidth_t::WIDTH_12BIT);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure channel %lu: %d", static_cast<unsigned long>(TEST_CHANNEL_1), static_cast<int>(result));
-        return false;
-    }
+  // Channel 0 (GPIO0)
+  result = adc.ConfigureChannel(TEST_CHANNEL_1, hf_adc_atten_t::ATTEN_DB_12,
+                                hf_adc_bitwidth_t::WIDTH_12BIT);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure channel %lu: %d", static_cast<unsigned long>(TEST_CHANNEL_1),
+             static_cast<int>(result));
+    return false;
+  }
 
-    // Channel 1 (GPIO1)
-    result = adc.ConfigureChannel(TEST_CHANNEL_2, hf_adc_atten_t::ATTEN_DB_12, 
-                                  hf_adc_bitwidth_t::WIDTH_12BIT);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure channel %lu: %d", static_cast<unsigned long>(TEST_CHANNEL_2), static_cast<int>(result));
-        return false;
-    }
+  // Channel 1 (GPIO1)
+  result = adc.ConfigureChannel(TEST_CHANNEL_2, hf_adc_atten_t::ATTEN_DB_12,
+                                hf_adc_bitwidth_t::WIDTH_12BIT);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure channel %lu: %d", static_cast<unsigned long>(TEST_CHANNEL_2),
+             static_cast<int>(result));
+    return false;
+  }
 
-    // Channel 2 (GPIO2)
-    result = adc.ConfigureChannel(TEST_CHANNEL_3, hf_adc_atten_t::ATTEN_DB_12, 
-                                  hf_adc_bitwidth_t::WIDTH_12BIT);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure channel %lu: %d", static_cast<unsigned long>(TEST_CHANNEL_3), static_cast<int>(result));
-        return false;
-    }
+  // Channel 2 (GPIO2)
+  result = adc.ConfigureChannel(TEST_CHANNEL_3, hf_adc_atten_t::ATTEN_DB_12,
+                                hf_adc_bitwidth_t::WIDTH_12BIT);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure channel %lu: %d", static_cast<unsigned long>(TEST_CHANNEL_3),
+             static_cast<int>(result));
+    return false;
+  }
 
-    // Enable all test channels
-    result = adc.EnableChannel(TEST_CHANNEL_1);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_1));
-        return false;
-    }
+  // Enable all test channels
+  result = adc.EnableChannel(TEST_CHANNEL_1);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_1));
+    return false;
+  }
 
-    result = adc.EnableChannel(TEST_CHANNEL_2);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_2));
-        return false;
-    }
+  result = adc.EnableChannel(TEST_CHANNEL_2);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_2));
+    return false;
+  }
 
-    result = adc.EnableChannel(TEST_CHANNEL_3);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_3));
-        return false;
-    }
+  result = adc.EnableChannel(TEST_CHANNEL_3);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_3));
+    return false;
+  }
 
-    ESP_LOGI(TAG, "All test channels configured and enabled");
-    return true;
+  ESP_LOGI(TAG, "All test channels configured and enabled");
+  return true;
 }
 
 /**
  * @brief Validate if voltage reading is within reasonable range
  */
 bool validate_voltage_reading(uint32_t voltage_mv, const char* channel_name) noexcept {
-    if (voltage_mv < MIN_VALID_VOLTAGE_MV || voltage_mv > MAX_VALID_VOLTAGE_MV) {
-        ESP_LOGW(TAG, "Channel %s voltage %lu mV outside valid range [%lu - %lu mV]", 
-                 channel_name, voltage_mv, MIN_VALID_VOLTAGE_MV, MAX_VALID_VOLTAGE_MV);
-        return false;
-    }
-    
-    ESP_LOGI(TAG, "Channel %s voltage: %lu mV [VALID]", channel_name, voltage_mv);
-    return true;
+  if (voltage_mv < MIN_VALID_VOLTAGE_MV || voltage_mv > MAX_VALID_VOLTAGE_MV) {
+    ESP_LOGW(TAG, "Channel %s voltage %lu mV outside valid range [%lu - %lu mV]", channel_name,
+             voltage_mv, MIN_VALID_VOLTAGE_MV, MAX_VALID_VOLTAGE_MV);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Channel %s voltage: %lu mV [VALID]", channel_name, voltage_mv);
+  return true;
 }
 
 /**
  * @brief Continuous mode callback function (ISR-safe)
  */
 bool continuous_callback(const hf_adc_continuous_data_t* data, void* user_data) noexcept {
-    (void)user_data; // Suppress unused parameter warning
-    if (!continuous_test_active || data == nullptr) {
-        return false;
-    }
+  (void)user_data; // Suppress unused parameter warning
+  if (!continuous_test_active || data == nullptr) {
+    return false;
+  }
 
-    // Count samples received
-    continuous_samples_received += data->conversion_count;
+  // Count samples received
+  continuous_samples_received += data->conversion_count;
 
-    // Send minimal data to queue for processing in main task
-    adc_queue_message_t msg;
-    msg.sample_count = data->conversion_count;
-    msg.timestamp = data->timestamp_us;
+  // Send minimal data to queue for processing in main task
+  adc_queue_message_t msg;
+  msg.sample_count = data->conversion_count;
+  msg.timestamp = data->timestamp_us;
 
-    BaseType_t higher_priority_task_woken = pdFALSE;
-    if (adc_data_queue != nullptr) {
-        xQueueSendFromISR(adc_data_queue, &msg, &higher_priority_task_woken);
-    }
+  BaseType_t higher_priority_task_woken = pdFALSE;
+  if (adc_data_queue != nullptr) {
+    xQueueSendFromISR(adc_data_queue, &msg, &higher_priority_task_woken);
+  }
 
-    return higher_priority_task_woken == pdTRUE;
+  return higher_priority_task_woken == pdTRUE;
 }
 
 /**
  * @brief Monitor callback function for threshold testing (ISR-safe)
  */
 void monitor_callback(const hf_adc_monitor_event_t* event, void* user_data) noexcept {
-    (void)user_data; // Suppress unused parameter warning
-    
-    if (!monitor_test_active || event == nullptr) {
-        return;
-    }
-    
-    // Update counters based on event type
-    if (event->event_type == hf_adc_monitor_event_type_t::HIGH_THRESH) {
-        high_threshold_count++;
-    } else if (event->event_type == hf_adc_monitor_event_type_t::LOW_THRESH) {
-        low_threshold_count++;
-    }
-    
-    // Record timestamp of last event
-    last_monitor_event_time = event->timestamp_us;
+  (void)user_data; // Suppress unused parameter warning
+
+  if (!monitor_test_active || event == nullptr) {
+    return;
+  }
+
+  // Update counters based on event type
+  if (event->event_type == hf_adc_monitor_event_type_t::HIGH_THRESH) {
+    high_threshold_count++;
+  } else if (event->event_type == hf_adc_monitor_event_type_t::LOW_THRESH) {
+    low_threshold_count++;
+  }
+
+  // Record timestamp of last event
+  last_monitor_event_time = event->timestamp_us;
 }
 
 /**
@@ -219,539 +222,544 @@ void monitor_callback(const hf_adc_monitor_event_t* event, void* user_data) noex
  * @details Validates the expected hardware connections before running other tests
  */
 bool test_hardware_validation() noexcept {
-    ESP_LOGI(TAG, "Validating hardware setup...");
-    ESP_LOGI(TAG, "Expected connections:");
-    ESP_LOGI(TAG, "  - GPIO3: 3.3V via voltage divider (should read ~3.0V)");
-    ESP_LOGI(TAG, "  - GPIO0: Potentiometer center tap (variable 0-3.3V)");  
-    ESP_LOGI(TAG, "  - GPIO1: Ground via 10kΩ resistor (should read ~0V)");
+  ESP_LOGI(TAG, "Validating hardware setup...");
+  ESP_LOGI(TAG, "Expected connections:");
+  ESP_LOGI(TAG, "  - GPIO3: 3.3V via voltage divider (should read ~3.0V)");
+  ESP_LOGI(TAG, "  - GPIO0: Potentiometer center tap (variable 0-3.3V)");
+  ESP_LOGI(TAG, "  - GPIO1: Ground via 10kΩ resistor (should read ~0V)");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Read all channels and validate hardware connections
-    bool hardware_ok = true;
-    
-    // GPIO3 - High reference (should be ~3.0-3.3V)
-    uint32_t high_voltage_mv;
-    if (test_adc.ReadSingleVoltage(TEST_CHANNEL_1, high_voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGI(TAG, "GPIO3 (HIGH): %lu mV", high_voltage_mv);
-        if (high_voltage_mv < 2800 || high_voltage_mv > 3300) {
-            ESP_LOGE(TAG, "GPIO3: Expected ~3000mV, got %lu mV - check voltage divider!", high_voltage_mv);
-            hardware_ok = false;
-        } else {
-            ESP_LOGI(TAG, "GPIO3: Hardware connection verified");
-        }
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
+
+  // Read all channels and validate hardware connections
+  bool hardware_ok = true;
+
+  // GPIO3 - High reference (should be ~3.0-3.3V)
+  uint32_t high_voltage_mv;
+  if (test_adc.ReadSingleVoltage(TEST_CHANNEL_1, high_voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGI(TAG, "GPIO3 (HIGH): %lu mV", high_voltage_mv);
+    if (high_voltage_mv < 2800 || high_voltage_mv > 3300) {
+      ESP_LOGE(TAG, "GPIO3: Expected ~3000mV, got %lu mV - check voltage divider!",
+               high_voltage_mv);
+      hardware_ok = false;
     } else {
-        ESP_LOGE(TAG, "Failed to read GPIO3");
-        hardware_ok = false;
+      ESP_LOGI(TAG, "GPIO3: Hardware connection verified");
     }
-    
-    // GPIO1 - Low reference (should be ~0V)  
-    uint32_t low_voltage_mv;
-    if (test_adc.ReadSingleVoltage(TEST_CHANNEL_3, low_voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGI(TAG, "GPIO1 (LOW): %lu mV", low_voltage_mv);
-        if (low_voltage_mv > 300) {
-            ESP_LOGE(TAG, "GPIO1: Expected ~0mV, got %lu mV - check ground connection!", low_voltage_mv);
-            hardware_ok = false;
-        } else {
-            ESP_LOGI(TAG, "GPIO1: Hardware connection verified");
-        }
-    } else {
-        ESP_LOGE(TAG, "Failed to read GPIO1");
-        hardware_ok = false;
-    }
-    
-    // GPIO0 - Variable (potentiometer - just check it's reasonable)
-    uint32_t pot_voltage_mv;
-    if (test_adc.ReadSingleVoltage(TEST_CHANNEL_2, pot_voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGI(TAG, "GPIO0 (POT): %lu mV", pot_voltage_mv);
-        if (pot_voltage_mv > 3300) {
-            ESP_LOGW(TAG, "GPIO0: %lu mV seems high - check potentiometer connection", pot_voltage_mv);
-        } else {
-            ESP_LOGI(TAG, "GPIO0: Potentiometer reading valid");
-        }
-    } else {
-        ESP_LOGE(TAG, "Failed to read GPIO0");
-        hardware_ok = false;
-    }
+  } else {
+    ESP_LOGE(TAG, "Failed to read GPIO3");
+    hardware_ok = false;
+  }
 
-    if (hardware_ok) {
-        ESP_LOGI(TAG, "[SUCCESS] Hardware validation passed - all connections verified");
+  // GPIO1 - Low reference (should be ~0V)
+  uint32_t low_voltage_mv;
+  if (test_adc.ReadSingleVoltage(TEST_CHANNEL_3, low_voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGI(TAG, "GPIO1 (LOW): %lu mV", low_voltage_mv);
+    if (low_voltage_mv > 300) {
+      ESP_LOGE(TAG, "GPIO1: Expected ~0mV, got %lu mV - check ground connection!", low_voltage_mv);
+      hardware_ok = false;
     } else {
-        ESP_LOGE(TAG, "[FAILED] Hardware validation failed - check connections before proceeding");
+      ESP_LOGI(TAG, "GPIO1: Hardware connection verified");
     }
-    
-    return hardware_ok;
+  } else {
+    ESP_LOGE(TAG, "Failed to read GPIO1");
+    hardware_ok = false;
+  }
+
+  // GPIO0 - Variable (potentiometer - just check it's reasonable)
+  uint32_t pot_voltage_mv;
+  if (test_adc.ReadSingleVoltage(TEST_CHANNEL_2, pot_voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGI(TAG, "GPIO0 (POT): %lu mV", pot_voltage_mv);
+    if (pot_voltage_mv > 3300) {
+      ESP_LOGW(TAG, "GPIO0: %lu mV seems high - check potentiometer connection", pot_voltage_mv);
+    } else {
+      ESP_LOGI(TAG, "GPIO0: Potentiometer reading valid");
+    }
+  } else {
+    ESP_LOGE(TAG, "Failed to read GPIO0");
+    hardware_ok = false;
+  }
+
+  if (hardware_ok) {
+    ESP_LOGI(TAG, "[SUCCESS] Hardware validation passed - all connections verified");
+  } else {
+    ESP_LOGE(TAG, "[FAILED] Hardware validation failed - check connections before proceeding");
+  }
+
+  return hardware_ok;
 }
 
 /**
  * @brief Test ADC initialization and basic setup
  */
 bool test_adc_initialization() noexcept {
-    ESP_LOGI(TAG, "Testing ADC initialization...");
+  ESP_LOGI(TAG, "Testing ADC initialization...");
 
-    // Test with proper configuration
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0; // ESP32-C6 has only ADC1 (unit 0)
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
-    adc_cfg.bit_width = hf_adc_bitwidth_t::WIDTH_12BIT;
+  // Test with proper configuration
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0; // ESP32-C6 has only ADC1 (unit 0)
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  adc_cfg.bit_width = hf_adc_bitwidth_t::WIDTH_12BIT;
 
-    EspAdc test_adc(adc_cfg);
+  EspAdc test_adc(adc_cfg);
 
-    if (!initialize_test_adc(test_adc)) {
-        return false;
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
+
+  // Verify ADC properties
+  uint8_t max_channels = test_adc.GetMaxChannels();
+  if (max_channels != 7) { // ESP32-C6 has 7 ADC channels (0-6)
+    ESP_LOGE(TAG, "Unexpected max channels: %d (expected 7)", max_channels);
+    return false;
+  }
+
+  // Check channel availability
+  for (hf_channel_id_t ch = 0; ch < 7; ch++) {
+    if (!test_adc.IsChannelAvailable(ch)) {
+      ESP_LOGE(TAG, "Channel %ld should be available", ch);
+      return false;
     }
+  }
 
-    // Verify ADC properties
-    uint8_t max_channels = test_adc.GetMaxChannels();
-    if (max_channels != 7) { // ESP32-C6 has 7 ADC channels (0-6)
-        ESP_LOGE(TAG, "Unexpected max channels: %d (expected 7)", max_channels);
-        return false;
-    }
+  // Check invalid channel
+  if (test_adc.IsChannelAvailable(7)) {
+    ESP_LOGE(TAG, "Channel 7 should not be available on ESP32-C6");
+    return false;
+  }
 
-    // Check channel availability
-    for (hf_channel_id_t ch = 0; ch < 7; ch++) {
-        if (!test_adc.IsChannelAvailable(ch)) {
-            ESP_LOGE(TAG, "Channel %ld should be available", ch);
-            return false;
-        }
-    }
-
-    // Check invalid channel
-    if (test_adc.IsChannelAvailable(7)) {
-        ESP_LOGE(TAG, "Channel 7 should not be available on ESP32-C6");
-        return false;
-    }
-
-    ESP_LOGI(TAG, "[SUCCESS] ADC initialization test passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] ADC initialization test passed");
+  return true;
 }
 
 /**
  * @brief Test ADC channel configuration
  */
 bool test_adc_channel_configuration() noexcept {
-    ESP_LOGI(TAG, "Testing ADC channel configuration...");
+  ESP_LOGI(TAG, "Testing ADC channel configuration...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Verify channels are enabled
-    if (!test_adc.IsChannelEnabled(TEST_CHANNEL_1)) {
-        ESP_LOGE(TAG, "Channel %lu should be enabled", static_cast<unsigned long>(TEST_CHANNEL_1));
-        return false;
-    }
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
 
-    if (!test_adc.IsChannelEnabled(TEST_CHANNEL_2)) {
-        ESP_LOGE(TAG, "Channel %lu should be enabled", static_cast<unsigned long>(TEST_CHANNEL_2));
-        return false;
-    }
+  // Verify channels are enabled
+  if (!test_adc.IsChannelEnabled(TEST_CHANNEL_1)) {
+    ESP_LOGE(TAG, "Channel %lu should be enabled", static_cast<unsigned long>(TEST_CHANNEL_1));
+    return false;
+  }
 
-    if (!test_adc.IsChannelEnabled(TEST_CHANNEL_3)) {
-        ESP_LOGE(TAG, "Channel %lu should be enabled", static_cast<unsigned long>(TEST_CHANNEL_3));
-        return false;
-    }
+  if (!test_adc.IsChannelEnabled(TEST_CHANNEL_2)) {
+    ESP_LOGE(TAG, "Channel %lu should be enabled", static_cast<unsigned long>(TEST_CHANNEL_2));
+    return false;
+  }
 
-    // Test disabling a channel
-    hf_adc_err_t result = test_adc.DisableChannel(TEST_CHANNEL_3);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to disable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_3));
-        return false;
-    }
+  if (!test_adc.IsChannelEnabled(TEST_CHANNEL_3)) {
+    ESP_LOGE(TAG, "Channel %lu should be enabled", static_cast<unsigned long>(TEST_CHANNEL_3));
+    return false;
+  }
 
-    if (test_adc.IsChannelEnabled(TEST_CHANNEL_3)) {
-        ESP_LOGE(TAG, "Channel %lu should be disabled", static_cast<unsigned long>(TEST_CHANNEL_3));
-        return false;
-    }
+  // Test disabling a channel
+  hf_adc_err_t result = test_adc.DisableChannel(TEST_CHANNEL_3);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to disable channel %lu", static_cast<unsigned long>(TEST_CHANNEL_3));
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC channel configuration test passed");
-    return true;
+  if (test_adc.IsChannelEnabled(TEST_CHANNEL_3)) {
+    ESP_LOGE(TAG, "Channel %lu should be disabled", static_cast<unsigned long>(TEST_CHANNEL_3));
+    return false;
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] ADC channel configuration test passed");
+  return true;
 }
 
 /**
  * @brief Test basic ADC conversion functionality
  */
 bool test_adc_basic_conversion() noexcept {
-    ESP_LOGI(TAG, "Testing basic ADC conversion...");
+  ESP_LOGI(TAG, "Testing basic ADC conversion...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Test raw reading
-    uint32_t raw_value = 0;
-    hf_adc_err_t result = test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-                 ESP_LOGE(TAG, "Failed to read raw value from channel %lu: %d", 
-                  static_cast<unsigned long>(TEST_CHANNEL_1), static_cast<int>(result));
-        return false;
-    }
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
 
-    if (raw_value > 4095) { // 12-bit ADC max value
-        ESP_LOGE(TAG, "Raw value %lu exceeds 12-bit maximum (4095)", raw_value);
-        return false;
-    }
+  // Test raw reading
+  uint32_t raw_value = 0;
+  hf_adc_err_t result = test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read raw value from channel %lu: %d",
+             static_cast<unsigned long>(TEST_CHANNEL_1), static_cast<int>(result));
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Channel %lu raw reading: %lu", static_cast<unsigned long>(TEST_CHANNEL_1), raw_value);
+  if (raw_value > 4095) { // 12-bit ADC max value
+    ESP_LOGE(TAG, "Raw value %lu exceeds 12-bit maximum (4095)", raw_value);
+    return false;
+  }
 
-    // Test voltage reading
-    uint32_t voltage_mv = 0;
-    result = test_adc.ReadSingleVoltage(TEST_CHANNEL_1, voltage_mv);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-                 ESP_LOGE(TAG, "Failed to read voltage from channel %lu: %d", 
-                  static_cast<unsigned long>(TEST_CHANNEL_1), static_cast<int>(result));
-        return false;
-    }
+  ESP_LOGI(TAG, "Channel %lu raw reading: %lu", static_cast<unsigned long>(TEST_CHANNEL_1),
+           raw_value);
 
-    if (!validate_voltage_reading(voltage_mv, "CH1")) {
-        return false;
-    }
+  // Test voltage reading
+  uint32_t voltage_mv = 0;
+  result = test_adc.ReadSingleVoltage(TEST_CHANNEL_1, voltage_mv);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read voltage from channel %lu: %d",
+             static_cast<unsigned long>(TEST_CHANNEL_1), static_cast<int>(result));
+    return false;
+  }
 
-    // Test BaseAdc interface methods
-    float voltage_v = 0.0f;
-    result = test_adc.ReadChannelV(TEST_CHANNEL_2, voltage_v);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-                 ESP_LOGE(TAG, "Failed to read voltage (V) from channel %lu: %d", 
-                  static_cast<unsigned long>(TEST_CHANNEL_2), static_cast<int>(result));
-        return false;
-    }
+  if (!validate_voltage_reading(voltage_mv, "CH1")) {
+    return false;
+  }
 
-    uint32_t count = 0;
-    result = test_adc.ReadChannelCount(TEST_CHANNEL_2, count);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-                 ESP_LOGE(TAG, "Failed to read count from channel %lu: %d", 
-                  static_cast<unsigned long>(TEST_CHANNEL_2), static_cast<int>(result));
-        return false;
-    }
+  // Test BaseAdc interface methods
+  float voltage_v = 0.0f;
+  result = test_adc.ReadChannelV(TEST_CHANNEL_2, voltage_v);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read voltage (V) from channel %lu: %d",
+             static_cast<unsigned long>(TEST_CHANNEL_2), static_cast<int>(result));
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Channel %lu: %.3fV, count: %lu", static_cast<unsigned long>(TEST_CHANNEL_2), voltage_v, count);
+  uint32_t count = 0;
+  result = test_adc.ReadChannelCount(TEST_CHANNEL_2, count);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read count from channel %lu: %d",
+             static_cast<unsigned long>(TEST_CHANNEL_2), static_cast<int>(result));
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Basic ADC conversion test passed");
-    return true;
+  ESP_LOGI(TAG, "Channel %lu: %.3fV, count: %lu", static_cast<unsigned long>(TEST_CHANNEL_2),
+           voltage_v, count);
+
+  ESP_LOGI(TAG, "[SUCCESS] Basic ADC conversion test passed");
+  return true;
 }
 
 /**
  * @brief Test ADC calibration functionality
  */
 bool test_adc_calibration() noexcept {
-    ESP_LOGI(TAG, "Testing ADC calibration...");
+  ESP_LOGI(TAG, "Testing ADC calibration...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
-    adc_cfg.calibration_config.enable_calibration = true;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  adc_cfg.calibration_config.enable_calibration = true;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Initialize calibration for different attenuation levels
-    hf_adc_err_t result = test_adc.InitializeCalibration(hf_adc_atten_t::ATTEN_DB_12);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to initialize calibration: %d", static_cast<int>(result));
-        return false;
-    }
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
 
-    // Check if calibration is available
-    if (!test_adc.IsCalibrationAvailable(hf_adc_atten_t::ATTEN_DB_12)) {
-        ESP_LOGW(TAG, "Calibration not available for 12dB attenuation");
-        // This is not necessarily a failure, continue testing
+  // Initialize calibration for different attenuation levels
+  hf_adc_err_t result = test_adc.InitializeCalibration(hf_adc_atten_t::ATTEN_DB_12);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to initialize calibration: %d", static_cast<int>(result));
+    return false;
+  }
+
+  // Check if calibration is available
+  if (!test_adc.IsCalibrationAvailable(hf_adc_atten_t::ATTEN_DB_12)) {
+    ESP_LOGW(TAG, "Calibration not available for 12dB attenuation");
+    // This is not necessarily a failure, continue testing
+  } else {
+    ESP_LOGI(TAG, "Calibration available for 12dB attenuation");
+
+    // Test raw to voltage conversion
+    uint32_t test_raw = 2048; // Mid-scale value
+    uint32_t converted_voltage = 0;
+    result = test_adc.RawToVoltage(test_raw, hf_adc_atten_t::ATTEN_DB_12, converted_voltage);
+    if (result == hf_adc_err_t::ADC_SUCCESS) {
+      ESP_LOGI(TAG, "Raw %lu converted to %lu mV", test_raw, converted_voltage);
     } else {
-        ESP_LOGI(TAG, "Calibration available for 12dB attenuation");
-        
-        // Test raw to voltage conversion
-        uint32_t test_raw = 2048; // Mid-scale value
-        uint32_t converted_voltage = 0;
-        result = test_adc.RawToVoltage(test_raw, hf_adc_atten_t::ATTEN_DB_12, converted_voltage);
-        if (result == hf_adc_err_t::ADC_SUCCESS) {
-            ESP_LOGI(TAG, "Raw %lu converted to %lu mV", test_raw, converted_voltage);
-        } else {
-            ESP_LOGW(TAG, "Raw to voltage conversion failed: %d", static_cast<int>(result));
-        }
+      ESP_LOGW(TAG, "Raw to voltage conversion failed: %d", static_cast<int>(result));
     }
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC calibration test passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] ADC calibration test passed");
+  return true;
 }
 
 /**
  * @brief Test reading from multiple ADC channels
  */
 bool test_adc_multiple_channels() noexcept {
-    ESP_LOGI(TAG, "Testing multiple ADC channels...");
+  ESP_LOGI(TAG, "Testing multiple ADC channels...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
+  EspAdc test_adc(adc_cfg);
+
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
+
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
+
+  // Test multiple channel reading using BaseAdc interface
+  hf_channel_id_t channels[] = {TEST_CHANNEL_1, TEST_CHANNEL_2, TEST_CHANNEL_3};
+  uint32_t readings[3] = {0};
+  float voltages[3] = {0.0f};
+
+  hf_adc_err_t result = test_adc.ReadMultipleChannels(channels, 3, readings, voltages);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read multiple channels: %d", static_cast<int>(result));
+    return false;
+  }
+
+  // Validate readings with hardware-specific expectations
+  for (int i = 0; i < 3; i++) {
+    ESP_LOGI(TAG, "Channel %ld (GPIO%ld): raw=%lu, voltage=%.3fV", channels[i], channels[i],
+             readings[i], voltages[i]);
+
+    if (readings[i] > 4095) {
+      ESP_LOGE(TAG, "Channel %ld raw reading %lu exceeds 12-bit maximum", channels[i], readings[i]);
+      return false;
     }
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
+    uint32_t voltage_mv = static_cast<uint32_t>(voltages[i] * 1000);
+
+    // Hardware-specific validation based on expected connections
+    if (channels[i] == TEST_CHANNEL_1) { // GPIO3 - High reference (~3.3V)
+      if (voltage_mv < 2800 || voltage_mv > 3300) {
+        ESP_LOGW(TAG, "GPIO3 (HIGH): Expected ~3.3V, got %lu mV - check voltage divider connection",
+                 voltage_mv);
+      } else {
+        ESP_LOGI(TAG, "GPIO3 (HIGH): %lu mV - within expected range", voltage_mv);
+      }
+    } else if (channels[i] == TEST_CHANNEL_3) { // GPIO1 - Low reference (~0V)
+      if (voltage_mv > 300) {
+        ESP_LOGW(TAG, "GPIO1 (LOW): Expected ~0V, got %lu mV - check ground connection",
+                 voltage_mv);
+      } else {
+        ESP_LOGI(TAG, "GPIO1 (LOW): %lu mV - within expected range", voltage_mv);
+      }
+    } else if (channels[i] == TEST_CHANNEL_2) { // GPIO0 - Variable (potentiometer)
+      if (voltage_mv >= 0 && voltage_mv <= 3300) {
+        ESP_LOGI(TAG, "GPIO0 (POT): %lu mV - potentiometer reading", voltage_mv);
+      } else {
+        ESP_LOGW(TAG, "GPIO0 (POT): %lu mV - outside valid range", voltage_mv);
+      }
     }
 
-    // Test multiple channel reading using BaseAdc interface
-    hf_channel_id_t channels[] = {TEST_CHANNEL_1, TEST_CHANNEL_2, TEST_CHANNEL_3};
-    uint32_t readings[3] = {0};
-    float voltages[3] = {0.0f};
-    
-    hf_adc_err_t result = test_adc.ReadMultipleChannels(channels, 3, readings, voltages);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read multiple channels: %d", static_cast<int>(result));
-        return false;
+    char channel_name[16];
+    snprintf(channel_name, sizeof(channel_name), "CH%ld", channels[i]);
+
+    if (!validate_voltage_reading(voltage_mv, channel_name)) {
+      ESP_LOGW(TAG, "Channel %ld voltage validation failed, but continuing test", channels[i]);
     }
+  }
 
-    // Validate readings with hardware-specific expectations
-    for (int i = 0; i < 3; i++) {
-        ESP_LOGI(TAG, "Channel %ld (GPIO%ld): raw=%lu, voltage=%.3fV", 
-                 channels[i], channels[i], readings[i], voltages[i]);
-        
-        if (readings[i] > 4095) {
-            ESP_LOGE(TAG, "Channel %ld raw reading %lu exceeds 12-bit maximum", 
-                     channels[i], readings[i]);
-            return false;
-        }
-
-        uint32_t voltage_mv = static_cast<uint32_t>(voltages[i] * 1000);
-        
-        // Hardware-specific validation based on expected connections
-        if (channels[i] == TEST_CHANNEL_1) { // GPIO3 - High reference (~3.3V)
-            if (voltage_mv < 2800 || voltage_mv > 3300) {
-                ESP_LOGW(TAG, "GPIO3 (HIGH): Expected ~3.3V, got %lu mV - check voltage divider connection", voltage_mv);
-            } else {
-                ESP_LOGI(TAG, "GPIO3 (HIGH): %lu mV - within expected range", voltage_mv);
-            }
-        } else if (channels[i] == TEST_CHANNEL_3) { // GPIO1 - Low reference (~0V)  
-            if (voltage_mv > 300) {
-                ESP_LOGW(TAG, "GPIO1 (LOW): Expected ~0V, got %lu mV - check ground connection", voltage_mv);
-            } else {
-                ESP_LOGI(TAG, "GPIO1 (LOW): %lu mV - within expected range", voltage_mv);
-            }
-        } else if (channels[i] == TEST_CHANNEL_2) { // GPIO0 - Variable (potentiometer)
-            if (voltage_mv >= 0 && voltage_mv <= 3300) {
-                ESP_LOGI(TAG, "GPIO0 (POT): %lu mV - potentiometer reading", voltage_mv);
-            } else {
-                ESP_LOGW(TAG, "GPIO0 (POT): %lu mV - outside valid range", voltage_mv);
-            }
-        }
-        
-        char channel_name[16];
-        snprintf(channel_name, sizeof(channel_name), "CH%ld", channels[i]);
-        
-        if (!validate_voltage_reading(voltage_mv, channel_name)) {
-            ESP_LOGW(TAG, "Channel %ld voltage validation failed, but continuing test", channels[i]);
-        }
-    }
-
-    ESP_LOGI(TAG, "[SUCCESS] Multiple ADC channels test passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Multiple ADC channels test passed");
+  return true;
 }
 
 /**
  * @brief Test ADC averaging functionality
  */
 bool test_adc_averaging() noexcept {
-    ESP_LOGI(TAG, "Testing ADC averaging...");
+  ESP_LOGI(TAG, "Testing ADC averaging...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Test averaging with different sample counts
-    uint16_t sample_counts[] = {1, 4, 8, 16};
-    
-    for (size_t i = 0; i < sizeof(sample_counts) / sizeof(sample_counts[0]); i++) {
-        uint32_t averaged_value = 0;
-        hf_adc_err_t result = test_adc.ReadAveraged(TEST_CHANNEL_1, sample_counts[i], averaged_value);
-        
-        if (result != hf_adc_err_t::ADC_SUCCESS) {
-            ESP_LOGE(TAG, "Failed to read averaged value with %d samples: %d", 
-                     sample_counts[i], static_cast<int>(result));
-            return false;
-        }
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
 
-        ESP_LOGI(TAG, "Channel %lu averaged over %d samples: %lu", 
-                 static_cast<unsigned long>(TEST_CHANNEL_1), sample_counts[i], averaged_value);
+  // Test averaging with different sample counts
+  uint16_t sample_counts[] = {1, 4, 8, 16};
 
-        if (averaged_value > 4095) {
-            ESP_LOGE(TAG, "Averaged value %lu exceeds 12-bit maximum", averaged_value);
-            return false;
-        }
-    }
+  for (size_t i = 0; i < sizeof(sample_counts) / sizeof(sample_counts[0]); i++) {
+    uint32_t averaged_value = 0;
+    hf_adc_err_t result = test_adc.ReadAveraged(TEST_CHANNEL_1, sample_counts[i], averaged_value);
 
-    // Test BaseAdc averaging interface
-    float voltage_v = 0.0f;
-    hf_adc_err_t result = test_adc.ReadChannelV(TEST_CHANNEL_2, voltage_v, 8, 10);
     if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read averaged voltage: %d", static_cast<int>(result));
-        return false;
+      ESP_LOGE(TAG, "Failed to read averaged value with %d samples: %d", sample_counts[i],
+               static_cast<int>(result));
+      return false;
     }
 
-    ESP_LOGI(TAG, "Channel %lu averaged voltage (8 samples, 10ms between): %.3fV", 
-             static_cast<unsigned long>(TEST_CHANNEL_2), voltage_v);
+    ESP_LOGI(TAG, "Channel %lu averaged over %d samples: %lu",
+             static_cast<unsigned long>(TEST_CHANNEL_1), sample_counts[i], averaged_value);
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC averaging test passed");
-    return true;
+    if (averaged_value > 4095) {
+      ESP_LOGE(TAG, "Averaged value %lu exceeds 12-bit maximum", averaged_value);
+      return false;
+    }
+  }
+
+  // Test BaseAdc averaging interface
+  float voltage_v = 0.0f;
+  hf_adc_err_t result = test_adc.ReadChannelV(TEST_CHANNEL_2, voltage_v, 8, 10);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read averaged voltage: %d", static_cast<int>(result));
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Channel %lu averaged voltage (8 samples, 10ms between): %.3fV",
+           static_cast<unsigned long>(TEST_CHANNEL_2), voltage_v);
+
+  ESP_LOGI(TAG, "[SUCCESS] ADC averaging test passed");
+  return true;
 }
 
 /**
  * @brief Test ADC continuous mode functionality
  */
 bool test_adc_continuous_mode() noexcept {
-    ESP_LOGI(TAG, "Testing ADC continuous mode...");
+  ESP_LOGI(TAG, "Testing ADC continuous mode...");
 
-    // Create queue for continuous mode data
-    adc_data_queue = xQueueCreate(10, sizeof(adc_queue_message_t));
-    if (adc_data_queue == nullptr) {
-        ESP_LOGE(TAG, "Failed to create ADC data queue");
-        return false;
-    }
+  // Create queue for continuous mode data
+  adc_data_queue = xQueueCreate(10, sizeof(adc_queue_message_t));
+  if (adc_data_queue == nullptr) {
+    ESP_LOGE(TAG, "Failed to create ADC data queue");
+    return false;
+  }
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::CONTINUOUS;
-    adc_cfg.continuous_config.sample_freq_hz = 1000;
-    adc_cfg.continuous_config.samples_per_frame = CONTINUOUS_SAMPLES_PER_FRAME;
-    adc_cfg.continuous_config.max_store_frames = CONTINUOUS_MAX_STORE_FRAMES;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::CONTINUOUS;
+  adc_cfg.continuous_config.sample_freq_hz = 1000;
+  adc_cfg.continuous_config.samples_per_frame = CONTINUOUS_SAMPLES_PER_FRAME;
+  adc_cfg.continuous_config.max_store_frames = CONTINUOUS_MAX_STORE_FRAMES;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
-
-    // Configure continuous mode
-    hf_adc_err_t result = test_adc.ConfigureContinuous(adc_cfg.continuous_config);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure continuous mode: %d", static_cast<int>(result));
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
-
-    // Set callback
-    result = test_adc.SetContinuousCallback(continuous_callback, nullptr);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set continuous callback: %d", static_cast<int>(result));
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
-
-    // Start continuous mode
-    continuous_test_active = true;
-    continuous_samples_received = 0;
-    
-    result = test_adc.StartContinuous();
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to start continuous mode: %d", static_cast<int>(result));
-        continuous_test_active = false;
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
-
-    if (!test_adc.IsContinuousRunning()) {
-        ESP_LOGE(TAG, "Continuous mode should be running");
-        continuous_test_active = false;
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
-
-    ESP_LOGI(TAG, "Continuous mode started, collecting data for %lu ms...", CONTINUOUS_TEST_DURATION_MS);
-
-    // Wait and collect data
-    uint32_t start_time = xTaskGetTickCount() * portTICK_PERIOD_MS;
-    uint32_t messages_received = 0;
-    
-    while ((xTaskGetTickCount() * portTICK_PERIOD_MS - start_time) < CONTINUOUS_TEST_DURATION_MS) {
-        adc_queue_message_t msg;
-        
-        if (xQueueReceive(adc_data_queue, &msg, pdMS_TO_TICKS(100)) == pdTRUE) {
-            messages_received++;
-            ESP_LOGD(TAG, "Received %lu samples at timestamp %llu", msg.sample_count, msg.timestamp);
-        }
-    }
-
-    // Stop continuous mode
-    continuous_test_active = false;
-    result = test_adc.StopContinuous();
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to stop continuous mode: %d", static_cast<int>(result));
-        vQueueDelete(adc_data_queue);
-        return false;
-    }
-
-    ESP_LOGI(TAG, "Continuous mode test completed:");
-    ESP_LOGI(TAG, "  - Messages received: %lu", messages_received);
-    ESP_LOGI(TAG, "  - Total samples: %lu", continuous_samples_received);
-    ESP_LOGI(TAG, "  - Test duration: %lu ms", CONTINUOUS_TEST_DURATION_MS);
-
+  if (!initialize_test_adc(test_adc)) {
     vQueueDelete(adc_data_queue);
-    adc_data_queue = nullptr;
+    return false;
+  }
 
-    if (messages_received == 0) {
-        ESP_LOGE(TAG, "No continuous mode data received");
-        return false;
+  if (!configure_test_channels(test_adc)) {
+    vQueueDelete(adc_data_queue);
+    return false;
+  }
+
+  // Configure continuous mode
+  hf_adc_err_t result = test_adc.ConfigureContinuous(adc_cfg.continuous_config);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure continuous mode: %d", static_cast<int>(result));
+    vQueueDelete(adc_data_queue);
+    return false;
+  }
+
+  // Set callback
+  result = test_adc.SetContinuousCallback(continuous_callback, nullptr);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set continuous callback: %d", static_cast<int>(result));
+    vQueueDelete(adc_data_queue);
+    return false;
+  }
+
+  // Start continuous mode
+  continuous_test_active = true;
+  continuous_samples_received = 0;
+
+  result = test_adc.StartContinuous();
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to start continuous mode: %d", static_cast<int>(result));
+    continuous_test_active = false;
+    vQueueDelete(adc_data_queue);
+    return false;
+  }
+
+  if (!test_adc.IsContinuousRunning()) {
+    ESP_LOGE(TAG, "Continuous mode should be running");
+    continuous_test_active = false;
+    vQueueDelete(adc_data_queue);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Continuous mode started, collecting data for %lu ms...",
+           CONTINUOUS_TEST_DURATION_MS);
+
+  // Wait and collect data
+  uint32_t start_time = xTaskGetTickCount() * portTICK_PERIOD_MS;
+  uint32_t messages_received = 0;
+
+  while ((xTaskGetTickCount() * portTICK_PERIOD_MS - start_time) < CONTINUOUS_TEST_DURATION_MS) {
+    adc_queue_message_t msg;
+
+    if (xQueueReceive(adc_data_queue, &msg, pdMS_TO_TICKS(100)) == pdTRUE) {
+      messages_received++;
+      ESP_LOGD(TAG, "Received %lu samples at timestamp %llu", msg.sample_count, msg.timestamp);
     }
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC continuous mode test passed");
-    return true;
+  // Stop continuous mode
+  continuous_test_active = false;
+  result = test_adc.StopContinuous();
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to stop continuous mode: %d", static_cast<int>(result));
+    vQueueDelete(adc_data_queue);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Continuous mode test completed:");
+  ESP_LOGI(TAG, "  - Messages received: %lu", messages_received);
+  ESP_LOGI(TAG, "  - Total samples: %lu", continuous_samples_received);
+  ESP_LOGI(TAG, "  - Test duration: %lu ms", CONTINUOUS_TEST_DURATION_MS);
+
+  vQueueDelete(adc_data_queue);
+  adc_data_queue = nullptr;
+
+  if (messages_received == 0) {
+    ESP_LOGE(TAG, "No continuous mode data received");
+    return false;
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] ADC continuous mode test passed");
+  return true;
 }
 
 /**
@@ -762,441 +770,460 @@ bool test_adc_continuous_mode() noexcept {
  * - Adjust potentiometer during test to trigger high/low thresholds
  */
 bool test_adc_monitor_thresholds() noexcept {
-    ESP_LOGI(TAG, "Testing ADC monitor thresholds...");
-    ESP_LOGI(TAG, "Hardware setup required:");
-    ESP_LOGI(TAG, "  - GPIO0: Connect to potentiometer (0-3.3V)");
-    ESP_LOGI(TAG, "  - Adjust potentiometer during test to trigger thresholds");
+  ESP_LOGI(TAG, "Testing ADC monitor thresholds...");
+  ESP_LOGI(TAG, "Hardware setup required:");
+  ESP_LOGI(TAG, "  - GPIO0: Connect to potentiometer (0-3.3V)");
+  ESP_LOGI(TAG, "  - Adjust potentiometer during test to trigger thresholds");
 
-    // Configure ADC for monitor testing
-    hf_adc_unit_config_t adc_config = {};
-    adc_config.unit_id = 0; // ESP32-C6 has only ADC1
-    adc_config.mode = hf_adc_mode_t::CONTINUOUS; // Monitor requires continuous mode
-    adc_config.continuous_config.sample_freq_hz = 1000; // 1kHz sampling
-    adc_config.continuous_config.samples_per_frame = 64;
-    adc_config.continuous_config.max_store_frames = 4;
-    
-    EspAdc adc(adc_config);
-    
-    if (!initialize_test_adc(adc)) {
-        ESP_LOGE(TAG, "Failed to initialize ADC for monitor test");
-        return false;
-    }
-    
-    // Configure potentiometer channel (GPIO0 = TEST_CHANNEL_2)
-    const hf_channel_id_t MONITOR_CHANNEL = TEST_CHANNEL_2; // GPIO0
-    hf_adc_err_t result = adc.ConfigureChannel(MONITOR_CHANNEL, hf_adc_atten_t::ATTEN_DB_12);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure monitor channel");
-        return false;
-    }
-    
-    result = adc.EnableChannel(MONITOR_CHANNEL);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable monitor channel");
-        return false;
-    }
+  // Configure ADC for monitor testing
+  hf_adc_unit_config_t adc_config = {};
+  adc_config.unit_id = 0;                             // ESP32-C6 has only ADC1
+  adc_config.mode = hf_adc_mode_t::CONTINUOUS;        // Monitor requires continuous mode
+  adc_config.continuous_config.sample_freq_hz = 1000; // 1kHz sampling
+  adc_config.continuous_config.samples_per_frame = 64;
+  adc_config.continuous_config.max_store_frames = 4;
 
-    // Read current voltage to set appropriate thresholds
-    uint32_t current_voltage_mv;
-    result = adc.ReadSingleVoltage(MONITOR_CHANNEL, current_voltage_mv);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read current voltage for threshold setup");
-        return false;
+  EspAdc adc(adc_config);
+
+  if (!initialize_test_adc(adc)) {
+    ESP_LOGE(TAG, "Failed to initialize ADC for monitor test");
+    return false;
+  }
+
+  // Configure potentiometer channel (GPIO0 = TEST_CHANNEL_2)
+  const hf_channel_id_t MONITOR_CHANNEL = TEST_CHANNEL_2; // GPIO0
+  hf_adc_err_t result = adc.ConfigureChannel(MONITOR_CHANNEL, hf_adc_atten_t::ATTEN_DB_12);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure monitor channel");
+    return false;
+  }
+
+  result = adc.EnableChannel(MONITOR_CHANNEL);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable monitor channel");
+    return false;
+  }
+
+  // Read current voltage to set appropriate thresholds
+  uint32_t current_voltage_mv;
+  result = adc.ReadSingleVoltage(MONITOR_CHANNEL, current_voltage_mv);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read current voltage for threshold setup");
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Current potentiometer voltage: %lu mV", current_voltage_mv);
+
+  // Validate potentiometer is working (not stuck at rail)
+  if (current_voltage_mv < 100 || current_voltage_mv > 3200) {
+    ESP_LOGW(TAG, "Potentiometer voltage (%lu mV) at rail - may affect monitor testing",
+             current_voltage_mv);
+  }
+
+  // Set intelligent thresholds based on current voltage with proper bounds
+  // Ensure thresholds are sufficiently spread and within ADC range
+  uint32_t high_thresh_mv, low_thresh_mv;
+
+  if (current_voltage_mv < 1000) {
+    // Pot is low - set thresholds above current position
+    high_thresh_mv = current_voltage_mv + 800;
+    low_thresh_mv = (current_voltage_mv > 400) ? current_voltage_mv - 400 : 200;
+  } else if (current_voltage_mv > 2300) {
+    // Pot is high - set thresholds below current position
+    low_thresh_mv = current_voltage_mv - 800;
+    high_thresh_mv = (current_voltage_mv < 2900) ? current_voltage_mv + 400 : 3100;
+  } else {
+    // Pot is mid-range - set thresholds on both sides
+    high_thresh_mv = current_voltage_mv + 600;
+    low_thresh_mv = current_voltage_mv - 600;
+  }
+
+  // Clamp to valid ADC range
+  high_thresh_mv = (high_thresh_mv > 3200) ? 3200 : high_thresh_mv;
+  low_thresh_mv = (low_thresh_mv < 200) ? 200 : low_thresh_mv;
+
+  // Ensure minimum separation between thresholds
+  if ((high_thresh_mv - low_thresh_mv) < 800) {
+    ESP_LOGW(TAG, "Threshold separation too small, adjusting...");
+    uint32_t mid = (high_thresh_mv + low_thresh_mv) / 2;
+    high_thresh_mv = mid + 400;
+    low_thresh_mv = mid - 400;
+  }
+
+  // Convert mV to raw ADC counts (approximate for 12dB attenuation)
+  // 12dB attenuation: ~0-3.3V range, 4096 counts
+  uint32_t high_thresh_raw = (high_thresh_mv * 4095) / 3300;
+  uint32_t low_thresh_raw = (low_thresh_mv * 4095) / 3300;
+
+  ESP_LOGI(TAG, "Setting thresholds:");
+  ESP_LOGI(TAG, "  - High: %lu mV (%lu counts)", high_thresh_mv, high_thresh_raw);
+  ESP_LOGI(TAG, "  - Low:  %lu mV (%lu counts)", low_thresh_mv, low_thresh_raw);
+
+  // Configure monitor
+  hf_adc_monitor_config_t monitor_config = {};
+  monitor_config.monitor_id = 0;
+  monitor_config.channel_id = MONITOR_CHANNEL;
+  monitor_config.high_threshold = high_thresh_raw;
+  monitor_config.low_threshold = low_thresh_raw;
+
+  result = adc.ConfigureMonitor(monitor_config);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure monitor");
+    return false;
+  }
+
+  // Set monitor callback
+  result = adc.SetMonitorCallback(0, monitor_callback);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set monitor callback");
+    return false;
+  }
+
+  // Start continuous mode (required for monitoring)
+  result = adc.StartContinuous();
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to start continuous mode");
+    return false;
+  }
+
+  // Enable monitor
+  result = adc.SetMonitorEnabled(0, true);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable monitor");
+    return false;
+  }
+
+  // Reset counters and activate test
+  high_threshold_count = 0;
+  low_threshold_count = 0;
+  last_monitor_event_time = 0;
+  monitor_test_active = true;
+
+  ESP_LOGI(TAG, "Monitor system active! Please adjust potentiometer now:");
+  ESP_LOGI(TAG, "   Current reading: %lu mV", current_voltage_mv);
+  ESP_LOGI(TAG, "   Turn potentiometer HIGH (above %lu mV) to trigger high threshold",
+           high_thresh_mv);
+  ESP_LOGI(TAG, "   Turn potentiometer LOW (below %lu mV) to trigger low threshold", low_thresh_mv);
+  ESP_LOGI(TAG, "   Test duration: 15 seconds with real-time feedback");
+  ESP_LOGI(TAG,
+           "   Tip: Start with small movements to verify detection, then make larger adjustments");
+
+  // Monitor for 15 seconds with periodic status updates
+  const uint32_t TEST_DURATION_MS = 15000;
+  const uint32_t UPDATE_INTERVAL_MS = 2000; // 2 second updates
+  uint32_t elapsed_ms = 0;
+
+  while (elapsed_ms < TEST_DURATION_MS) {
+    vTaskDelay(pdMS_TO_TICKS(UPDATE_INTERVAL_MS));
+    elapsed_ms += UPDATE_INTERVAL_MS;
+
+    // Read current voltage
+    uint32_t voltage_mv;
+    if (adc.ReadSingleVoltage(MONITOR_CHANNEL, voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
+      ESP_LOGI(TAG, "%2lu/%2lu sec | Voltage: %4lu mV | High events: %2lu | Low events: %2lu",
+               elapsed_ms / 1000, TEST_DURATION_MS / 1000, voltage_mv, high_threshold_count,
+               low_threshold_count);
     }
-    
-    ESP_LOGI(TAG, "Current potentiometer voltage: %lu mV", current_voltage_mv);
-    
-    // Validate potentiometer is working (not stuck at rail)
-    if (current_voltage_mv < 100 || current_voltage_mv > 3200) {
-        ESP_LOGW(TAG, "Potentiometer voltage (%lu mV) at rail - may affect monitor testing", current_voltage_mv);
-    }
-    
-    // Set intelligent thresholds based on current voltage with proper bounds
-    // Ensure thresholds are sufficiently spread and within ADC range
-    uint32_t high_thresh_mv, low_thresh_mv;
-    
-    if (current_voltage_mv < 1000) {
-        // Pot is low - set thresholds above current position
-        high_thresh_mv = current_voltage_mv + 800;
-        low_thresh_mv = (current_voltage_mv > 400) ? current_voltage_mv - 400 : 200;
-    } else if (current_voltage_mv > 2300) {
-        // Pot is high - set thresholds below current position  
-        low_thresh_mv = current_voltage_mv - 800;
-        high_thresh_mv = (current_voltage_mv < 2900) ? current_voltage_mv + 400 : 3100;
+  }
+
+  // Stop monitoring
+  monitor_test_active = false;
+  adc.SetMonitorEnabled(0, false);
+  adc.StopContinuous();
+
+  ESP_LOGI(TAG, "Monitor test completed:");
+  ESP_LOGI(TAG, "  - High threshold events: %lu", high_threshold_count);
+  ESP_LOGI(TAG, "  - Low threshold events:  %lu", low_threshold_count);
+  ESP_LOGI(TAG, "  - Total events:          %lu", high_threshold_count + low_threshold_count);
+  ESP_LOGI(TAG, "  - Last event time:       %llu us", last_monitor_event_time);
+
+  // Validation
+  bool test_passed = true;
+
+  if (high_threshold_count == 0 && low_threshold_count == 0) {
+    ESP_LOGW(
+        TAG,
+        "No threshold events detected - please ensure potentiometer is connected and adjusted");
+    ESP_LOGW(TAG, "   This may indicate hardware setup issues or thresholds not crossed");
+    // Don't fail the test - could be valid if thresholds weren't crossed
+  }
+
+  if (last_monitor_event_time == 0 && (high_threshold_count > 0 || low_threshold_count > 0)) {
+    ESP_LOGE(TAG, "Events counted but no timestamp recorded - callback issue");
+    test_passed = false;
+  }
+
+  if (test_passed) {
+    ESP_LOGI(TAG, "[SUCCESS] ADC monitor threshold test completed");
+    if (high_threshold_count > 0 || low_threshold_count > 0) {
+      ESP_LOGI(TAG, "Monitor system working correctly - events detected and processed");
     } else {
-        // Pot is mid-range - set thresholds on both sides
-        high_thresh_mv = current_voltage_mv + 600;
-        low_thresh_mv = current_voltage_mv - 600;
+      ESP_LOGI(TAG, "Monitor system ready - no threshold crossings during test period");
     }
-    
-    // Clamp to valid ADC range
-    high_thresh_mv = (high_thresh_mv > 3200) ? 3200 : high_thresh_mv;
-    low_thresh_mv = (low_thresh_mv < 200) ? 200 : low_thresh_mv;
-    
-    // Ensure minimum separation between thresholds
-    if ((high_thresh_mv - low_thresh_mv) < 800) {
-        ESP_LOGW(TAG, "Threshold separation too small, adjusting...");
-        uint32_t mid = (high_thresh_mv + low_thresh_mv) / 2;
-        high_thresh_mv = mid + 400;
-        low_thresh_mv = mid - 400;
-    }
-    
-    // Convert mV to raw ADC counts (approximate for 12dB attenuation)
-    // 12dB attenuation: ~0-3.3V range, 4096 counts
-    uint32_t high_thresh_raw = (high_thresh_mv * 4095) / 3300;
-    uint32_t low_thresh_raw = (low_thresh_mv * 4095) / 3300;
-    
-    ESP_LOGI(TAG, "Setting thresholds:");
-    ESP_LOGI(TAG, "  - High: %lu mV (%lu counts)", high_thresh_mv, high_thresh_raw);
-    ESP_LOGI(TAG, "  - Low:  %lu mV (%lu counts)", low_thresh_mv, low_thresh_raw);
+  } else {
+    ESP_LOGE(TAG, "[FAILED] ADC monitor threshold test failed");
+  }
 
-    // Configure monitor
-    hf_adc_monitor_config_t monitor_config = {};
-    monitor_config.monitor_id = 0;
-    monitor_config.channel_id = MONITOR_CHANNEL;
-    monitor_config.high_threshold = high_thresh_raw;
-    monitor_config.low_threshold = low_thresh_raw;
-    
-    result = adc.ConfigureMonitor(monitor_config);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure monitor");
-        return false;
-    }
-    
-    // Set monitor callback
-    result = adc.SetMonitorCallback(0, monitor_callback);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set monitor callback");
-        return false;
-    }
-    
-    // Start continuous mode (required for monitoring)
-    result = adc.StartContinuous();
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to start continuous mode");
-        return false;
-    }
-    
-    // Enable monitor
-    result = adc.SetMonitorEnabled(0, true);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable monitor");
-        return false;
-    }
-    
-    // Reset counters and activate test
-    high_threshold_count = 0;
-    low_threshold_count = 0;
-    last_monitor_event_time = 0;
-    monitor_test_active = true;
-    
-    ESP_LOGI(TAG, "Monitor system active! Please adjust potentiometer now:");
-    ESP_LOGI(TAG, "   Current reading: %lu mV", current_voltage_mv);
-    ESP_LOGI(TAG, "   Turn potentiometer HIGH (above %lu mV) to trigger high threshold", high_thresh_mv);
-    ESP_LOGI(TAG, "   Turn potentiometer LOW (below %lu mV) to trigger low threshold", low_thresh_mv);
-    ESP_LOGI(TAG, "   Test duration: 15 seconds with real-time feedback");
-    ESP_LOGI(TAG, "   Tip: Start with small movements to verify detection, then make larger adjustments");
-    
-    // Monitor for 15 seconds with periodic status updates
-    const uint32_t TEST_DURATION_MS = 15000;
-    const uint32_t UPDATE_INTERVAL_MS = 2000; // 2 second updates
-    uint32_t elapsed_ms = 0;
-    
-    while (elapsed_ms < TEST_DURATION_MS) {
-        vTaskDelay(pdMS_TO_TICKS(UPDATE_INTERVAL_MS));
-        elapsed_ms += UPDATE_INTERVAL_MS;
-        
-        // Read current voltage
-        uint32_t voltage_mv;
-        if (adc.ReadSingleVoltage(MONITOR_CHANNEL, voltage_mv) == hf_adc_err_t::ADC_SUCCESS) {
-            ESP_LOGI(TAG, "%2lu/%2lu sec | Voltage: %4lu mV | High events: %2lu | Low events: %2lu",
-                     elapsed_ms / 1000, TEST_DURATION_MS / 1000, voltage_mv, 
-                     high_threshold_count, low_threshold_count);
-        }
-    }
-    
-    // Stop monitoring
-    monitor_test_active = false;
-    adc.SetMonitorEnabled(0, false);
-    adc.StopContinuous();
-    
-    ESP_LOGI(TAG, "Monitor test completed:");
-    ESP_LOGI(TAG, "  - High threshold events: %lu", high_threshold_count);
-    ESP_LOGI(TAG, "  - Low threshold events:  %lu", low_threshold_count);
-    ESP_LOGI(TAG, "  - Total events:          %lu", high_threshold_count + low_threshold_count);
-    ESP_LOGI(TAG, "  - Last event time:       %llu us", last_monitor_event_time);
-    
-    // Validation
-    bool test_passed = true;
-    
-    if (high_threshold_count == 0 && low_threshold_count == 0) {
-        ESP_LOGW(TAG, "No threshold events detected - please ensure potentiometer is connected and adjusted");
-        ESP_LOGW(TAG, "   This may indicate hardware setup issues or thresholds not crossed");
-        // Don't fail the test - could be valid if thresholds weren't crossed
-    }
-    
-    if (last_monitor_event_time == 0 && (high_threshold_count > 0 || low_threshold_count > 0)) {
-        ESP_LOGE(TAG, "Events counted but no timestamp recorded - callback issue");
-        test_passed = false;
-    }
-    
-    if (test_passed) {
-        ESP_LOGI(TAG, "[SUCCESS] ADC monitor threshold test completed");
-        if (high_threshold_count > 0 || low_threshold_count > 0) {
-            ESP_LOGI(TAG, "Monitor system working correctly - events detected and processed");
-        } else {
-            ESP_LOGI(TAG, "Monitor system ready - no threshold crossings during test period");
-        }
-    } else {
-        ESP_LOGE(TAG, "[FAILED] ADC monitor threshold test failed");
-    }
-    
-    return test_passed;
+  return test_passed;
 }
 
 /**
  * @brief Test ADC error handling
  */
 bool test_adc_error_handling() noexcept {
-    ESP_LOGI(TAG, "Testing ADC error handling...");
+  ESP_LOGI(TAG, "Testing ADC error handling...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    // Test reading from invalid channel
-    uint32_t raw_value = 0;
-    hf_adc_err_t result = test_adc.ReadSingleRaw(99, raw_value); // Invalid channel
-    if (result == hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Should have failed to read from invalid channel");
-        return false;
-    }
-    ESP_LOGI(TAG, "Correctly rejected invalid channel read: %d", static_cast<int>(result));
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Test reading from disabled channel
-    result = test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value); // Channel not configured/enabled
-    if (result == hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Should have failed to read from disabled channel");
-        return false;
-    }
-    ESP_LOGI(TAG, "Correctly rejected disabled channel read: %d", static_cast<int>(result));
+  // Test reading from invalid channel
+  uint32_t raw_value = 0;
+  hf_adc_err_t result = test_adc.ReadSingleRaw(99, raw_value); // Invalid channel
+  if (result == hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Should have failed to read from invalid channel");
+    return false;
+  }
+  ESP_LOGI(TAG, "Correctly rejected invalid channel read: %d", static_cast<int>(result));
 
-    // Configure and enable channel for valid read
-    result = test_adc.ConfigureChannel(TEST_CHANNEL_1, hf_adc_atten_t::ATTEN_DB_12);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to configure channel: %d", static_cast<int>(result));
-        return false;
-    }
+  // Test reading from disabled channel
+  result = test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value); // Channel not configured/enabled
+  if (result == hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Should have failed to read from disabled channel");
+    return false;
+  }
+  ESP_LOGI(TAG, "Correctly rejected disabled channel read: %d", static_cast<int>(result));
 
-    result = test_adc.EnableChannel(TEST_CHANNEL_1);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable channel: %d", static_cast<int>(result));
-        return false;
-    }
+  // Configure and enable channel for valid read
+  result = test_adc.ConfigureChannel(TEST_CHANNEL_1, hf_adc_atten_t::ATTEN_DB_12);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to configure channel: %d", static_cast<int>(result));
+    return false;
+  }
 
-    // Now valid read should work
-    result = test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Valid channel read should have succeeded: %d", static_cast<int>(result));
-        return false;
-    }
-    ESP_LOGI(TAG, "Valid channel read succeeded: %lu", raw_value);
+  result = test_adc.EnableChannel(TEST_CHANNEL_1);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable channel: %d", static_cast<int>(result));
+    return false;
+  }
 
-    // Test null pointer handling
-    result = test_adc.ReadMultipleRaw(nullptr, 1, &raw_value);
-    if (result == hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Should have failed with null channel array");
-        return false;
-    }
-    ESP_LOGI(TAG, "Correctly rejected null pointer: %d", static_cast<int>(result));
+  // Now valid read should work
+  result = test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Valid channel read should have succeeded: %d", static_cast<int>(result));
+    return false;
+  }
+  ESP_LOGI(TAG, "Valid channel read succeeded: %lu", raw_value);
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC error handling test passed");
-    return true;
+  // Test null pointer handling
+  result = test_adc.ReadMultipleRaw(nullptr, 1, &raw_value);
+  if (result == hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Should have failed with null channel array");
+    return false;
+  }
+  ESP_LOGI(TAG, "Correctly rejected null pointer: %d", static_cast<int>(result));
+
+  ESP_LOGI(TAG, "[SUCCESS] ADC error handling test passed");
+  return true;
 }
 
 /**
  * @brief Test ADC statistics and diagnostics
  */
 bool test_adc_statistics() noexcept {
-    ESP_LOGI(TAG, "Testing ADC statistics...");
+  ESP_LOGI(TAG, "Testing ADC statistics...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Reset statistics
-    hf_adc_err_t result = test_adc.ResetStatistics();
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to reset statistics: %d", static_cast<int>(result));
-        return false;
-    }
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
 
-    // Perform several readings to generate statistics
-    for (int i = 0; i < 10; i++) {
-        uint32_t raw_value = 0;
-        test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
-        vTaskDelay(pdMS_TO_TICKS(10));
-    }
+  // Reset statistics
+  hf_adc_err_t result = test_adc.ResetStatistics();
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to reset statistics: %d", static_cast<int>(result));
+    return false;
+  }
 
-    // Get statistics
-    hf_adc_statistics_t stats = {};
-    result = test_adc.GetStatistics(stats);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get statistics: %d", static_cast<int>(result));
-        return false;
-    }
+  // Perform several readings to generate statistics
+  for (int i = 0; i < 10; i++) {
+    uint32_t raw_value = 0;
+    test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
+    vTaskDelay(pdMS_TO_TICKS(10));
+  }
 
-    ESP_LOGI(TAG, "ADC Statistics:");
-    ESP_LOGI(TAG, "  - Total conversions: %lu", stats.totalConversions);
-    ESP_LOGI(TAG, "  - Successful: %lu", stats.successfulConversions);
-    ESP_LOGI(TAG, "  - Failed: %lu", stats.failedConversions);
-    ESP_LOGI(TAG, "  - Min time: %lu us", stats.minConversionTimeUs);
-    ESP_LOGI(TAG, "  - Max time: %lu us", stats.maxConversionTimeUs);
-    ESP_LOGI(TAG, "  - Avg time: %lu us", stats.averageConversionTimeUs);
+  // Get statistics
+  hf_adc_statistics_t stats = {};
+  result = test_adc.GetStatistics(stats);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get statistics: %d", static_cast<int>(result));
+    return false;
+  }
 
-    // Get diagnostics
-    hf_adc_diagnostics_t diagnostics = {};
-    result = test_adc.GetDiagnostics(diagnostics);
-    if (result != hf_adc_err_t::ADC_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get diagnostics: %d", static_cast<int>(result));
-        return false;
-    }
+  ESP_LOGI(TAG, "ADC Statistics:");
+  ESP_LOGI(TAG, "  - Total conversions: %lu", stats.totalConversions);
+  ESP_LOGI(TAG, "  - Successful: %lu", stats.successfulConversions);
+  ESP_LOGI(TAG, "  - Failed: %lu", stats.failedConversions);
+  ESP_LOGI(TAG, "  - Min time: %lu us", stats.minConversionTimeUs);
+  ESP_LOGI(TAG, "  - Max time: %lu us", stats.maxConversionTimeUs);
+  ESP_LOGI(TAG, "  - Avg time: %lu us", stats.averageConversionTimeUs);
 
-    ESP_LOGI(TAG, "ADC Diagnostics:");
-    ESP_LOGI(TAG, "  - Healthy: %s", diagnostics.adcHealthy ? "Yes" : "No");
-    ESP_LOGI(TAG, "  - Enabled channels: 0x%lx", diagnostics.enabled_channels);
-    ESP_LOGI(TAG, "  - Last error: %d", static_cast<int>(diagnostics.lastErrorCode));
+  // Get diagnostics
+  hf_adc_diagnostics_t diagnostics = {};
+  result = test_adc.GetDiagnostics(diagnostics);
+  if (result != hf_adc_err_t::ADC_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get diagnostics: %d", static_cast<int>(result));
+    return false;
+  }
 
-    if (stats.totalConversions < 10) {
-        ESP_LOGE(TAG, "Expected at least 10 conversions, got %lu", stats.totalConversions);
-        return false;
-    }
+  ESP_LOGI(TAG, "ADC Diagnostics:");
+  ESP_LOGI(TAG, "  - Healthy: %s", diagnostics.adcHealthy ? "Yes" : "No");
+  ESP_LOGI(TAG, "  - Enabled channels: 0x%lx", diagnostics.enabled_channels);
+  ESP_LOGI(TAG, "  - Last error: %d", static_cast<int>(diagnostics.lastErrorCode));
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC statistics test passed");
-    return true;
+  if (stats.totalConversions < 10) {
+    ESP_LOGE(TAG, "Expected at least 10 conversions, got %lu", stats.totalConversions);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] ADC statistics test passed");
+  return true;
 }
 
 /**
  * @brief Test ADC performance characteristics
  */
 bool test_adc_performance() noexcept {
-    ESP_LOGI(TAG, "Testing ADC performance...");
+  ESP_LOGI(TAG, "Testing ADC performance...");
 
-    hf_adc_unit_config_t adc_cfg = {};
-    adc_cfg.unit_id = 0;
-    adc_cfg.mode = hf_adc_mode_t::ONESHOT;
+  hf_adc_unit_config_t adc_cfg = {};
+  adc_cfg.unit_id = 0;
+  adc_cfg.mode = hf_adc_mode_t::ONESHOT;
 
-    EspAdc test_adc(adc_cfg);
-    
-    if (!initialize_test_adc(test_adc)) {
-        return false;
-    }
+  EspAdc test_adc(adc_cfg);
 
-    if (!configure_test_channels(test_adc)) {
-        return false;
-    }
+  if (!initialize_test_adc(test_adc)) {
+    return false;
+  }
 
-    // Performance test: measure conversion speed
-    const uint32_t num_conversions = 1000;
-    uint64_t start_time = esp_timer_get_time();
-    
-    for (uint32_t i = 0; i < num_conversions; i++) {
-        uint32_t raw_value = 0;
-        test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
-    }
-    
-    uint64_t end_time = esp_timer_get_time();
-    uint64_t total_time_us = end_time - start_time;
-    uint32_t avg_time_per_conversion_us = total_time_us / num_conversions;
+  if (!configure_test_channels(test_adc)) {
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Performance Results:");
-    ESP_LOGI(TAG, "  - Total conversions: %lu", num_conversions);
-    ESP_LOGI(TAG, "  - Total time: %llu us", total_time_us);
-    ESP_LOGI(TAG, "  - Average per conversion: %lu us", avg_time_per_conversion_us);
-    ESP_LOGI(TAG, "  - Conversions per second: %lu", 1000000 / avg_time_per_conversion_us);
+  // Performance test: measure conversion speed
+  const uint32_t num_conversions = 1000;
+  uint64_t start_time = esp_timer_get_time();
 
-    // Verify reasonable performance (should be faster than 1ms per conversion)
-    if (avg_time_per_conversion_us > 1000) {
-        ESP_LOGW(TAG, "ADC conversion seems slow: %lu us per conversion", avg_time_per_conversion_us);
-    }
+  for (uint32_t i = 0; i < num_conversions; i++) {
+    uint32_t raw_value = 0;
+    test_adc.ReadSingleRaw(TEST_CHANNEL_1, raw_value);
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] ADC performance test passed");
-    return true;
+  uint64_t end_time = esp_timer_get_time();
+  uint64_t total_time_us = end_time - start_time;
+  uint32_t avg_time_per_conversion_us = total_time_us / num_conversions;
+
+  ESP_LOGI(TAG, "Performance Results:");
+  ESP_LOGI(TAG, "  - Total conversions: %lu", num_conversions);
+  ESP_LOGI(TAG, "  - Total time: %llu us", total_time_us);
+  ESP_LOGI(TAG, "  - Average per conversion: %lu us", avg_time_per_conversion_us);
+  ESP_LOGI(TAG, "  - Conversions per second: %lu", 1000000 / avg_time_per_conversion_us);
+
+  // Verify reasonable performance (should be faster than 1ms per conversion)
+  if (avg_time_per_conversion_us > 1000) {
+    ESP_LOGW(TAG, "ADC conversion seems slow: %lu us per conversion", avg_time_per_conversion_us);
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] ADC performance test passed");
+  return true;
 }
 
 extern "C" void app_main(void) {
-    ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
-    ESP_LOGI(TAG, "║                    ESP32-C6 ADC COMPREHENSIVE TEST SUITE                    ║");
-    ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
-    ESP_LOGI(TAG, "║                                                                              ║");
-    ESP_LOGI(TAG, "║  Hardware Setup Required (ESP32-C6 DevKit-M-1):                             ║");
-    ESP_LOGI(TAG, "║  - GPIO3 (ADC1_CH3): Connect to 3.3V via voltage divider (high reference)  ║");
-    ESP_LOGI(TAG, "║  - GPIO0 (ADC1_CH0): Connect to potentiometer center tap (variable 0-3.3V) ║");
-    ESP_LOGI(TAG, "║  - GPIO1 (ADC1_CH1): Connect to ground via 10kΩ resistor (low reference)   ║");
-    ESP_LOGI(TAG, "║                                                                              ║");
-    ESP_LOGI(TAG, "║  Monitor Test: Adjust potentiometer on GPIO0 during monitor test            ║");
-    ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
+  ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
+  ESP_LOGI(TAG, "║                    ESP32-C6 ADC COMPREHENSIVE TEST SUITE                    ║");
+  ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
+  ESP_LOGI(TAG, "║                                                                              ║");
+  ESP_LOGI(TAG, "║  Hardware Setup Required (ESP32-C6 DevKit-M-1):                             ║");
+  ESP_LOGI(TAG, "║  - GPIO3 (ADC1_CH3): Connect to 3.3V via voltage divider (high reference)  ║");
+  ESP_LOGI(TAG, "║  - GPIO0 (ADC1_CH0): Connect to potentiometer center tap (variable 0-3.3V) ║");
+  ESP_LOGI(TAG, "║  - GPIO1 (ADC1_CH1): Connect to ground via 10kΩ resistor (low reference)   ║");
+  ESP_LOGI(TAG, "║                                                                              ║");
+  ESP_LOGI(TAG, "║  Monitor Test: Adjust potentiometer on GPIO0 during monitor test            ║");
+  ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
 
-    vTaskDelay(pdMS_TO_TICKS(2000));
+  vTaskDelay(pdMS_TO_TICKS(2000));
 
-    // Run comprehensive ADC tests - hardware validation first!
-    RUN_TEST(test_hardware_validation);
-    RUN_TEST(test_adc_initialization);
-    RUN_TEST(test_adc_channel_configuration);
-    RUN_TEST(test_adc_basic_conversion);
-    RUN_TEST(test_adc_calibration);
-    RUN_TEST(test_adc_multiple_channels);
-    RUN_TEST(test_adc_averaging);
-    RUN_TEST(test_adc_continuous_mode);
-    RUN_TEST(test_adc_monitor_thresholds);
-    RUN_TEST(test_adc_error_handling);
-    RUN_TEST(test_adc_statistics);
-    RUN_TEST(test_adc_performance);
+  // Run comprehensive ADC tests - hardware validation first!
+  RUN_TEST(test_hardware_validation);
+  RUN_TEST(test_adc_initialization);
+  RUN_TEST(test_adc_channel_configuration);
+  RUN_TEST(test_adc_basic_conversion);
+  RUN_TEST(test_adc_calibration);
+  RUN_TEST(test_adc_multiple_channels);
+  RUN_TEST(test_adc_averaging);
+  RUN_TEST(test_adc_continuous_mode);
+  RUN_TEST(test_adc_monitor_thresholds);
+  RUN_TEST(test_adc_error_handling);
+  RUN_TEST(test_adc_statistics);
+  RUN_TEST(test_adc_performance);
 
-    print_test_summary(g_test_results, "ADC", TAG);
+  print_test_summary(g_test_results, "ADC", TAG);
 
-    if (g_test_results.failed_tests == 0) {
-        ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
-        ESP_LOGI(TAG, "║                      ALL ADC TESTS PASSED!                                  ║");
-        ESP_LOGI(TAG, "║                                                                              ║");
-        ESP_LOGI(TAG, "║  ESP32-C6 ADC system is working correctly with comprehensive testing        ║");
-        ESP_LOGI(TAG, "║  covering hardware validation, initialization, calibration, single/multi-   ║");
-        ESP_LOGI(TAG, "║  channel reading, continuous mode, monitor thresholds with bounds,         ║");
-        ESP_LOGI(TAG, "║  error handling, statistics, and performance testing.                      ║");
-        ESP_LOGI(TAG, "║                                                                              ║");
-        ESP_LOGI(TAG, "║  Hardware connections verified:                                             ║");
-        ESP_LOGI(TAG, "║  GPIO3 (HIGH)   GPIO0 (POT)   GPIO1 (LOW)   Monitor System                ║");
-        ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-    } else {
-        ESP_LOGE(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
-        ESP_LOGE(TAG, "║                        SOME TESTS FAILED                                    ║");
-        ESP_LOGE(TAG, "║                                                                              ║");
-        ESP_LOGE(TAG, "║  Please check hardware connections and review failed test details above.    ║");
-        ESP_LOGE(TAG, "║  Failed tests: %2d / %2d                                                     ║", 
-                 g_test_results.failed_tests, g_test_results.total_tests);
-        ESP_LOGE(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-    }
+  if (g_test_results.failed_tests == 0) {
+    ESP_LOGI(TAG,
+             "╔══════════════════════════════════════════════════════════════════════════════╗");
+    ESP_LOGI(TAG,
+             "║                      ALL ADC TESTS PASSED!                                  ║");
+    ESP_LOGI(TAG,
+             "║                                                                              ║");
+    ESP_LOGI(TAG,
+             "║  ESP32-C6 ADC system is working correctly with comprehensive testing        ║");
+    ESP_LOGI(TAG,
+             "║  covering hardware validation, initialization, calibration, single/multi-   ║");
+    ESP_LOGI(TAG, "║  channel reading, continuous mode, monitor thresholds with bounds,         ║");
+    ESP_LOGI(TAG, "║  error handling, statistics, and performance testing.                      ║");
+    ESP_LOGI(TAG,
+             "║                                                                              ║");
+    ESP_LOGI(TAG,
+             "║  Hardware connections verified:                                             ║");
+    ESP_LOGI(TAG, "║  GPIO3 (HIGH)   GPIO0 (POT)   GPIO1 (LOW)   Monitor System                ║");
+    ESP_LOGI(TAG,
+             "╚══════════════════════════════════════════════════════════════════════════════╝");
+  } else {
+    ESP_LOGE(TAG,
+             "╔══════════════════════════════════════════════════════════════════════════════╗");
+    ESP_LOGE(TAG,
+             "║                        SOME TESTS FAILED                                    ║");
+    ESP_LOGE(TAG,
+             "║                                                                              ║");
+    ESP_LOGE(TAG,
+             "║  Please check hardware connections and review failed test details above.    ║");
+    ESP_LOGE(TAG,
+             "║  Failed tests: %2d / %2d                                                     ║",
+             g_test_results.failed_tests, g_test_results.total_tests);
+    ESP_LOGE(TAG,
+             "╚══════════════════════════════════════════════════════════════════════════════╝");
+  }
 
-    // Keep running and periodically display system status
-    while (true) {
-        vTaskDelay(pdMS_TO_TICKS(30000)); // 30 second intervals
-        ESP_LOGI(TAG, "[INFO] ADC test completed. System running normally. Tests: %d/%d passed", 
-                 g_test_results.passed_tests, g_test_results.total_tests);
-    }
+  // Keep running and periodically display system status
+  while (true) {
+    vTaskDelay(pdMS_TO_TICKS(30000)); // 30 second intervals
+    ESP_LOGI(TAG, "[INFO] ADC test completed. System running normally. Tests: %d/%d passed",
+             g_test_results.passed_tests, g_test_results.total_tests);
+  }
 }

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -41,5 +41,6 @@ extern "C" void app_main(void) {
   vTaskDelay(pdMS_TO_TICKS(1000));
   RUN_TEST(test_can_initialization);
   print_test_summary(g_test_results, "CAN", TAG);
-  while (true) vTaskDelay(pdMS_TO_TICKS(10000));
+  while (true)
+    vTaskDelay(pdMS_TO_TICKS(10000));
 }

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file I2cComprehensiveTest.cpp
  * @brief Comprehensive I2C testing suite for ESP32-C6 DevKit-M-1 (noexcept)
- * 
+ *
  * This file contains comprehensive testing for the ESP I2C implementation including:
  * - Bus initialization and configuration validation
  * - Device creation and management
@@ -13,23 +13,23 @@
  * - Thread safety verification
  * - Performance and timing tests
  * - Edge cases and fault injection
- * 
+ *
  * @author Nebiyu Tadesse
  * @date 2025
  * @copyright HardFOC
  */
 
 #include "base/BaseI2c.h"
+#include "driver/i2c_master.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "mcu/esp32/EspI2c.h"
 #include "mcu/esp32/utils/EspTypes_I2C.h"
-#include "driver/i2c_master.h"
-#include "esp_timer.h"
-#include <vector>
-#include <memory>
 #include <algorithm>
+#include <memory>
+#include <vector>
 
 #include "TestFramework.h"
 
@@ -39,12 +39,12 @@ static TestResults g_test_results;
 // Test configuration constants
 static constexpr hf_pin_num_t TEST_SDA_PIN = 21;
 static constexpr hf_pin_num_t TEST_SCL_PIN = 22;
-static constexpr uint16_t TEST_DEVICE_ADDR_1 = 0x48;  // Common I2C device address
-static constexpr uint16_t TEST_DEVICE_ADDR_2 = 0x50;  // EEPROM address
-static constexpr uint16_t NONEXISTENT_ADDR = 0x7E;    // Unlikely to exist
-static constexpr uint32_t STANDARD_FREQ = 100000;     // 100kHz
-static constexpr uint32_t FAST_FREQ = 400000;         // 400kHz
-static constexpr uint32_t FAST_PLUS_FREQ = 1000000;   // 1MHz
+static constexpr uint16_t TEST_DEVICE_ADDR_1 = 0x48; // Common I2C device address
+static constexpr uint16_t TEST_DEVICE_ADDR_2 = 0x50; // EEPROM address
+static constexpr uint16_t NONEXISTENT_ADDR = 0x7E;   // Unlikely to exist
+static constexpr uint32_t STANDARD_FREQ = 100000;    // 100kHz
+static constexpr uint32_t FAST_FREQ = 400000;        // 400kHz
+static constexpr uint32_t FAST_PLUS_FREQ = 1000000;  // 1MHz
 
 // Forward declarations
 bool test_i2c_bus_initialization() noexcept;
@@ -75,94 +75,93 @@ void log_test_separator(const char* test_name) noexcept;
 
 bool test_i2c_bus_initialization() noexcept {
   log_test_separator("I2C Bus Initialization");
-  
+
   // Test 1: Basic initialization
   hf_i2c_master_bus_config_t bus_config = {};
   bus_config.i2c_port = I2C_NUM_0;
   bus_config.sda_io_num = TEST_SDA_PIN;
   bus_config.scl_io_num = TEST_SCL_PIN;
   bus_config.enable_internal_pullup = true;
-  
+
   auto test_bus = std::make_unique<EspI2cBus>(bus_config);
-  
+
   if (!test_bus->Initialize()) {
     ESP_LOGE(TAG, "Failed to initialize I2C bus");
     return false;
   }
-  
+
   if (!test_bus->IsInitialized()) {
     ESP_LOGE(TAG, "Bus not marked as initialized");
     return false;
   }
-  
+
   // Test 2: Double initialization should succeed (idempotent)
   if (!test_bus->Initialize()) {
     ESP_LOGE(TAG, "Second initialization failed");
     return false;
   }
-  
+
   // Test 3: Verify configuration
   const auto& config = test_bus->GetConfig();
   if (config.sda_io_num != TEST_SDA_PIN || config.scl_io_num != TEST_SCL_PIN) {
     ESP_LOGE(TAG, "Configuration mismatch");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Bus initialization tests passed");
   return true;
 }
 
 bool test_i2c_bus_deinitialization() noexcept {
   log_test_separator("I2C Bus Deinitialization");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Verify initialization
   if (!test_bus->IsInitialized()) {
     ESP_LOGE(TAG, "Bus not initialized");
     return false;
   }
-  
+
   // Test deinitialization
   if (!test_bus->Deinitialize()) {
     ESP_LOGE(TAG, "Failed to deinitialize bus");
     return false;
   }
-  
+
   if (test_bus->IsInitialized()) {
     ESP_LOGE(TAG, "Bus still marked as initialized");
     return false;
   }
-  
+
   // Test double deinitialization should succeed
   if (!test_bus->Deinitialize()) {
     ESP_LOGE(TAG, "Second deinitialization failed");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Bus deinitialization tests passed");
   return true;
 }
 
 bool test_i2c_configuration_validation() noexcept {
   log_test_separator("I2C Configuration Validation");
-  
+
   // Test various clock sources
-  for (auto clk_src : {hf_i2c_clock_source_t::HF_I2C_CLK_SRC_DEFAULT,
-                       hf_i2c_clock_source_t::HF_I2C_CLK_SRC_APB,
-                       hf_i2c_clock_source_t::HF_I2C_CLK_SRC_XTAL}) {
-    
+  for (auto clk_src :
+       {hf_i2c_clock_source_t::HF_I2C_CLK_SRC_DEFAULT, hf_i2c_clock_source_t::HF_I2C_CLK_SRC_APB,
+        hf_i2c_clock_source_t::HF_I2C_CLK_SRC_XTAL}) {
     hf_i2c_master_bus_config_t bus_config = {};
     bus_config.i2c_port = I2C_NUM_0;
     bus_config.sda_io_num = TEST_SDA_PIN;
     bus_config.scl_io_num = TEST_SCL_PIN;
     bus_config.clk_source = clk_src;
     bus_config.enable_internal_pullup = true;
-    
+
     auto test_bus = std::make_unique<EspI2cBus>(bus_config);
     if (!test_bus->Initialize()) {
       ESP_LOGE(TAG, "Failed to initialize with clock source %d", static_cast<int>(clk_src));
@@ -170,19 +169,18 @@ bool test_i2c_configuration_validation() noexcept {
     }
     test_bus->Deinitialize();
   }
-  
+
   // Test glitch filter settings
   for (auto filter : {hf_i2c_glitch_filter_t::HF_I2C_GLITCH_FILTER_0_CYCLES,
                       hf_i2c_glitch_filter_t::HF_I2C_GLITCH_FILTER_3_CYCLES,
                       hf_i2c_glitch_filter_t::HF_I2C_GLITCH_FILTER_7_CYCLES}) {
-    
     hf_i2c_master_bus_config_t bus_config = {};
     bus_config.i2c_port = I2C_NUM_0;
     bus_config.sda_io_num = TEST_SDA_PIN;
     bus_config.scl_io_num = TEST_SCL_PIN;
     bus_config.glitch_ignore_cnt = filter;
     bus_config.enable_internal_pullup = true;
-    
+
     auto test_bus = std::make_unique<EspI2cBus>(bus_config);
     if (!test_bus->Initialize()) {
       ESP_LOGE(TAG, "Failed to initialize with glitch filter %d", static_cast<int>(filter));
@@ -190,75 +188,75 @@ bool test_i2c_configuration_validation() noexcept {
     }
     test_bus->Deinitialize();
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Configuration validation tests passed");
   return true;
 }
 
 bool test_i2c_device_creation() noexcept {
   log_test_separator("I2C Device Creation");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Test 1: Create device with 7-bit address
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = TEST_DEVICE_ADDR_1;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create 7-bit device");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get created device");
     return false;
   }
-  
+
   // Test 2: Verify device count
   if (test_bus->GetDeviceCount() != 1) {
     ESP_LOGE(TAG, "Device count mismatch");
     return false;
   }
-  
+
   // Test 3: Create device with 10-bit address
   hf_i2c_device_config_t device_config_10bit = {};
-  device_config_10bit.device_address = 0x200;  // 10-bit address
+  device_config_10bit.device_address = 0x200; // 10-bit address
   device_config_10bit.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_10_BIT;
   device_config_10bit.scl_speed_hz = FAST_FREQ;
-  
+
   int device_index_10bit = test_bus->CreateDevice(device_config_10bit);
   if (device_index_10bit < 0) {
     ESP_LOGE(TAG, "Failed to create 10-bit device");
     return false;
   }
-  
+
   // Test 4: Verify multiple devices
   if (test_bus->GetDeviceCount() != 2) {
     ESP_LOGE(TAG, "Device count after second device incorrect");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Device creation tests passed");
   return true;
 }
 
 bool test_i2c_device_management() noexcept {
   log_test_separator("I2C Device Management");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create multiple devices
   std::vector<int> device_indices;
   for (uint16_t addr = 0x10; addr <= 0x13; ++addr) {
@@ -266,7 +264,7 @@ bool test_i2c_device_management() noexcept {
     device_config.device_address = addr;
     device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
     device_config.scl_speed_hz = STANDARD_FREQ;
-    
+
     int idx = test_bus->CreateDevice(device_config);
     if (idx < 0) {
       ESP_LOGE(TAG, "Failed to create device with address 0x%02X", addr);
@@ -274,7 +272,7 @@ bool test_i2c_device_management() noexcept {
     }
     device_indices.push_back(idx);
   }
-  
+
   // Test device lookup by address
   for (uint16_t addr = 0x10; addr <= 0x13; ++addr) {
     BaseI2c* device = test_bus->GetDeviceByAddress(addr);
@@ -283,446 +281,447 @@ bool test_i2c_device_management() noexcept {
       return false;
     }
   }
-  
+
   // Test device removal
   uint16_t remove_addr = 0x11;
   if (!test_bus->RemoveDeviceByAddress(remove_addr)) {
     ESP_LOGE(TAG, "Failed to remove device with address 0x%02X", remove_addr);
     return false;
   }
-  
+
   // Verify device is gone
   BaseI2c* removed_device = test_bus->GetDeviceByAddress(remove_addr);
   if (removed_device) {
     ESP_LOGE(TAG, "Device with address 0x%02X still exists after removal", remove_addr);
     return false;
   }
-  
+
   // Verify remaining devices
   if (test_bus->GetDeviceCount() != 3) {
     ESP_LOGE(TAG, "Device count after removal incorrect: %zu", test_bus->GetDeviceCount());
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Device management tests passed");
   return true;
 }
 
 bool test_i2c_device_probing() noexcept {
   log_test_separator("I2C Device Probing");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Test probing non-existent device
   bool exists = test_bus->ProbeDevice(NONEXISTENT_ADDR);
-  ESP_LOGI(TAG, "Probe result for address 0x%02X: %s", NONEXISTENT_ADDR, exists ? "EXISTS" : "NOT FOUND");
-  
+  ESP_LOGI(TAG, "Probe result for address 0x%02X: %s", NONEXISTENT_ADDR,
+           exists ? "EXISTS" : "NOT FOUND");
+
   // Note: We can't guarantee specific devices are connected, so we'll just verify the method works
   // and doesn't crash. In a real test environment, you would connect known devices.
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Device probing tests passed");
   return true;
 }
 
 bool test_i2c_bus_scanning() noexcept {
   log_test_separator("I2C Bus Scanning");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Scan the bus for devices
   std::vector<hf_u16_t> found_devices;
   size_t device_count = test_bus->ScanDevices(found_devices);
-  
+
   ESP_LOGI(TAG, "Bus scan found %zu devices", device_count);
   for (auto addr : found_devices) {
     ESP_LOGI(TAG, "  - Device at address 0x%02X", addr);
   }
-  
+
   // Test custom scan range
   std::vector<hf_u16_t> limited_scan;
   size_t limited_count = test_bus->ScanDevices(limited_scan, 0x20, 0x30);
   ESP_LOGI(TAG, "Limited scan (0x20-0x30) found %zu devices", limited_count);
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Bus scanning tests passed");
   return true;
 }
 
 bool test_i2c_write_operations() noexcept {
   log_test_separator("I2C Write Operations");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create a test device
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = TEST_DEVICE_ADDR_1;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create test device");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get test device");
     return false;
   }
-  
+
   // Test various write operations
   uint8_t single_byte = 0xAA;
   hf_i2c_err_t result = device->Write(&single_byte, 1);
   ESP_LOGI(TAG, "Single byte write result: %s", HfI2CErrToString(result).data());
-  
+
   uint8_t multi_bytes[] = {0x01, 0x02, 0x03, 0x04};
   result = device->Write(multi_bytes, sizeof(multi_bytes));
   ESP_LOGI(TAG, "Multi-byte write result: %s", HfI2CErrToString(result).data());
-  
+
   // Test with timeout
   result = device->Write(multi_bytes, sizeof(multi_bytes), 500);
   ESP_LOGI(TAG, "Write with timeout result: %s", HfI2CErrToString(result).data());
-  
+
   // Test zero-length write (should fail)
   result = device->Write(nullptr, 0);
   if (result == hf_i2c_err_t::I2C_SUCCESS) {
     ESP_LOGW(TAG, "Zero-length write unexpectedly succeeded");
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Write operations tests passed");
   return true;
 }
 
 bool test_i2c_read_operations() noexcept {
   log_test_separator("I2C Read Operations");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create a test device
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = TEST_DEVICE_ADDR_1;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create test device");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get test device");
     return false;
   }
-  
+
   // Test various read operations
   uint8_t single_byte;
   hf_i2c_err_t result = device->Read(&single_byte, 1);
-  ESP_LOGI(TAG, "Single byte read result: %s (data: 0x%02X)", 
-           HfI2CErrToString(result).data(), single_byte);
-  
+  ESP_LOGI(TAG, "Single byte read result: %s (data: 0x%02X)", HfI2CErrToString(result).data(),
+           single_byte);
+
   uint8_t multi_bytes[8];
   result = device->Read(multi_bytes, sizeof(multi_bytes));
   ESP_LOGI(TAG, "Multi-byte read result: %s", HfI2CErrToString(result).data());
-  
+
   // Test with timeout
   result = device->Read(multi_bytes, 4, 500);
   ESP_LOGI(TAG, "Read with timeout result: %s", HfI2CErrToString(result).data());
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Read operations tests passed");
   return true;
 }
 
 bool test_i2c_write_read_operations() noexcept {
   log_test_separator("I2C Write-Read Operations");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create a test device
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = TEST_DEVICE_ADDR_1;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create test device");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get test device");
     return false;
   }
-  
+
   // Test write-read operation (typical register read)
   uint8_t reg_addr = 0x10;
   uint8_t read_data[4];
   hf_i2c_err_t result = device->WriteRead(&reg_addr, 1, read_data, sizeof(read_data));
   ESP_LOGI(TAG, "Write-read operation result: %s", HfI2CErrToString(result).data());
-  
+
   // Test with timeout
   result = device->WriteRead(&reg_addr, 1, read_data, 2, 500);
   ESP_LOGI(TAG, "Write-read with timeout result: %s", HfI2CErrToString(result).data());
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Write-read operations tests passed");
   return true;
 }
 
 bool test_i2c_error_handling() noexcept {
   log_test_separator("I2C Error Handling");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Test operations on non-existent device
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = NONEXISTENT_ADDR;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create test device");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get test device");
     return false;
   }
-  
+
   // Test operations that should fail
   uint8_t dummy_data = 0xFF;
   hf_i2c_err_t result = device->Write(&dummy_data, 1);
   ESP_LOGI(TAG, "Write to non-existent device result: %s", HfI2CErrToString(result).data());
-  
+
   result = device->Read(&dummy_data, 1);
   ESP_LOGI(TAG, "Read from non-existent device result: %s", HfI2CErrToString(result).data());
-  
+
   // Test invalid parameters
   result = device->Write(nullptr, 1);
   ESP_LOGI(TAG, "Write with null pointer result: %s", HfI2CErrToString(result).data());
-  
+
   result = device->Read(nullptr, 1);
   ESP_LOGI(TAG, "Read with null pointer result: %s", HfI2CErrToString(result).data());
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Error handling tests passed");
   return true;
 }
 
 bool test_i2c_timeout_handling() noexcept {
   log_test_separator("I2C Timeout Handling");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create device for timeout testing
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = NONEXISTENT_ADDR;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create test device");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get test device");
     return false;
   }
-  
+
   // Test various timeout values
   uint8_t dummy_data = 0xFF;
   uint64_t start_time, end_time;
-  
+
   // Short timeout
   start_time = esp_timer_get_time();
-  hf_i2c_err_t result = device->Write(&dummy_data, 1, 100);  // 100ms timeout
+  hf_i2c_err_t result = device->Write(&dummy_data, 1, 100); // 100ms timeout
   end_time = esp_timer_get_time();
   uint64_t duration_ms = (end_time - start_time) / 1000;
-  
-  ESP_LOGI(TAG, "Short timeout test: %s (took %llu ms)", 
-           HfI2CErrToString(result).data(), duration_ms);
-  
+
+  ESP_LOGI(TAG, "Short timeout test: %s (took %llu ms)", HfI2CErrToString(result).data(),
+           duration_ms);
+
   // Very short timeout
   start_time = esp_timer_get_time();
-  result = device->Write(&dummy_data, 1, 10);  // 10ms timeout
+  result = device->Write(&dummy_data, 1, 10); // 10ms timeout
   end_time = esp_timer_get_time();
   duration_ms = (end_time - start_time) / 1000;
-  
-  ESP_LOGI(TAG, "Very short timeout test: %s (took %llu ms)", 
-           HfI2CErrToString(result).data(), duration_ms);
-  
+
+  ESP_LOGI(TAG, "Very short timeout test: %s (took %llu ms)", HfI2CErrToString(result).data(),
+           duration_ms);
+
   ESP_LOGI(TAG, "[SUCCESS] Timeout handling tests passed");
   return true;
 }
 
 bool test_i2c_multi_device_operations() noexcept {
   log_test_separator("I2C Multi-Device Operations");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create multiple devices with different configurations
   std::vector<BaseI2c*> devices;
   std::vector<uint16_t> addresses = {0x48, 0x50, 0x68, 0x76};
   std::vector<uint32_t> speeds = {STANDARD_FREQ, FAST_FREQ, STANDARD_FREQ, FAST_FREQ};
-  
+
   for (size_t i = 0; i < addresses.size(); ++i) {
     hf_i2c_device_config_t device_config = {};
     device_config.device_address = addresses[i];
     device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
     device_config.scl_speed_hz = speeds[i];
-    
+
     int device_index = test_bus->CreateDevice(device_config);
     if (device_index < 0) {
       ESP_LOGW(TAG, "Failed to create device %zu (addr 0x%02X)", i, addresses[i]);
       continue;
     }
-    
+
     BaseI2c* device = test_bus->GetDevice(device_index);
     if (device) {
       devices.push_back(device);
     }
   }
-  
+
   ESP_LOGI(TAG, "Created %zu devices on the bus", devices.size());
-  
+
   // Test concurrent operations (simulate real-world usage)
   for (auto* device : devices) {
     uint8_t test_data = 0xAA;
     hf_i2c_err_t result = device->Write(&test_data, 1, 100);
     ESP_LOGI(TAG, "Multi-device write result: %s", HfI2CErrToString(result).data());
-    
+
     // Small delay between operations
     vTaskDelay(pdMS_TO_TICKS(10));
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Multi-device operations tests passed");
   return true;
 }
 
 bool test_i2c_clock_speeds() noexcept {
   log_test_separator("I2C Clock Speed Tests");
-  
+
   std::vector<uint32_t> test_speeds = {
-    100000,   // Standard mode
-    400000,   // Fast mode
-    1000000   // Fast mode plus
+      100000, // Standard mode
+      400000, // Fast mode
+      1000000 // Fast mode plus
   };
-  
+
   for (auto speed : test_speeds) {
     auto test_bus = create_test_bus(speed);
     if (!test_bus) {
       ESP_LOGE(TAG, "Failed to create test bus with speed %lu Hz", speed);
       return false;
     }
-    
+
     // Create a device with this speed
     hf_i2c_device_config_t device_config = {};
     device_config.device_address = TEST_DEVICE_ADDR_1;
     device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
     device_config.scl_speed_hz = speed;
-    
+
     int device_index = test_bus->CreateDevice(device_config);
     if (device_index < 0) {
       ESP_LOGE(TAG, "Failed to create device with speed %lu Hz", speed);
       return false;
     }
-    
+
     EspI2cDevice* esp_device = test_bus->GetEspDevice(device_index);
     if (esp_device) {
       uint32_t actual_freq;
       hf_i2c_err_t result = esp_device->GetActualClockFrequency(actual_freq);
-      ESP_LOGI(TAG, "Speed %lu Hz: actual frequency %lu Hz (result: %s)", 
-               speed, actual_freq, HfI2CErrToString(result).data());
+      ESP_LOGI(TAG, "Speed %lu Hz: actual frequency %lu Hz (result: %s)", speed, actual_freq,
+               HfI2CErrToString(result).data());
     }
-    
+
     ESP_LOGI(TAG, "Successfully tested clock speed: %lu Hz", speed);
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Clock speed tests passed");
   return true;
 }
 
 bool test_i2c_address_modes() noexcept {
   log_test_separator("I2C Address Mode Tests");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Test 7-bit addressing
   hf_i2c_device_config_t device_config_7bit = {};
-  device_config_7bit.device_address = 0x48;  // 7-bit address
+  device_config_7bit.device_address = 0x48; // 7-bit address
   device_config_7bit.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config_7bit.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index_7bit = test_bus->CreateDevice(device_config_7bit);
   if (device_index_7bit < 0) {
     ESP_LOGE(TAG, "Failed to create 7-bit address device");
     return false;
   }
-  
+
   // Test 10-bit addressing
   hf_i2c_device_config_t device_config_10bit = {};
-  device_config_10bit.device_address = 0x200;  // 10-bit address
+  device_config_10bit.device_address = 0x200; // 10-bit address
   device_config_10bit.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_10_BIT;
   device_config_10bit.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index_10bit = test_bus->CreateDevice(device_config_10bit);
   if (device_index_10bit < 0) {
     ESP_LOGE(TAG, "Failed to create 10-bit address device");
     return false;
   }
-  
+
   // Verify both devices exist
   BaseI2c* device_7bit = test_bus->GetDevice(device_index_7bit);
   BaseI2c* device_10bit = test_bus->GetDevice(device_index_10bit);
-  
+
   if (!device_7bit || !device_10bit) {
     ESP_LOGE(TAG, "Failed to retrieve created devices");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Successfully created devices with 7-bit and 10-bit addressing");
   ESP_LOGI(TAG, "[SUCCESS] Address mode tests passed");
   return true;
@@ -730,43 +729,42 @@ bool test_i2c_address_modes() noexcept {
 
 bool test_i2c_esp_specific_features() noexcept {
   log_test_separator("ESP-Specific I2C Features");
-  
+
   // Test different clock sources
-  for (auto clk_src : {hf_i2c_clock_source_t::HF_I2C_CLK_SRC_APB,
-                       hf_i2c_clock_source_t::HF_I2C_CLK_SRC_XTAL}) {
-    
+  for (auto clk_src :
+       {hf_i2c_clock_source_t::HF_I2C_CLK_SRC_APB, hf_i2c_clock_source_t::HF_I2C_CLK_SRC_XTAL}) {
     hf_i2c_master_bus_config_t bus_config = {};
     bus_config.i2c_port = I2C_NUM_0;
     bus_config.sda_io_num = TEST_SDA_PIN;
     bus_config.scl_io_num = TEST_SCL_PIN;
     bus_config.clk_source = clk_src;
     bus_config.enable_internal_pullup = true;
-    bus_config.trans_queue_depth = 16;  // Test larger queue
-    
+    bus_config.trans_queue_depth = 16; // Test larger queue
+
     auto test_bus = std::make_unique<EspI2cBus>(bus_config);
     if (!test_bus->Initialize()) {
       ESP_LOGE(TAG, "Failed to initialize with clock source %d", static_cast<int>(clk_src));
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Successfully initialized with clock source %d", static_cast<int>(clk_src));
     test_bus->Deinitialize();
   }
-  
+
   // Test power management features
   hf_i2c_master_bus_config_t bus_config = {};
   bus_config.i2c_port = I2C_NUM_0;
   bus_config.sda_io_num = TEST_SDA_PIN;
   bus_config.scl_io_num = TEST_SCL_PIN;
-  bus_config.allow_pd = true;  // Enable power down in sleep
+  bus_config.allow_pd = true; // Enable power down in sleep
   bus_config.enable_internal_pullup = true;
-  
+
   auto test_bus = std::make_unique<EspI2cBus>(bus_config);
   if (!test_bus->Initialize()) {
     ESP_LOGE(TAG, "Failed to initialize with power management");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Successfully initialized with power management features");
   ESP_LOGI(TAG, "[SUCCESS] ESP-specific feature tests passed");
   return true;
@@ -774,103 +772,103 @@ bool test_i2c_esp_specific_features() noexcept {
 
 bool test_i2c_thread_safety() noexcept {
   log_test_separator("I2C Thread Safety");
-  
+
   // This test would require multiple tasks in a real implementation
   // For now, we'll just verify the mutex protection doesn't break anything
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create a device
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = TEST_DEVICE_ADDR_1;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = STANDARD_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create device for thread safety test");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get device for thread safety test");
     return false;
   }
-  
+
   // Perform multiple rapid operations (simulating concurrent access)
   for (int i = 0; i < 10; ++i) {
     uint8_t data = static_cast<uint8_t>(i);
     device->Write(&data, 1, 50);
     device->Read(&data, 1, 50);
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Thread safety tests passed (basic verification)");
   return true;
 }
 
 bool test_i2c_performance() noexcept {
   log_test_separator("I2C Performance Tests");
-  
-  auto test_bus = create_test_bus(FAST_FREQ);  // Use fast mode for performance test
+
+  auto test_bus = create_test_bus(FAST_FREQ); // Use fast mode for performance test
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Create a device
   hf_i2c_device_config_t device_config = {};
   device_config.device_address = TEST_DEVICE_ADDR_1;
   device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
   device_config.scl_speed_hz = FAST_FREQ;
-  
+
   int device_index = test_bus->CreateDevice(device_config);
   if (device_index < 0) {
     ESP_LOGE(TAG, "Failed to create device for performance test");
     return false;
   }
-  
+
   BaseI2c* device = test_bus->GetDevice(device_index);
   if (!device) {
     ESP_LOGE(TAG, "Failed to get device for performance test");
     return false;
   }
-  
+
   // Performance test: multiple write operations
   const int num_operations = 100;
   uint8_t test_data[16];
   std::fill(test_data, test_data + sizeof(test_data), 0xAA);
-  
+
   uint64_t start_time = esp_timer_get_time();
-  
+
   for (int i = 0; i < num_operations; ++i) {
     device->Write(test_data, sizeof(test_data), 100);
   }
-  
+
   uint64_t end_time = esp_timer_get_time();
   uint64_t total_time_us = end_time - start_time;
   double avg_time_ms = (double)total_time_us / (num_operations * 1000.0);
-  
-  ESP_LOGI(TAG, "Performance test: %d operations in %llu μs (avg: %.2f ms per operation)", 
+
+  ESP_LOGI(TAG, "Performance test: %d operations in %llu μs (avg: %.2f ms per operation)",
            num_operations, total_time_us, avg_time_ms);
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Performance tests completed");
   return true;
 }
 
 bool test_i2c_edge_cases() noexcept {
   log_test_separator("I2C Edge Cases");
-  
+
   auto test_bus = create_test_bus();
   if (!test_bus) {
     ESP_LOGE(TAG, "Failed to create test bus");
     return false;
   }
-  
+
   // Test maximum number of devices (implementation dependent)
   std::vector<int> device_indices;
   for (uint16_t addr = 0x08; addr < 0x78; ++addr) {
@@ -878,31 +876,31 @@ bool test_i2c_edge_cases() noexcept {
     device_config.device_address = addr;
     device_config.dev_addr_length = hf_i2c_address_bits_t::HF_I2C_ADDR_7_BIT;
     device_config.scl_speed_hz = STANDARD_FREQ;
-    
+
     int idx = test_bus->CreateDevice(device_config);
     if (idx >= 0) {
       device_indices.push_back(idx);
     } else {
-      break;  // Reached limit or error
+      break; // Reached limit or error
     }
   }
-  
+
   ESP_LOGI(TAG, "Created maximum of %zu devices", device_indices.size());
-  
+
   // Test bus reset
   if (!test_bus->ResetBus()) {
     ESP_LOGW(TAG, "Bus reset failed or not supported");
   } else {
     ESP_LOGI(TAG, "Bus reset successful");
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Edge case tests passed");
   return true;
 }
 
 bool test_i2c_power_management() noexcept {
   log_test_separator("I2C Power Management");
-  
+
   // Test with power down allowed
   hf_i2c_master_bus_config_t bus_config = {};
   bus_config.i2c_port = I2C_NUM_0;
@@ -910,13 +908,13 @@ bool test_i2c_power_management() noexcept {
   bus_config.scl_io_num = TEST_SCL_PIN;
   bus_config.allow_pd = true;
   bus_config.enable_internal_pullup = true;
-  
+
   auto test_bus = std::make_unique<EspI2cBus>(bus_config);
   if (!test_bus->Initialize()) {
     ESP_LOGE(TAG, "Failed to initialize bus with power management");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "Successfully tested power management configuration");
   ESP_LOGI(TAG, "[SUCCESS] Power management tests passed");
   return true;
@@ -929,29 +927,31 @@ EspI2cBus* create_test_bus(uint32_t freq) noexcept {
   bus_config.sda_io_num = TEST_SDA_PIN;
   bus_config.scl_io_num = TEST_SCL_PIN;
   bus_config.enable_internal_pullup = true;
-  
+
   auto bus = std::make_unique<EspI2cBus>(bus_config);
   if (!bus->Initialize()) {
     return nullptr;
   }
-  
-  return bus.release();  // Transfer ownership to caller
+
+  return bus.release(); // Transfer ownership to caller
 }
 
 bool verify_device_functionality(BaseI2c* device) noexcept {
-  if (!device) return false;
-  
+  if (!device)
+    return false;
+
   uint8_t test_data = 0xAA;
   hf_i2c_err_t result = device->Write(&test_data, 1, 100);
   return result != hf_i2c_err_t::I2C_ERR_FAILURE;
 }
 
 void log_test_separator(const char* test_name) noexcept {
-  ESP_LOGI(TAG, "\n" 
-                "═══════════════════════════════════════════════════════════════════\n"
-                "  %s\n"
-                "═══════════════════════════════════════════════════════════════════", 
-                test_name);
+  ESP_LOGI(TAG,
+           "\n"
+           "═══════════════════════════════════════════════════════════════════\n"
+           "  %s\n"
+           "═══════════════════════════════════════════════════════════════════",
+           test_name);
 }
 
 extern "C" void app_main(void) {
@@ -959,9 +959,9 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "║                    ESP32-C6 I2C COMPREHENSIVE TEST SUITE                    ║");
   ESP_LOGI(TAG, "║                         HardFOC Internal Interface                          ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   // Run all I2C tests
   RUN_TEST(test_i2c_bus_initialization);
   RUN_TEST(test_i2c_bus_deinitialization);
@@ -983,9 +983,9 @@ extern "C" void app_main(void) {
   RUN_TEST(test_i2c_performance);
   RUN_TEST(test_i2c_edge_cases);
   RUN_TEST(test_i2c_power_management);
-  
+
   print_test_summary(g_test_results, "I2C", TAG);
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/LoggerComprehensiveTest.cpp
+++ b/examples/esp32/main/LoggerComprehensiveTest.cpp
@@ -57,7 +57,8 @@ bool test_logger_cleanup() noexcept;
 // Helper functions
 hf_logger_config_t create_test_config() noexcept;
 bool verify_logger_state(EspLogger& logger, bool should_be_initialized) noexcept;
-void log_performance_metrics(const char* test_name, hf_u64_t start_time, hf_u32_t operations) noexcept;
+void log_performance_metrics(const char* test_name, hf_u64_t start_time,
+                             hf_u32_t operations) noexcept;
 
 //==============================================================================
 // HELPER FUNCTIONS
@@ -70,7 +71,7 @@ hf_logger_config_t create_test_config() noexcept {
   config.format_options = hf_log_format_t::LOG_FORMAT_DEFAULT;
   config.max_message_length = TEST_MAX_MESSAGE_LENGTH;
   config.buffer_size = TEST_BUFFER_SIZE;
-  config.flush_interval_ms = 100;  // Set flush interval
+  config.flush_interval_ms = 100; // Set flush interval
   config.enable_thread_safety = true;
   config.enable_performance_monitoring = true;
   // Note: enable_health_monitoring doesn't exist in config structure
@@ -87,14 +88,15 @@ bool verify_logger_state(EspLogger& logger, bool should_be_initialized) noexcept
   return true;
 }
 
-void log_performance_metrics(const char* test_name, hf_u64_t start_time, hf_u32_t operations) noexcept {
+void log_performance_metrics(const char* test_name, hf_u64_t start_time,
+                             hf_u32_t operations) noexcept {
   hf_u64_t end_time = esp_timer_get_time();
   hf_u64_t duration_us = end_time - start_time;
   double duration_ms = duration_us / 1000.0;
   double ops_per_sec = (operations * 1000000.0) / duration_us;
-  
-  ESP_LOGI(TAG, "%s Performance: %lu ops in %.2f ms (%.2f ops/sec)", 
-           test_name, operations, duration_ms, ops_per_sec);
+
+  ESP_LOGI(TAG, "%s Performance: %lu ops in %.2f ms (%.2f ops/sec)", test_name, operations,
+           duration_ms, ops_per_sec);
 }
 
 //==============================================================================
@@ -106,7 +108,7 @@ bool test_logger_construction() noexcept {
 
   // Test construction with default parameters using nothrow allocation
   auto logger = hf::utils::make_unique_nothrow<EspLogger>();
-  
+
   if (!logger) {
     ESP_LOGE(TAG, "Failed to construct EspLogger instance - out of memory");
     return false;
@@ -163,7 +165,7 @@ bool test_logger_initialization() noexcept {
 
   // Demonstrate the PrintStatus method
   ESP_LOGI(TAG, "Demonstrating PrintStatus method:");
-  result = g_logger_instance->PrintStatus("INIT_STATUS", false);  // Brief status after init
+  result = g_logger_instance->PrintStatus("INIT_STATUS", false); // Brief status after init
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGW(TAG, "PrintStatus failed: %d", static_cast<int>(result));
   }
@@ -219,7 +221,8 @@ bool test_logger_basic_logging() noexcept {
   }
 
   // Test generic Log method
-  result = g_logger_instance->Log(hf_log_level_t::LOG_LEVEL_INFO, TEST_TAG, "Generic log message: %s", "test");
+  result = g_logger_instance->Log(hf_log_level_t::LOG_LEVEL_INFO, TEST_TAG,
+                                  "Generic log message: %s", "test");
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "Generic Log method failed: %d", static_cast<int>(result));
     return false;
@@ -238,13 +241,9 @@ bool test_logger_level_management() noexcept {
   }
 
   // Test setting and getting log levels
-  hf_log_level_t test_levels[] = {
-    hf_log_level_t::LOG_LEVEL_ERROR,
-    hf_log_level_t::LOG_LEVEL_WARN,
-    hf_log_level_t::LOG_LEVEL_INFO,
-    hf_log_level_t::LOG_LEVEL_DEBUG,
-    hf_log_level_t::LOG_LEVEL_VERBOSE
-  };
+  hf_log_level_t test_levels[] = {hf_log_level_t::LOG_LEVEL_ERROR, hf_log_level_t::LOG_LEVEL_WARN,
+                                  hf_log_level_t::LOG_LEVEL_INFO, hf_log_level_t::LOG_LEVEL_DEBUG,
+                                  hf_log_level_t::LOG_LEVEL_VERBOSE};
 
   hf_u8_t num_levels = sizeof(test_levels) / sizeof(test_levels[0]);
 
@@ -252,7 +251,8 @@ bool test_logger_level_management() noexcept {
     // Set log level for specific tag
     hf_logger_err_t result = g_logger_instance->SetLogLevel(TEST_TAG, test_levels[i]);
     if (result != hf_logger_err_t::LOGGER_SUCCESS) {
-      ESP_LOGE(TAG, "Failed to set log level %d: %d", static_cast<int>(test_levels[i]), static_cast<int>(result));
+      ESP_LOGE(TAG, "Failed to set log level %d: %d", static_cast<int>(test_levels[i]),
+               static_cast<int>(result));
       return false;
     }
 
@@ -265,15 +265,15 @@ bool test_logger_level_management() noexcept {
     }
 
     if (retrieved_level != test_levels[i]) {
-      ESP_LOGE(TAG, "Log level mismatch. Expected: %d, Got: %d", 
-               static_cast<int>(test_levels[i]), static_cast<int>(retrieved_level));
+      ESP_LOGE(TAG, "Log level mismatch. Expected: %d, Got: %d", static_cast<int>(test_levels[i]),
+               static_cast<int>(retrieved_level));
       return false;
     }
 
     // Test if level is enabled
     bool level_enabled = g_logger_instance->IsLevelEnabled(test_levels[i], TEST_TAG);
-    ESP_LOGI(TAG, "Level %d enabled for tag '%s': %s", 
-             static_cast<int>(test_levels[i]), TEST_TAG, level_enabled ? "true" : "false");
+    ESP_LOGI(TAG, "Level %d enabled for tag '%s': %s", static_cast<int>(test_levels[i]), TEST_TAG,
+             level_enabled ? "true" : "false");
   }
 
   // Test default tag level management
@@ -338,8 +338,8 @@ bool test_logger_formatted_logging() noexcept {
 
   // Long format string test
   const char* long_format = "Long message with many parameters: %d %s %f %c %x %o %p %zu %ld %u";
-  result = g_logger_instance->Info(TEST_TAG, long_format, 
-                                  42, "test", 3.14, 'X', 0xFF, 077, test_ptr, sizeof(int), 1000L, 500U);
+  result = g_logger_instance->Info(TEST_TAG, long_format, 42, "test", 3.14, 'X', 0xFF, 077,
+                                   test_ptr, sizeof(int), 1000L, 500U);
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "Long format string failed: %d", static_cast<int>(result));
     return false;
@@ -360,9 +360,9 @@ bool test_logger_log_v2_features() noexcept {
   // Check Log V2 availability
   bool log_v2_available = g_logger_instance->IsLogV2Available();
   hf_u8_t log_version = g_logger_instance->GetLogVersion();
-  
-  ESP_LOGI(TAG, "Log V2 available: %s, Log version: %d", 
-           log_v2_available ? "true" : "false", log_version);
+
+  ESP_LOGI(TAG, "Log V2 available: %s, Log version: %d", log_v2_available ? "true" : "false",
+           log_version);
 
   if (log_v2_available) {
     ESP_LOGI(TAG, "Testing Log V2 specific features...");
@@ -372,7 +372,8 @@ bool test_logger_log_v2_features() noexcept {
                                0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10};
 
     // Test LogBuffer
-    hf_logger_err_t result = g_logger_instance->LogBuffer(TEST_TAG, test_buffer, sizeof(test_buffer));
+    hf_logger_err_t result =
+        g_logger_instance->LogBuffer(TEST_TAG, test_buffer, sizeof(test_buffer));
     if (result != hf_logger_err_t::LOGGER_SUCCESS) {
       ESP_LOGE(TAG, "LogBuffer failed: %d", static_cast<int>(result));
       return false;
@@ -433,7 +434,8 @@ bool test_logger_buffer_logging() noexcept {
   }
 
   // Test small buffer
-  hf_logger_err_t result = g_logger_instance->LogBuffer(TEST_TAG, small_buffer, sizeof(small_buffer));
+  hf_logger_err_t result =
+      g_logger_instance->LogBuffer(TEST_TAG, small_buffer, sizeof(small_buffer));
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "Small buffer logging failed: %d", static_cast<int>(result));
     return false;
@@ -484,9 +486,8 @@ bool test_logger_location_logging() noexcept {
   hf_u32_t test_line = __LINE__ + 2;
   const char* test_function = __FUNCTION__;
   hf_logger_err_t result = g_logger_instance->LogWithLocation(
-    hf_log_level_t::LOG_LEVEL_INFO, TEST_TAG, test_file, test_line, test_function,
-    "Location test message with parameters: %d, %s", 42, "test"
-  );
+      hf_log_level_t::LOG_LEVEL_INFO, TEST_TAG, test_file, test_line, test_function,
+      "Location test message with parameters: %d, %s", 42, "test");
 
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "LogWithLocation failed: %d", static_cast<int>(result));
@@ -494,10 +495,9 @@ bool test_logger_location_logging() noexcept {
   }
 
   // Test with different log levels
-  result = g_logger_instance->LogWithLocation(
-    hf_log_level_t::LOG_LEVEL_ERROR, TEST_TAG, test_file, __LINE__, test_function,
-    "Error location test: %s", "critical error"
-  );
+  result = g_logger_instance->LogWithLocation(hf_log_level_t::LOG_LEVEL_ERROR, TEST_TAG, test_file,
+                                              __LINE__, test_function, "Error location test: %s",
+                                              "critical error");
 
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "Error level LogWithLocation failed: %d", static_cast<int>(result));
@@ -505,10 +505,8 @@ bool test_logger_location_logging() noexcept {
   }
 
   // Test with null parameters (should handle gracefully)
-  result = g_logger_instance->LogWithLocation(
-    hf_log_level_t::LOG_LEVEL_WARN, TEST_TAG, nullptr, 0, nullptr,
-    "Null parameters test"
-  );
+  result = g_logger_instance->LogWithLocation(hf_log_level_t::LOG_LEVEL_WARN, TEST_TAG, nullptr, 0,
+                                              nullptr, "Null parameters test");
 
   if (result == hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGI(TAG, "Null parameters location logging succeeded");
@@ -564,7 +562,7 @@ bool test_logger_statistics_diagnostics() noexcept {
 
   // Verify and print reset statistics using the logger's built-in method
   ESP_LOGI(TAG, "=== Statistics After Reset ===");
-  result = g_logger_instance->PrintStatistics(TAG, false);  // Brief output after reset
+  result = g_logger_instance->PrintStatistics(TAG, false); // Brief output after reset
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "Failed to print reset statistics: %d", static_cast<int>(result));
     return false;
@@ -579,7 +577,7 @@ bool test_logger_statistics_diagnostics() noexcept {
 
   // Print reset diagnostics using the logger's built-in method
   ESP_LOGI(TAG, "=== Diagnostics After Reset ===");
-  result = g_logger_instance->PrintDiagnostics(TAG, false);  // Brief output after reset
+  result = g_logger_instance->PrintDiagnostics(TAG, false); // Brief output after reset
   if (result != hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGE(TAG, "Failed to print reset diagnostics: %d", static_cast<int>(result));
     return false;
@@ -611,7 +609,8 @@ bool test_logger_health_monitoring() noexcept {
 
   // Test error message retrieval
   char error_message[256];
-  hf_logger_err_t result = g_logger_instance->GetLastErrorMessage(error_message, sizeof(error_message));
+  hf_logger_err_t result =
+      g_logger_instance->GetLastErrorMessage(error_message, sizeof(error_message));
   if (result == hf_logger_err_t::LOGGER_SUCCESS) {
     ESP_LOGI(TAG, "Last error message: %s", error_message);
   } else {
@@ -700,8 +699,8 @@ bool test_logger_performance_testing() noexcept {
   // Test formatted logging performance
   start_time = esp_timer_get_time();
   for (hf_u32_t i = 0; i < num_operations; i++) {
-    g_logger_instance->Info(TEST_TAG, "Format test: %d, %s, %.2f", 
-                           static_cast<int>(i), "test", static_cast<double>(i) * 0.1);
+    g_logger_instance->Info(TEST_TAG, "Format test: %d, %s, %.2f", static_cast<int>(i), "test",
+                            static_cast<double>(i) * 0.1);
   }
   log_performance_metrics("Formatted Logging", start_time, num_operations);
 
@@ -742,35 +741,31 @@ bool test_logger_utility_functions() noexcept {
   }
 
   // Test level checking for various tags and levels
-  hf_log_level_t test_levels[] = {
-    hf_log_level_t::LOG_LEVEL_ERROR,
-    hf_log_level_t::LOG_LEVEL_WARN,
-    hf_log_level_t::LOG_LEVEL_INFO,
-    hf_log_level_t::LOG_LEVEL_DEBUG,
-    hf_log_level_t::LOG_LEVEL_VERBOSE
-  };
+  hf_log_level_t test_levels[] = {hf_log_level_t::LOG_LEVEL_ERROR, hf_log_level_t::LOG_LEVEL_WARN,
+                                  hf_log_level_t::LOG_LEVEL_INFO, hf_log_level_t::LOG_LEVEL_DEBUG,
+                                  hf_log_level_t::LOG_LEVEL_VERBOSE};
 
   for (hf_u8_t i = 0; i < sizeof(test_levels) / sizeof(test_levels[0]); i++) {
     bool enabled = g_logger_instance->IsLevelEnabled(test_levels[i], TEST_TAG);
-    ESP_LOGI(TAG, "Level %d enabled for %s: %s", 
-             static_cast<int>(test_levels[i]), TEST_TAG, enabled ? "true" : "false");
+    ESP_LOGI(TAG, "Level %d enabled for %s: %s", static_cast<int>(test_levels[i]), TEST_TAG,
+             enabled ? "true" : "false");
 
     enabled = g_logger_instance->IsLevelEnabled(test_levels[i], nullptr);
-    ESP_LOGI(TAG, "Level %d enabled for default: %s", 
-             static_cast<int>(test_levels[i]), enabled ? "true" : "false");
+    ESP_LOGI(TAG, "Level %d enabled for default: %s", static_cast<int>(test_levels[i]),
+             enabled ? "true" : "false");
   }
 
   // Test version information
   hf_u8_t log_version = g_logger_instance->GetLogVersion();
   bool log_v2_available = g_logger_instance->IsLogV2Available();
-  
+
   ESP_LOGI(TAG, "Logger version information:");
   ESP_LOGI(TAG, "  Log version: %d", log_version);
   ESP_LOGI(TAG, "  Log V2 available: %s", log_v2_available ? "true" : "false");
 
   // Test custom output callback functionality
   ESP_LOGI(TAG, "Testing custom output callback functionality...");
-  
+
   // Create a test logger instance with custom callback
   static std::string captured_output;
   auto custom_callback = [](const char* message, hf_u32_t length) {
@@ -780,7 +775,7 @@ bool test_logger_utility_functions() noexcept {
 
   hf_logger_config_t custom_config = create_test_config();
   custom_config.custom_output_callback = custom_callback;
-  
+
   auto custom_logger = hf::utils::make_unique_nothrow<EspLogger>();
   if (custom_logger) {
     hf_logger_err_t result = custom_logger->Initialize(custom_config);

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file PwmComprehensiveTest.cpp
  * @brief Comprehensive PWM testing suite for ESP32-C6 DevKit-M-1 (noexcept)
- * 
+ *
  * This comprehensive test suite validates all functionality of the EspPwm class:
  * - Constructor/Destructor behavior
  * - Lifecycle management (Initialize/Deinitialize)
@@ -68,43 +68,43 @@ hf_pwm_channel_config_t create_test_channel_config(hf_gpio_num_t gpio_pin) noexc
 
 bool test_constructor_default() noexcept {
   ESP_LOGI(TAG, "Testing default constructor...");
-  
+
   // Test constructors without exception handling
   EspPwm pwm1;
   ESP_LOGI(TAG, "[SUCCESS] Default constructor completed");
-  
+
   // Test constructor with unit config
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm2(config);
   ESP_LOGI(TAG, "[SUCCESS] Constructor with config completed");
-  
+
   // Test legacy constructor
   EspPwm pwm3(HF_PWM_APB_CLOCK_HZ);
   ESP_LOGI(TAG, "[SUCCESS] Legacy constructor completed");
-  
+
   return true;
 }
 
 bool test_destructor_cleanup() noexcept {
   ESP_LOGI(TAG, "Testing destructor cleanup...");
-  
+
   {
     hf_pwm_unit_config_t config = create_test_config();
     EspPwm pwm(config);
-    
+
     // Initialize and configure a channel
     if (!pwm.EnsureInitialized()) {
       ESP_LOGE(TAG, "Failed to initialize PWM for destructor test");
       return false;
     }
-    
+
     hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
     pwm.ConfigureChannel(0, ch_config);
     pwm.EnableChannel(0);
-    
+
     ESP_LOGI(TAG, "PWM configured, testing destructor cleanup...");
   } // pwm should be destroyed here
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Destructor cleanup completed");
   return true;
 }
@@ -115,85 +115,85 @@ bool test_destructor_cleanup() noexcept {
 
 bool test_initialization_states() noexcept {
   ESP_LOGI(TAG, "Testing initialization states...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   // Test initial state
   if (pwm.IsInitialized()) {
     ESP_LOGE(TAG, "PWM should not be initialized initially");
     return false;
   }
-  
+
   // Test manual initialization
   hf_pwm_err_t result = pwm.Initialize();
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Manual initialization failed: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (!pwm.IsInitialized()) {
     ESP_LOGE(TAG, "PWM should be initialized after Initialize()");
     return false;
   }
-  
+
   // Test double initialization
   result = pwm.Initialize();
   if (result != hf_pwm_err_t::PWM_ERR_ALREADY_INITIALIZED) {
     ESP_LOGE(TAG, "Double initialization should return ALREADY_INITIALIZED");
     return false;
   }
-  
+
   // Test deinitialization
   result = pwm.Deinitialize();
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Deinitialization failed: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (pwm.IsInitialized()) {
     ESP_LOGE(TAG, "PWM should not be initialized after Deinitialize()");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Initialization states test passed");
   return true;
 }
 
 bool test_lazy_initialization() noexcept {
   ESP_LOGI(TAG, "Testing lazy initialization...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   // PWM should not be initialized initially
   if (pwm.IsInitialized()) {
     ESP_LOGE(TAG, "PWM should not be initialized initially");
     return false;
   }
-  
+
   // Test EnsureInitialized
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "EnsureInitialized() failed");
     return false;
   }
-  
+
   if (!pwm.IsInitialized()) {
     ESP_LOGE(TAG, "PWM should be initialized after EnsureInitialized()");
     return false;
   }
-  
+
   // Test EnsureDeinitialized
   if (!pwm.EnsureDeinitialized()) {
     ESP_LOGE(TAG, "EnsureDeinitialized() failed");
     return false;
   }
-  
+
   if (pwm.IsInitialized()) {
     ESP_LOGE(TAG, "PWM should not be initialized after EnsureDeinitialized()");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Lazy initialization test passed");
   return true;
 }
@@ -204,77 +204,75 @@ bool test_lazy_initialization() noexcept {
 
 bool test_mode_configuration() noexcept {
   ESP_LOGI(TAG, "Testing mode configuration...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Test basic mode
   hf_pwm_err_t result = pwm.SetMode(hf_pwm_mode_t::HF_PWM_MODE_BASIC);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set basic mode: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (pwm.GetMode() != hf_pwm_mode_t::HF_PWM_MODE_BASIC) {
     ESP_LOGE(TAG, "Mode not set correctly to BASIC");
     return false;
   }
-  
+
   // Test fade mode
   result = pwm.SetMode(hf_pwm_mode_t::HF_PWM_MODE_FADE);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set fade mode: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (pwm.GetMode() != hf_pwm_mode_t::HF_PWM_MODE_FADE) {
     ESP_LOGE(TAG, "Mode not set correctly to FADE");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Mode configuration test passed");
   return true;
 }
 
 bool test_clock_source_configuration() noexcept {
   ESP_LOGI(TAG, "Testing clock source configuration...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Test different clock sources
   hf_pwm_clock_source_t sources[] = {
-    hf_pwm_clock_source_t::HF_PWM_CLK_SRC_DEFAULT,
-    hf_pwm_clock_source_t::HF_PWM_CLK_SRC_APB,
-    hf_pwm_clock_source_t::HF_PWM_CLK_SRC_XTAL,
-    hf_pwm_clock_source_t::HF_PWM_CLK_SRC_RC_FAST
-  };
-  
+      hf_pwm_clock_source_t::HF_PWM_CLK_SRC_DEFAULT, hf_pwm_clock_source_t::HF_PWM_CLK_SRC_APB,
+      hf_pwm_clock_source_t::HF_PWM_CLK_SRC_XTAL, hf_pwm_clock_source_t::HF_PWM_CLK_SRC_RC_FAST};
+
   for (auto source : sources) {
     hf_pwm_err_t result = pwm.SetClockSource(source);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
-      ESP_LOGE(TAG, "Failed to set clock source %d: %s", static_cast<int>(source), HfPwmErrToString(result));
+      ESP_LOGE(TAG, "Failed to set clock source %d: %s", static_cast<int>(source),
+               HfPwmErrToString(result));
       return false;
     }
-    
+
     if (pwm.GetClockSource() != source) {
       ESP_LOGE(TAG, "Clock source not set correctly");
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Clock source %d set successfully", static_cast<int>(source));
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Clock source configuration test passed");
   return true;
 }
@@ -285,30 +283,30 @@ bool test_clock_source_configuration() noexcept {
 
 bool test_channel_configuration() noexcept {
   ESP_LOGI(TAG, "Testing channel configuration...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Test configuring multiple channels
   for (hf_channel_id_t ch = 0; ch < 4; ch++) {
     hf_pwm_channel_config_t ch_config = create_test_channel_config(2 + ch);
     ch_config.channel_id = ch;
     ch_config.duty_initial = 256 + (ch * 128); // Different duty cycles
-    
+
     hf_pwm_err_t result = pwm.ConfigureChannel(ch, ch_config);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to configure channel %d: %s", ch, HfPwmErrToString(result));
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Channel %d configured successfully", ch);
   }
-  
+
   // Test invalid channel configuration
   hf_pwm_channel_config_t invalid_config = create_test_channel_config(10);
   hf_pwm_err_t result = pwm.ConfigureChannel(EspPwm::MAX_CHANNELS, invalid_config);
@@ -316,22 +314,22 @@ bool test_channel_configuration() noexcept {
     ESP_LOGE(TAG, "Invalid channel should not be configurable");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Channel configuration test passed");
   return true;
 }
 
 bool test_channel_enable_disable() noexcept {
   ESP_LOGI(TAG, "Testing channel enable/disable...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure a channel first
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   hf_pwm_err_t result = pwm.ConfigureChannel(0, ch_config);
@@ -339,44 +337,44 @@ bool test_channel_enable_disable() noexcept {
     ESP_LOGE(TAG, "Failed to configure channel for enable/disable test");
     return false;
   }
-  
+
   // Test channel should not be enabled initially
   if (pwm.IsChannelEnabled(0)) {
     ESP_LOGE(TAG, "Channel should not be enabled initially");
     return false;
   }
-  
+
   // Test enable channel
   result = pwm.EnableChannel(0);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to enable channel: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (!pwm.IsChannelEnabled(0)) {
     ESP_LOGE(TAG, "Channel should be enabled after EnableChannel()");
     return false;
   }
-  
+
   // Test disable channel
   result = pwm.DisableChannel(0);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to disable channel: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (pwm.IsChannelEnabled(0)) {
     ESP_LOGE(TAG, "Channel should not be enabled after DisableChannel()");
     return false;
   }
-  
+
   // Test invalid channel operations
   result = pwm.EnableChannel(EspPwm::MAX_CHANNELS);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Invalid channel should not be enableable");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Channel enable/disable test passed");
   return true;
 }
@@ -387,136 +385,136 @@ bool test_channel_enable_disable() noexcept {
 
 bool test_duty_cycle_control() noexcept {
   ESP_LOGI(TAG, "Testing duty cycle control...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure and enable a channel
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   // Test different duty cycles
   float test_duties[] = {0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
-  
+
   for (float duty : test_duties) {
     hf_pwm_err_t result = pwm.SetDutyCycle(0, duty);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to set duty cycle %.2f: %s", duty, HfPwmErrToString(result));
       return false;
     }
-    
+
     float actual_duty = pwm.GetDutyCycle(0);
     if (abs(actual_duty - duty) > 0.01f) { // Allow small tolerance
       ESP_LOGE(TAG, "Duty cycle mismatch: expected %.2f, got %.2f", duty, actual_duty);
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Duty cycle %.2f set successfully", duty);
     vTaskDelay(pdMS_TO_TICKS(50)); // Brief delay for observation
   }
-  
+
   // Test raw duty cycle setting
   hf_u32_t raw_values[] = {0, 256, 512, 768, 1023}; // For 10-bit resolution
-  
+
   for (hf_u32_t raw_val : raw_values) {
     hf_pwm_err_t result = pwm.SetDutyCycleRaw(0, raw_val);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to set raw duty cycle %lu: %s", raw_val, HfPwmErrToString(result));
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Raw duty cycle %lu set successfully", raw_val);
     vTaskDelay(pdMS_TO_TICKS(50));
   }
-  
+
   // Test invalid duty cycles
   hf_pwm_err_t result = pwm.SetDutyCycle(0, -0.1f);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Negative duty cycle should not be accepted");
     return false;
   }
-  
+
   result = pwm.SetDutyCycle(0, 1.1f);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Duty cycle > 1.0 should not be accepted");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Duty cycle control test passed");
   return true;
 }
 
 bool test_frequency_control() noexcept {
   ESP_LOGI(TAG, "Testing frequency control...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure and enable a channel
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   // Test different frequencies
   hf_frequency_hz_t test_frequencies[] = {100, 500, 1000, 5000, 10000, 20000};
-  
+
   for (hf_frequency_hz_t freq : test_frequencies) {
     hf_pwm_err_t result = pwm.SetFrequency(0, freq);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to set frequency %lu: %s", freq, HfPwmErrToString(result));
       return false;
     }
-    
+
     hf_frequency_hz_t actual_freq = pwm.GetFrequency(0);
     // Allow some tolerance for frequency accuracy
     if (abs((int)actual_freq - (int)freq) > freq * 0.05) { // 5% tolerance
       ESP_LOGE(TAG, "Frequency mismatch: expected %lu, got %lu", freq, actual_freq);
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Frequency %lu Hz set successfully (actual: %lu Hz)", freq, actual_freq);
     vTaskDelay(pdMS_TO_TICKS(100));
   }
-  
+
   // Test invalid frequencies
   hf_pwm_err_t result = pwm.SetFrequency(0, 0);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Zero frequency should not be accepted");
     return false;
   }
-  
+
   result = pwm.SetFrequency(0, HF_PWM_MAX_FREQUENCY + 1);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Frequency above maximum should not be accepted");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Frequency control test passed");
   return true;
 }
 
 bool test_phase_shift_control() noexcept {
   ESP_LOGI(TAG, "Testing phase shift control...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure and enable channels
   for (hf_channel_id_t ch = 0; ch < 3; ch++) {
     hf_pwm_channel_config_t ch_config = create_test_channel_config(2 + ch);
@@ -524,29 +522,29 @@ bool test_phase_shift_control() noexcept {
     pwm.ConfigureChannel(ch, ch_config);
     pwm.EnableChannel(ch);
   }
-  
+
   // Test different phase shifts
   float test_phases[] = {0.0f, 90.0f, 180.0f, 270.0f};
-  
+
   for (int i = 0; i < 3; i++) {
     float phase = test_phases[i];
     hf_pwm_err_t result = pwm.SetPhaseShift(i, phase);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
-      ESP_LOGE(TAG, "Failed to set phase shift %.1f for channel %d: %s", 
-               phase, i, HfPwmErrToString(result));
+      ESP_LOGE(TAG, "Failed to set phase shift %.1f for channel %d: %s", phase, i,
+               HfPwmErrToString(result));
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Phase shift %.1f degrees set for channel %d", phase, i);
   }
-  
+
   // Test invalid phase shift
   hf_pwm_err_t result = pwm.SetPhaseShift(0, 400.0f);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Phase shift > 360 degrees should not be accepted");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Phase shift control test passed");
   return true;
 }
@@ -557,15 +555,15 @@ bool test_phase_shift_control() noexcept {
 
 bool test_synchronized_operations() noexcept {
   ESP_LOGI(TAG, "Testing synchronized operations...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure multiple channels
   for (hf_channel_id_t ch = 0; ch < 4; ch++) {
     hf_pwm_channel_config_t ch_config = create_test_channel_config(2 + ch);
@@ -574,58 +572,58 @@ bool test_synchronized_operations() noexcept {
     pwm.ConfigureChannel(ch, ch_config);
     pwm.EnableChannel(ch);
   }
-  
+
   // Test StartAll
   hf_pwm_err_t result = pwm.StartAll();
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "StartAll failed: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   ESP_LOGI(TAG, "StartAll executed successfully");
   vTaskDelay(pdMS_TO_TICKS(500));
-  
+
   // Test UpdateAll
   result = pwm.UpdateAll();
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "UpdateAll failed: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   ESP_LOGI(TAG, "UpdateAll executed successfully");
   vTaskDelay(pdMS_TO_TICKS(500));
-  
+
   // Test StopAll
   result = pwm.StopAll();
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "StopAll failed: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   ESP_LOGI(TAG, "StopAll executed successfully");
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Synchronized operations test passed");
   return true;
 }
 
 bool test_complementary_outputs() noexcept {
   ESP_LOGI(TAG, "Testing complementary outputs...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure primary and complementary channels
   hf_pwm_channel_config_t primary_config = create_test_channel_config(2);
   hf_pwm_channel_config_t comp_config = create_test_channel_config(3);
-  
+
   pwm.ConfigureChannel(0, primary_config);
   pwm.ConfigureChannel(1, comp_config);
-  
+
   // Test complementary output setup
   hf_u32_t deadtime_ns = 1000; // 1 microsecond deadtime
   hf_pwm_err_t result = pwm.SetComplementaryOutput(0, 1, deadtime_ns);
@@ -633,19 +631,19 @@ bool test_complementary_outputs() noexcept {
     ESP_LOGE(TAG, "Failed to set complementary output: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   pwm.EnableChannel(0);
   pwm.EnableChannel(1);
-  
+
   // Test different duty cycles with complementary outputs
   float test_duties[] = {0.2f, 0.5f, 0.8f};
-  
+
   for (float duty : test_duties) {
     pwm.SetDutyCycle(0, duty);
     ESP_LOGI(TAG, "Complementary output test with duty cycle %.1f", duty);
     vTaskDelay(pdMS_TO_TICKS(300));
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Complementary outputs test passed");
   return true;
 }
@@ -656,173 +654,173 @@ bool test_complementary_outputs() noexcept {
 
 bool test_hardware_fade() noexcept {
   ESP_LOGI(TAG, "Testing hardware fade functionality...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   config.enable_fade = true;
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure and enable a channel
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   // Set initial duty cycle
   pwm.SetDutyCycle(0, 0.1f);
   vTaskDelay(pdMS_TO_TICKS(100));
-  
+
   // Test fade operations
   struct FadeTest {
     float target_duty;
     hf_u32_t fade_time_ms;
   };
-  
+
   FadeTest fade_tests[] = {
-    {0.8f, 1000},  // Fade up
-    {0.2f, 800},   // Fade down
-    {0.9f, 1200},  // Fade up again
-    {0.0f, 500}    // Fade to minimum
+      {0.8f, 1000}, // Fade up
+      {0.2f, 800},  // Fade down
+      {0.9f, 1200}, // Fade up again
+      {0.0f, 500}   // Fade to minimum
   };
-  
+
   for (const auto& test : fade_tests) {
     ESP_LOGI(TAG, "Starting fade to %.1f over %lu ms", test.target_duty, test.fade_time_ms);
-    
+
     hf_pwm_err_t result = pwm.SetHardwareFade(0, test.target_duty, test.fade_time_ms);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to start fade: %s", HfPwmErrToString(result));
       return false;
     }
-    
+
     // Check if fade is active
     if (!pwm.IsFadeActive(0)) {
       ESP_LOGE(TAG, "Fade should be active after SetHardwareFade");
       return false;
     }
-    
+
     // Wait for fade to complete
     vTaskDelay(pdMS_TO_TICKS(test.fade_time_ms + 200));
-    
+
     // Check if fade completed
     if (pwm.IsFadeActive(0)) {
       ESP_LOGI(TAG, "Warning: Fade still active after expected completion time");
     }
-    
+
     ESP_LOGI(TAG, "Fade completed");
   }
-  
+
   // Test stop fade
   pwm.SetHardwareFade(0, 0.5f, 2000); // Start a long fade
   vTaskDelay(pdMS_TO_TICKS(200));
-  
+
   hf_pwm_err_t result = pwm.StopHardwareFade(0);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to stop fade: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (pwm.IsFadeActive(0)) {
     ESP_LOGE(TAG, "Fade should not be active after StopHardwareFade");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Hardware fade test passed");
   return true;
 }
 
 bool test_idle_level_control() noexcept {
   ESP_LOGI(TAG, "Testing idle level control...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure channels
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   pwm.ConfigureChannel(0, ch_config);
-  
+
   // Test different idle levels
   hf_u8_t idle_levels[] = {0, 1};
-  
+
   for (hf_u8_t idle_level : idle_levels) {
     hf_pwm_err_t result = pwm.SetIdleLevel(0, idle_level);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to set idle level %d: %s", idle_level, HfPwmErrToString(result));
       return false;
     }
-    
+
     ESP_LOGI(TAG, "Idle level %d set successfully", idle_level);
   }
-  
+
   // Test invalid idle level
   hf_pwm_err_t result = pwm.SetIdleLevel(0, 2);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Invalid idle level should not be accepted");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Idle level control test passed");
   return true;
 }
 
 bool test_timer_management() noexcept {
   ESP_LOGI(TAG, "Testing timer management...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure channels with different configurations to test timer allocation
   struct ChannelConfig {
     hf_channel_id_t channel;
     hf_gpio_num_t gpio;
   };
-  
+
   ChannelConfig configs[] = {
-    {0, 2},   // Timer 0
-    {1, 3},   // Should share Timer 0
-    {2, 4},   // Timer 1
-    {3, 5}    // Timer 2
+      {0, 2}, // Timer 0
+      {1, 3}, // Should share Timer 0
+      {2, 4}, // Timer 1
+      {3, 5}  // Timer 2
   };
-  
+
   for (const auto& cfg : configs) {
     hf_pwm_channel_config_t ch_config = create_test_channel_config(cfg.gpio);
     ch_config.channel_id = cfg.channel;
-    
+
     hf_pwm_err_t result = pwm.ConfigureChannel(cfg.channel, ch_config);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to configure channel %d: %s", cfg.channel, HfPwmErrToString(result));
       return false;
     }
-    
+
     int8_t timer_id = pwm.GetTimerAssignment(cfg.channel);
     ESP_LOGI(TAG, "Channel %d assigned to timer %d", cfg.channel, timer_id);
   }
-  
+
   // Test forced timer assignment
   hf_pwm_err_t result = pwm.ForceTimerAssignment(0, 3);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to force timer assignment: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   int8_t timer_id = pwm.GetTimerAssignment(0);
   if (timer_id != 3) {
     ESP_LOGE(TAG, "Forced timer assignment failed: expected 3, got %d", timer_id);
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Timer management test passed");
   return true;
 }
@@ -833,22 +831,22 @@ bool test_timer_management() noexcept {
 
 bool test_status_reporting() noexcept {
   ESP_LOGI(TAG, "Testing status reporting...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure and enable a channel
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   ch_config.duty_initial = 600; // ~60% for 10-bit resolution
-  
+
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   // Test channel status reporting
   hf_pwm_channel_status_t status;
   hf_pwm_err_t result = pwm.GetChannelStatus(0, status);
@@ -856,20 +854,20 @@ bool test_status_reporting() noexcept {
     ESP_LOGE(TAG, "Failed to get channel status: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   if (!status.enabled) {
     ESP_LOGE(TAG, "Channel status should show enabled");
     return false;
   }
-  
+
   if (!status.configured) {
     ESP_LOGE(TAG, "Channel status should show configured");
     return false;
   }
-  
-  ESP_LOGI(TAG, "Channel status: enabled=%d, configured=%d, duty=%.2f, freq=%lu", 
-           status.enabled, status.configured, status.current_duty_cycle, status.current_frequency);
-  
+
+  ESP_LOGI(TAG, "Channel status: enabled=%d, configured=%d, duty=%.2f, freq=%lu", status.enabled,
+           status.configured, status.current_duty_cycle, status.current_frequency);
+
   // Test capabilities reporting
   hf_pwm_capabilities_t capabilities;
   result = pwm.GetCapabilities(capabilities);
@@ -877,41 +875,41 @@ bool test_status_reporting() noexcept {
     ESP_LOGE(TAG, "Failed to get capabilities: %s", HfPwmErrToString(result));
     return false;
   }
-  
+
   ESP_LOGI(TAG, "PWM capabilities retrieved successfully");
-  
+
   // Test error reporting
   hf_pwm_err_t last_error = pwm.GetLastError(0);
   ESP_LOGI(TAG, "Last error for channel 0: %s", HfPwmErrToString(last_error));
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Status reporting test passed");
   return true;
 }
 
 bool test_statistics_and_diagnostics() noexcept {
   ESP_LOGI(TAG, "Testing statistics and diagnostics...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Perform some operations to generate statistics
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   for (int i = 0; i < 5; i++) {
     pwm.SetDutyCycle(0, 0.2f + (i * 0.15f));
     pwm.SetFrequency(0, 1000 + (i * 500));
     vTaskDelay(pdMS_TO_TICKS(50));
   }
-  
+
   pwm.DisableChannel(0);
-  
+
   // Test statistics reporting
   hf_pwm_statistics_t statistics;
   hf_pwm_err_t result = pwm.GetStatistics(statistics);
@@ -919,11 +917,13 @@ bool test_statistics_and_diagnostics() noexcept {
     ESP_LOGE(TAG, "Failed to get statistics: %s", HfPwmErrToString(result));
     return false;
   }
-  
-  ESP_LOGI(TAG, "Statistics - Duty updates: %lu, Freq changes: %lu, Channel enables: %lu, Channel disables: %lu",
+
+  ESP_LOGI(TAG,
+           "Statistics - Duty updates: %lu, Freq changes: %lu, Channel enables: %lu, Channel "
+           "disables: %lu",
            statistics.duty_updates_count, statistics.frequency_changes_count,
            statistics.channel_enables_count, statistics.channel_disables_count);
-  
+
   // Test diagnostics reporting
   hf_pwm_diagnostics_t diagnostics;
   result = pwm.GetDiagnostics(diagnostics);
@@ -931,11 +931,13 @@ bool test_statistics_and_diagnostics() noexcept {
     ESP_LOGE(TAG, "Failed to get diagnostics: %s", HfPwmErrToString(result));
     return false;
   }
-  
-  ESP_LOGI(TAG, "Diagnostics - Hardware init: %d, Fade ready: %d, Active channels: %d, Active timers: %d",
-           diagnostics.hardware_initialized, diagnostics.fade_functionality_ready,
-           diagnostics.active_channels, diagnostics.active_timers);
-  
+
+  ESP_LOGI(
+      TAG,
+      "Diagnostics - Hardware init: %d, Fade ready: %d, Active channels: %d, Active timers: %d",
+      diagnostics.hardware_initialized, diagnostics.fade_functionality_ready,
+      diagnostics.active_channels, diagnostics.active_timers);
+
   ESP_LOGI(TAG, "[SUCCESS] Statistics and diagnostics test passed");
   return true;
 }
@@ -958,46 +960,45 @@ void test_period_callback(hf_channel_id_t channel_id, void* user_data) {
 void test_fault_callback(hf_channel_id_t channel_id, hf_pwm_err_t error, void* user_data) {
   g_fault_callback_called = true;
   g_callback_channel = channel_id;
-  ESP_LOGI(TAG, "Fault callback called for channel %d, error: %s", 
-           channel_id, HfPwmErrToString(error));
+  ESP_LOGI(TAG, "Fault callback called for channel %d, error: %s", channel_id,
+           HfPwmErrToString(error));
 }
 
 bool test_callbacks() noexcept {
   ESP_LOGI(TAG, "Testing callback functionality...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   config.enable_interrupts = true;
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Reset callback flags
   g_period_callback_called = false;
   g_fault_callback_called = false;
-  
+
   // Set callbacks
   pwm.SetPeriodCallback(test_period_callback, nullptr);
   pwm.SetFaultCallback(test_fault_callback, nullptr);
-  
+
   // Configure and enable a channel
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   ch_config.duty_initial = 10; // Low duty cycle to trigger period callbacks quickly
-  
+
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   // Wait for potential callbacks
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   // Note: Period callbacks may not always trigger in test environment
   // depending on ESP32 configuration and interrupt setup
   ESP_LOGI(TAG, "Callback test completed - Period callback called: %s, Fault callback called: %s",
-           g_period_callback_called ? "YES" : "NO",
-           g_fault_callback_called ? "YES" : "NO");
-  
+           g_period_callback_called ? "YES" : "NO", g_fault_callback_called ? "YES" : "NO");
+
   ESP_LOGI(TAG, "[SUCCESS] Callback test completed");
   return true;
 }
@@ -1008,95 +1009,96 @@ bool test_callbacks() noexcept {
 
 bool test_edge_cases() noexcept {
   ESP_LOGI(TAG, "Testing edge cases...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Test boundary duty cycles
   hf_pwm_channel_config_t ch_config = create_test_channel_config(2);
   pwm.ConfigureChannel(0, ch_config);
   pwm.EnableChannel(0);
-  
+
   // Test minimum and maximum duty cycles
   hf_pwm_err_t result = pwm.SetDutyCycle(0, 0.0f);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set minimum duty cycle");
     return false;
   }
-  
+
   result = pwm.SetDutyCycle(0, 1.0f);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set maximum duty cycle");
     return false;
   }
-  
+
   // Test boundary frequencies
   result = pwm.SetFrequency(0, HF_PWM_MIN_FREQUENCY);
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set minimum frequency");
     return false;
   }
-  
+
   // Don't test absolute maximum frequency as it may not be achievable
   result = pwm.SetFrequency(0, 50000); // Test a high but reasonable frequency
   if (result != hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Failed to set high frequency");
     return false;
   }
-  
+
   // Test invalid channel operations
   result = pwm.SetDutyCycle(EspPwm::MAX_CHANNELS, 0.5f);
   if (result == hf_pwm_err_t::PWM_SUCCESS) {
     ESP_LOGE(TAG, "Invalid channel operation should fail");
     return false;
   }
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Edge cases test passed");
   return true;
 }
 
 bool test_stress_scenarios() noexcept {
   ESP_LOGI(TAG, "Testing stress scenarios...");
-  
+
   hf_pwm_unit_config_t config = create_test_config();
   EspPwm pwm(config);
-  
+
   if (!pwm.EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize PWM");
     return false;
   }
-  
+
   // Configure maximum number of channels
   for (hf_channel_id_t ch = 0; ch < EspPwm::MAX_CHANNELS; ch++) {
     hf_pwm_channel_config_t ch_config = create_test_channel_config(2 + ch);
     ch_config.channel_id = ch;
     ch_config.duty_initial = 200 + (ch * 100);
-    
+
     hf_pwm_err_t result = pwm.ConfigureChannel(ch, ch_config);
     if (result != hf_pwm_err_t::PWM_SUCCESS) {
       ESP_LOGE(TAG, "Failed to configure channel %d in stress test", ch);
       return false;
     }
-    
+
     pwm.EnableChannel(ch);
   }
-  
+
   // Rapid duty cycle changes
   for (int iteration = 0; iteration < 20; iteration++) {
     for (hf_channel_id_t ch = 0; ch < EspPwm::MAX_CHANNELS; ch++) {
       float duty = 0.1f + (iteration * 0.04f);
-      if (duty > 1.0f) duty = 1.0f;
-      
+      if (duty > 1.0f)
+        duty = 1.0f;
+
       pwm.SetDutyCycle(ch, duty);
     }
     vTaskDelay(pdMS_TO_TICKS(10)); // Brief delay
   }
-  
+
   // Rapid frequency changes
   for (int iteration = 0; iteration < 10; iteration++) {
     for (hf_channel_id_t ch = 0; ch < EspPwm::MAX_CHANNELS; ch++) {
@@ -1105,16 +1107,16 @@ bool test_stress_scenarios() noexcept {
     }
     vTaskDelay(pdMS_TO_TICKS(50));
   }
-  
+
   // Test synchronized operations with all channels
   pwm.StartAll();
   vTaskDelay(pdMS_TO_TICKS(100));
-  
+
   pwm.UpdateAll();
   vTaskDelay(pdMS_TO_TICKS(100));
-  
+
   pwm.StopAll();
-  
+
   ESP_LOGI(TAG, "[SUCCESS] Stress scenarios test passed");
   return true;
 }
@@ -1128,68 +1130,69 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "║                    ESP32-C6 PWM COMPREHENSIVE TEST SUITE                    ║");
   ESP_LOGI(TAG, "║                         Testing EspPwm Class Thoroughly                      ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   vTaskDelay(pdMS_TO_TICKS(1000));
-  
+
   // Constructor/Destructor Tests
   ESP_LOGI(TAG, "\n=== CONSTRUCTOR/DESTRUCTOR TESTS ===");
   RUN_TEST(test_constructor_default);
   RUN_TEST(test_destructor_cleanup);
-  
+
   // Lifecycle Tests
   ESP_LOGI(TAG, "\n=== LIFECYCLE TESTS ===");
   RUN_TEST(test_initialization_states);
   RUN_TEST(test_lazy_initialization);
-  
+
   // Configuration Tests
   ESP_LOGI(TAG, "\n=== CONFIGURATION TESTS ===");
   RUN_TEST(test_mode_configuration);
   RUN_TEST(test_clock_source_configuration);
-  
+
   // Channel Management Tests
   ESP_LOGI(TAG, "\n=== CHANNEL MANAGEMENT TESTS ===");
   RUN_TEST(test_channel_configuration);
   RUN_TEST(test_channel_enable_disable);
-  
+
   // PWM Control Tests
   ESP_LOGI(TAG, "\n=== PWM CONTROL TESTS ===");
   RUN_TEST(test_duty_cycle_control);
   RUN_TEST(test_frequency_control);
   RUN_TEST(test_phase_shift_control);
-  
+
   // Advanced Features Tests
   ESP_LOGI(TAG, "\n=== ADVANCED FEATURES TESTS ===");
   RUN_TEST(test_synchronized_operations);
   RUN_TEST(test_complementary_outputs);
-  
+
   // ESP32-Specific Features Tests
   ESP_LOGI(TAG, "\n=== ESP32-SPECIFIC FEATURES TESTS ===");
   RUN_TEST(test_hardware_fade);
   RUN_TEST(test_idle_level_control);
   RUN_TEST(test_timer_management);
-  
+
   // Status and Diagnostics Tests
   ESP_LOGI(TAG, "\n=== STATUS AND DIAGNOSTICS TESTS ===");
   RUN_TEST(test_status_reporting);
   RUN_TEST(test_statistics_and_diagnostics);
-  
+
   // Callback Tests
   ESP_LOGI(TAG, "\n=== CALLBACK TESTS ===");
   RUN_TEST(test_callbacks);
-  
+
   // Edge Cases and Stress Tests
   ESP_LOGI(TAG, "\n=== EDGE CASES AND STRESS TESTS ===");
   RUN_TEST(test_edge_cases);
   RUN_TEST(test_stress_scenarios);
-  
+
   // Print final summary
   ESP_LOGI(TAG, "\n");
   print_test_summary(g_test_results, "ESP32 PWM COMPREHENSIVE", TAG);
-  
-  ESP_LOGI(TAG, "\n╔══════════════════════════════════════════════════════════════════════════════╗");
+
+  ESP_LOGI(TAG,
+           "\n╔══════════════════════════════════════════════════════════════════════════════╗");
   ESP_LOGI(TAG, "║                    ESP32-C6 PWM TESTING COMPLETED                           ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-  
+
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));
   }

--- a/examples/esp32/main/TemperatureComprehensiveTest.cpp
+++ b/examples/esp32/main/TemperatureComprehensiveTest.cpp
@@ -26,30 +26,33 @@ static std::atomic<float> g_last_callback_temperature{0.0f};
 // CALLBACK FUNCTIONS FOR TESTING
 //==============================================================================
 
-void threshold_callback(BaseTemperature* sensor, float temperature, hf_u32_t threshold_type, void* user_data) {
-    g_threshold_callback_count++;
-    g_last_callback_temperature = temperature;
-    ESP_LOGI(TAG, "Threshold callback: %.2f°C, type: %u", temperature, threshold_type);
+void threshold_callback(BaseTemperature* sensor, float temperature, hf_u32_t threshold_type,
+                        void* user_data) {
+  g_threshold_callback_count++;
+  g_last_callback_temperature = temperature;
+  ESP_LOGI(TAG, "Threshold callback: %.2f°C, type: %u", temperature, threshold_type);
 }
 
-void monitoring_callback(BaseTemperature* sensor, const hf_temp_reading_t* reading, void* user_data) {
-    g_monitoring_callback_count++;
-    if (reading) {
-        g_last_callback_temperature = reading->temperature_celsius;
-        ESP_LOGD(TAG, "Monitoring callback: %.2f°C", reading->temperature_celsius);
-    }
+void monitoring_callback(BaseTemperature* sensor, const hf_temp_reading_t* reading,
+                         void* user_data) {
+  g_monitoring_callback_count++;
+  if (reading) {
+    g_last_callback_temperature = reading->temperature_celsius;
+    ESP_LOGD(TAG, "Monitoring callback: %.2f°C", reading->temperature_celsius);
+  }
 }
 
 void esp_threshold_callback(EspTemperature* sensor, float temperature, bool is_high_threshold) {
-    g_threshold_callback_count++;
-    g_last_callback_temperature = temperature;
-    ESP_LOGI(TAG, "ESP threshold callback: %.2f°C, high: %s", temperature, is_high_threshold ? "true" : "false");
+  g_threshold_callback_count++;
+  g_last_callback_temperature = temperature;
+  ESP_LOGI(TAG, "ESP threshold callback: %.2f°C, high: %s", temperature,
+           is_high_threshold ? "true" : "false");
 }
 
 void esp_monitoring_callback(EspTemperature* sensor, float temperature, hf_u64_t timestamp_us) {
-    g_monitoring_callback_count++;
-    g_last_callback_temperature = temperature;
-    ESP_LOGD(TAG, "ESP monitoring callback: %.2f°C at %llu", temperature, timestamp_us);
+  g_monitoring_callback_count++;
+  g_last_callback_temperature = temperature;
+  ESP_LOGD(TAG, "ESP monitoring callback: %.2f°C at %llu", temperature, timestamp_us);
 }
 
 //==============================================================================
@@ -57,97 +60,97 @@ void esp_monitoring_callback(EspTemperature* sensor, float temperature, hf_u64_t
 //==============================================================================
 
 bool test_temperature_sensor_initialization() noexcept {
-    ESP_LOGI(TAG, "Testing temperature sensor initialization...");
+  ESP_LOGI(TAG, "Testing temperature sensor initialization...");
 
-    EspTemperature test_temp;
-    
-    // Test initial state
-    if (test_temp.GetState() != HF_TEMP_STATE_UNINITIALIZED) {
-        ESP_LOGE(TAG, "Initial state should be UNINITIALIZED");
-        return false;
-    }
+  EspTemperature test_temp;
 
-    // Test initialization
-    auto init_result = test_temp.EnsureInitialized();
-    if (!init_result) {
-        ESP_LOGE(TAG, "Failed to initialize temperature sensor");
-        return false;
-    }
+  // Test initial state
+  if (test_temp.GetState() != HF_TEMP_STATE_UNINITIALIZED) {
+    ESP_LOGE(TAG, "Initial state should be UNINITIALIZED");
+    return false;
+  }
 
-    // Verify state after initialization
-    if (test_temp.GetState() != HF_TEMP_STATE_INITIALIZED) {
-        ESP_LOGE(TAG, "State should be INITIALIZED after init");
-        return false;
-    }
+  // Test initialization
+  auto init_result = test_temp.EnsureInitialized();
+  if (!init_result) {
+    ESP_LOGE(TAG, "Failed to initialize temperature sensor");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Temperature sensor initialization successful");
-    return true;
+  // Verify state after initialization
+  if (test_temp.GetState() != HF_TEMP_STATE_INITIALIZED) {
+    ESP_LOGE(TAG, "State should be INITIALIZED after init");
+    return false;
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] Temperature sensor initialization successful");
+  return true;
 }
 
 bool test_temperature_reading() noexcept {
-    ESP_LOGI(TAG, "Testing temperature reading...");
+  ESP_LOGI(TAG, "Testing temperature reading...");
 
-    EspTemperature test_temp;
-    
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
 
-    // Test basic reading
-    hf_temp_reading_t reading = {};
-    auto read_result = test_temp.ReadTemperature(&reading);
-    if (read_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read temperature: %s", GetTempErrorString(read_result));
-        return false;
-    }
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Validate reading
-    if (!reading.is_valid) {
-        ESP_LOGE(TAG, "Temperature reading is not valid");
-        return false;
-    }
+  // Test basic reading
+  hf_temp_reading_t reading = {};
+  auto read_result = test_temp.ReadTemperature(&reading);
+  if (read_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read temperature: %s", GetTempErrorString(read_result));
+    return false;
+  }
 
-    // Check reasonable temperature range (-50°C to 150°C for chip)
-    if (reading.temperature_celsius < -50.0f || reading.temperature_celsius > 150.0f) {
-        ESP_LOGE(TAG, "Temperature %.2f°C outside reasonable range", reading.temperature_celsius);
-        return false;
-    }
+  // Validate reading
+  if (!reading.is_valid) {
+    ESP_LOGE(TAG, "Temperature reading is not valid");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Temperature reading: %.2f°C", reading.temperature_celsius);
-    return true;
+  // Check reasonable temperature range (-50°C to 150°C for chip)
+  if (reading.temperature_celsius < -50.0f || reading.temperature_celsius > 150.0f) {
+    ESP_LOGE(TAG, "Temperature %.2f°C outside reasonable range", reading.temperature_celsius);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] Temperature reading: %.2f°C", reading.temperature_celsius);
+  return true;
 }
 
 bool test_sensor_info() noexcept {
-    ESP_LOGI(TAG, "Testing sensor info retrieval...");
+  ESP_LOGI(TAG, "Testing sensor info retrieval...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    hf_temp_sensor_info_t info = {};
-    auto info_result = test_temp.GetSensorInfo(&info);
-    if (info_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get sensor info");
-        return false;
-    }
+  hf_temp_sensor_info_t info = {};
+  auto info_result = test_temp.GetSensorInfo(&info);
+  if (info_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get sensor info");
+    return false;
+  }
 
-    // Validate sensor info
-    if (info.sensor_type != HF_TEMP_SENSOR_TYPE_INTERNAL) {
-        ESP_LOGE(TAG, "Sensor type should be INTERNAL");
-        return false;
-    }
+  // Validate sensor info
+  if (info.sensor_type != HF_TEMP_SENSOR_TYPE_INTERNAL) {
+    ESP_LOGE(TAG, "Sensor type should be INTERNAL");
+    return false;
+  }
 
-    if (info.capabilities == HF_TEMP_CAP_NONE) {
-        ESP_LOGE(TAG, "Sensor should have capabilities");
-        return false;
-    }
+  if (info.capabilities == HF_TEMP_CAP_NONE) {
+    ESP_LOGE(TAG, "Sensor should have capabilities");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Sensor info: %s %s, Range: %.1f to %.1f°C", 
-             info.manufacturer, info.model, info.min_temp_celsius, info.max_temp_celsius);
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Sensor info: %s %s, Range: %.1f to %.1f°C", info.manufacturer,
+           info.model, info.min_temp_celsius, info.max_temp_celsius);
+  return true;
 }
 
 //==============================================================================
@@ -155,53 +158,53 @@ bool test_sensor_info() noexcept {
 //==============================================================================
 
 bool test_range_management() noexcept {
-    ESP_LOGI(TAG, "Testing range management...");
+  ESP_LOGI(TAG, "Testing range management...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Test getting current range
-    float min_temp, max_temp;
-    auto range_result = test_temp.GetRange(&min_temp, &max_temp);
-    if (range_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get current range");
-        return false;
-    }
+  // Test getting current range
+  float min_temp, max_temp;
+  auto range_result = test_temp.GetRange(&min_temp, &max_temp);
+  if (range_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get current range");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Current range: %.1f to %.1f°C", min_temp, max_temp);
+  ESP_LOGI(TAG, "Current range: %.1f to %.1f°C", min_temp, max_temp);
 
-    // Test setting different ranges
-    auto set_range_result = test_temp.SetRange(20.0f, 100.0f);
-    if (set_range_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set range 20-100°C");
-        return false;
-    }
+  // Test setting different ranges
+  auto set_range_result = test_temp.SetRange(20.0f, 100.0f);
+  if (set_range_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set range 20-100°C");
+    return false;
+  }
 
-    // Verify range was set
-    auto verify_result = test_temp.GetRange(&min_temp, &max_temp);
-    if (verify_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to verify range");
-        return false;
-    }
+  // Verify range was set
+  auto verify_result = test_temp.GetRange(&min_temp, &max_temp);
+  if (verify_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to verify range");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "New range: %.1f to %.1f°C", min_temp, max_temp);
+  ESP_LOGI(TAG, "New range: %.1f to %.1f°C", min_temp, max_temp);
 
-    // Test ESP32-specific range methods
-    auto esp_range = test_temp.GetMeasurementRange();
-    ESP_LOGI(TAG, "ESP32 range: %d", static_cast<int>(esp_range));
+  // Test ESP32-specific range methods
+  auto esp_range = test_temp.GetMeasurementRange();
+  ESP_LOGI(TAG, "ESP32 range: %d", static_cast<int>(esp_range));
 
-    // Test finding optimal range
-    auto optimal_range = test_temp.FindOptimalRange(-10.0f, 80.0f);
-    if (optimal_range >= ESP_TEMP_RANGE_COUNT) {
-        ESP_LOGE(TAG, "Failed to find optimal range");
-        return false;
-    }
+  // Test finding optimal range
+  auto optimal_range = test_temp.FindOptimalRange(-10.0f, 80.0f);
+  if (optimal_range >= ESP_TEMP_RANGE_COUNT) {
+    ESP_LOGE(TAG, "Failed to find optimal range");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Range management tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Range management tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -209,55 +212,55 @@ bool test_range_management() noexcept {
 //==============================================================================
 
 bool test_threshold_monitoring() noexcept {
-    ESP_LOGI(TAG, "Testing threshold monitoring...");
+  ESP_LOGI(TAG, "Testing threshold monitoring...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Reset callback counters
-    g_threshold_callback_count = 0;
+  // Reset callback counters
+  g_threshold_callback_count = 0;
 
-    // Set thresholds
-    auto set_result = test_temp.SetThresholds(10.0f, 50.0f);
-    if (set_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set thresholds");
-        return false;
-    }
+  // Set thresholds
+  auto set_result = test_temp.SetThresholds(10.0f, 50.0f);
+  if (set_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set thresholds");
+    return false;
+  }
 
-    // Verify thresholds
-    float low_thresh, high_thresh;
-    auto get_result = test_temp.GetThresholds(&low_thresh, &high_thresh);
-    if (get_result != hf_temp_err_t::TEMP_SUCCESS || low_thresh != 10.0f || high_thresh != 50.0f) {
-        ESP_LOGE(TAG, "Threshold verification failed");
-        return false;
-    }
+  // Verify thresholds
+  float low_thresh, high_thresh;
+  auto get_result = test_temp.GetThresholds(&low_thresh, &high_thresh);
+  if (get_result != hf_temp_err_t::TEMP_SUCCESS || low_thresh != 10.0f || high_thresh != 50.0f) {
+    ESP_LOGE(TAG, "Threshold verification failed");
+    return false;
+  }
 
-    // Enable threshold monitoring
-    auto enable_result = test_temp.EnableThresholdMonitoring(threshold_callback, nullptr);
-    if (enable_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enable threshold monitoring");
-        return false;
-    }
+  // Enable threshold monitoring
+  auto enable_result = test_temp.EnableThresholdMonitoring(threshold_callback, nullptr);
+  if (enable_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enable threshold monitoring");
+    return false;
+  }
 
-    // Test ESP32-specific threshold callback
-    auto esp_callback_result = test_temp.SetEspThresholdCallback(esp_threshold_callback);
-    if (esp_callback_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set ESP threshold callback");
-        return false;
-    }
+  // Test ESP32-specific threshold callback
+  auto esp_callback_result = test_temp.SetEspThresholdCallback(esp_threshold_callback);
+  if (esp_callback_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set ESP threshold callback");
+    return false;
+  }
 
-    // Disable threshold monitoring
-    auto disable_result = test_temp.DisableThresholdMonitoring();
-    if (disable_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to disable threshold monitoring");
-        return false;
-    }
+  // Disable threshold monitoring
+  auto disable_result = test_temp.DisableThresholdMonitoring();
+  if (disable_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to disable threshold monitoring");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Threshold monitoring tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Threshold monitoring tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -265,69 +268,69 @@ bool test_threshold_monitoring() noexcept {
 //==============================================================================
 
 bool test_continuous_monitoring() noexcept {
-    ESP_LOGI(TAG, "Testing continuous monitoring...");
+  ESP_LOGI(TAG, "Testing continuous monitoring...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Reset callback counters
-    g_monitoring_callback_count = 0;
+  // Reset callback counters
+  g_monitoring_callback_count = 0;
 
-    // Check initial monitoring state
-    if (test_temp.IsMonitoringActive()) {
-        ESP_LOGE(TAG, "Monitoring should not be active initially");
-        return false;
-    }
+  // Check initial monitoring state
+  if (test_temp.IsMonitoringActive()) {
+    ESP_LOGE(TAG, "Monitoring should not be active initially");
+    return false;
+  }
 
-    // Start continuous monitoring
-    auto start_result = test_temp.StartContinuousMonitoring(10, monitoring_callback, nullptr);
-    if (start_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to start continuous monitoring");
-        return false;
-    }
+  // Start continuous monitoring
+  auto start_result = test_temp.StartContinuousMonitoring(10, monitoring_callback, nullptr);
+  if (start_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to start continuous monitoring");
+    return false;
+  }
 
-    // Verify monitoring is active
-    if (!test_temp.IsMonitoringActive()) {
-        ESP_LOGE(TAG, "Monitoring should be active");
-        return false;
-    }
+  // Verify monitoring is active
+  if (!test_temp.IsMonitoringActive()) {
+    ESP_LOGE(TAG, "Monitoring should be active");
+    return false;
+  }
 
-    // Test ESP32-specific monitoring callback
-    auto esp_callback_result = test_temp.SetEspMonitoringCallback(esp_monitoring_callback);
-    if (esp_callback_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set ESP monitoring callback");
-        return false;
-    }
+  // Test ESP32-specific monitoring callback
+  auto esp_callback_result = test_temp.SetEspMonitoringCallback(esp_monitoring_callback);
+  if (esp_callback_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set ESP monitoring callback");
+    return false;
+  }
 
-    // Wait for some callbacks
-    vTaskDelay(pdMS_TO_TICKS(1500));
+  // Wait for some callbacks
+  vTaskDelay(pdMS_TO_TICKS(1500));
 
-    // Check if callbacks were received
-    int callback_count = g_monitoring_callback_count.load();
-    if (callback_count < 5) {
-        ESP_LOGW(TAG, "Only received %d callbacks, expected more", callback_count);
-    } else {
-        ESP_LOGI(TAG, "Received %d monitoring callbacks", callback_count);
-    }
+  // Check if callbacks were received
+  int callback_count = g_monitoring_callback_count.load();
+  if (callback_count < 5) {
+    ESP_LOGW(TAG, "Only received %d callbacks, expected more", callback_count);
+  } else {
+    ESP_LOGI(TAG, "Received %d monitoring callbacks", callback_count);
+  }
 
-    // Stop continuous monitoring
-    auto stop_result = test_temp.StopContinuousMonitoring();
-    if (stop_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to stop continuous monitoring");
-        return false;
-    }
+  // Stop continuous monitoring
+  auto stop_result = test_temp.StopContinuousMonitoring();
+  if (stop_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to stop continuous monitoring");
+    return false;
+  }
 
-    // Verify monitoring is stopped
-    if (test_temp.IsMonitoringActive()) {
-        ESP_LOGE(TAG, "Monitoring should not be active after stop");
-        return false;
-    }
+  // Verify monitoring is stopped
+  if (test_temp.IsMonitoringActive()) {
+    ESP_LOGE(TAG, "Monitoring should not be active after stop");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Continuous monitoring tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Continuous monitoring tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -335,65 +338,65 @@ bool test_continuous_monitoring() noexcept {
 //==============================================================================
 
 bool test_calibration() noexcept {
-    ESP_LOGI(TAG, "Testing calibration functionality...");
+  ESP_LOGI(TAG, "Testing calibration functionality...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Test getting initial calibration offset
-    float initial_offset;
-    auto get_result = test_temp.GetCalibrationOffset(&initial_offset);
-    if (get_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get initial calibration offset");
-        return false;
-    }
+  // Test getting initial calibration offset
+  float initial_offset;
+  auto get_result = test_temp.GetCalibrationOffset(&initial_offset);
+  if (get_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get initial calibration offset");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Initial calibration offset: %.2f°C", initial_offset);
+  ESP_LOGI(TAG, "Initial calibration offset: %.2f°C", initial_offset);
 
-    // Test setting calibration offset
-    const float test_offset = 2.5f;
-    auto set_result = test_temp.SetCalibrationOffset(test_offset);
-    if (set_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set calibration offset");
-        return false;
-    }
+  // Test setting calibration offset
+  const float test_offset = 2.5f;
+  auto set_result = test_temp.SetCalibrationOffset(test_offset);
+  if (set_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set calibration offset");
+    return false;
+  }
 
-    // Verify calibration offset was set
-    float current_offset;
-    auto verify_result = test_temp.GetCalibrationOffset(&current_offset);
-    if (verify_result != hf_temp_err_t::TEMP_SUCCESS || current_offset != test_offset) {
-        ESP_LOGE(TAG, "Calibration offset verification failed");
-        return false;
-    }
+  // Verify calibration offset was set
+  float current_offset;
+  auto verify_result = test_temp.GetCalibrationOffset(&current_offset);
+  if (verify_result != hf_temp_err_t::TEMP_SUCCESS || current_offset != test_offset) {
+    ESP_LOGE(TAG, "Calibration offset verification failed");
+    return false;
+  }
 
-    // Test reading with calibration
-    hf_temp_reading_t reading_calibrated = {};
-    auto read_result = test_temp.ReadTemperature(&reading_calibrated);
-    if (read_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read temperature with calibration");
-        return false;
-    }
+  // Test reading with calibration
+  hf_temp_reading_t reading_calibrated = {};
+  auto read_result = test_temp.ReadTemperature(&reading_calibrated);
+  if (read_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read temperature with calibration");
+    return false;
+  }
 
-    // Reset calibration
-    auto reset_result = test_temp.ResetCalibration();
-    if (reset_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to reset calibration");
-        return false;
-    }
+  // Reset calibration
+  auto reset_result = test_temp.ResetCalibration();
+  if (reset_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to reset calibration");
+    return false;
+  }
 
-    // Verify calibration was reset
-    float reset_offset;
-    auto final_result = test_temp.GetCalibrationOffset(&reset_offset);
-    if (final_result != hf_temp_err_t::TEMP_SUCCESS || reset_offset != 0.0f) {
-        ESP_LOGE(TAG, "Calibration reset verification failed");
-        return false;
-    }
+  // Verify calibration was reset
+  float reset_offset;
+  auto final_result = test_temp.GetCalibrationOffset(&reset_offset);
+  if (final_result != hf_temp_err_t::TEMP_SUCCESS || reset_offset != 0.0f) {
+    ESP_LOGE(TAG, "Calibration reset verification failed");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Calibration tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Calibration tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -401,62 +404,62 @@ bool test_calibration() noexcept {
 //==============================================================================
 
 bool test_power_management() noexcept {
-    ESP_LOGI(TAG, "Testing power management...");
+  ESP_LOGI(TAG, "Testing power management...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Check initial sleep state
-    if (test_temp.IsSleeping()) {
-        ESP_LOGE(TAG, "Sensor should not be sleeping initially");
-        return false;
-    }
+  // Check initial sleep state
+  if (test_temp.IsSleeping()) {
+    ESP_LOGE(TAG, "Sensor should not be sleeping initially");
+    return false;
+  }
 
-    // Enter sleep mode
-    auto sleep_result = test_temp.EnterSleepMode();
-    if (sleep_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to enter sleep mode");
-        return false;
-    }
+  // Enter sleep mode
+  auto sleep_result = test_temp.EnterSleepMode();
+  if (sleep_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to enter sleep mode");
+    return false;
+  }
 
-    // Verify sleep state
-    if (!test_temp.IsSleeping()) {
-        ESP_LOGE(TAG, "Sensor should be sleeping");
-        return false;
-    }
+  // Verify sleep state
+  if (!test_temp.IsSleeping()) {
+    ESP_LOGE(TAG, "Sensor should be sleeping");
+    return false;
+  }
 
-    // Verify state is SLEEPING
-    if (test_temp.GetState() != HF_TEMP_STATE_SLEEPING) {
-        ESP_LOGE(TAG, "State should be SLEEPING");
-        return false;
-    }
+  // Verify state is SLEEPING
+  if (test_temp.GetState() != HF_TEMP_STATE_SLEEPING) {
+    ESP_LOGE(TAG, "State should be SLEEPING");
+    return false;
+  }
 
-    // Exit sleep mode
-    auto wake_result = test_temp.ExitSleepMode();
-    if (wake_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to exit sleep mode");
-        return false;
-    }
+  // Exit sleep mode
+  auto wake_result = test_temp.ExitSleepMode();
+  if (wake_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to exit sleep mode");
+    return false;
+  }
 
-    // Verify wake state
-    if (test_temp.IsSleeping()) {
-        ESP_LOGE(TAG, "Sensor should not be sleeping after wake");
-        return false;
-    }
+  // Verify wake state
+  if (test_temp.IsSleeping()) {
+    ESP_LOGE(TAG, "Sensor should not be sleeping after wake");
+    return false;
+  }
 
-    // Verify we can read temperature after wake
-    hf_temp_reading_t reading = {};
-    auto read_result = test_temp.ReadTemperature(&reading);
-    if (read_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read temperature after wake");
-        return false;
-    }
+  // Verify we can read temperature after wake
+  hf_temp_reading_t reading = {};
+  auto read_result = test_temp.ReadTemperature(&reading);
+  if (read_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read temperature after wake");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Power management tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Power management tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -464,29 +467,29 @@ bool test_power_management() noexcept {
 //==============================================================================
 
 bool test_self_test_and_health() noexcept {
-    ESP_LOGI(TAG, "Testing self-test and health monitoring...");
+  ESP_LOGI(TAG, "Testing self-test and health monitoring...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Perform self-test
-    auto self_test_result = test_temp.SelfTest();
-    if (self_test_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Self-test failed: %s", GetTempErrorString(self_test_result));
-        return false;
-    }
+  // Perform self-test
+  auto self_test_result = test_temp.SelfTest();
+  if (self_test_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Self-test failed: %s", GetTempErrorString(self_test_result));
+    return false;
+  }
 
-    // Check health status
-    auto health_result = test_temp.CheckHealth();
-    if (health_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGW(TAG, "Health check indicates issues: %s", GetTempErrorString(health_result));
-    }
+  // Check health status
+  auto health_result = test_temp.CheckHealth();
+  if (health_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGW(TAG, "Health check indicates issues: %s", GetTempErrorString(health_result));
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Self-test and health monitoring passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Self-test and health monitoring passed");
+  return true;
 }
 
 //==============================================================================
@@ -494,65 +497,65 @@ bool test_self_test_and_health() noexcept {
 //==============================================================================
 
 bool test_statistics_and_diagnostics() noexcept {
-    ESP_LOGI(TAG, "Testing statistics and diagnostics...");
+  ESP_LOGI(TAG, "Testing statistics and diagnostics...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Perform some operations to generate statistics
-    for (int i = 0; i < 5; i++) {
-        hf_temp_reading_t reading = {};
-        test_temp.ReadTemperature(&reading);
-        vTaskDelay(pdMS_TO_TICKS(100));
-    }
+  // Perform some operations to generate statistics
+  for (int i = 0; i < 5; i++) {
+    hf_temp_reading_t reading = {};
+    test_temp.ReadTemperature(&reading);
+    vTaskDelay(pdMS_TO_TICKS(100));
+  }
 
-    // Get statistics
-    hf_temp_statistics_t stats = {};
-    auto stats_result = test_temp.GetStatistics(stats);
-    if (stats_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get statistics");
-        return false;
-    }
+  // Get statistics
+  hf_temp_statistics_t stats = {};
+  auto stats_result = test_temp.GetStatistics(stats);
+  if (stats_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get statistics");
+    return false;
+  }
 
-    // Validate statistics
-    if (stats.temperature_readings < 5) {
-        ESP_LOGE(TAG, "Expected at least 5 temperature readings in statistics");
-        return false;
-    }
+  // Validate statistics
+  if (stats.temperature_readings < 5) {
+    ESP_LOGE(TAG, "Expected at least 5 temperature readings in statistics");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Statistics: %u total ops, %u readings, %.2f avg temp", 
-             stats.total_operations, stats.temperature_readings, stats.avg_temperature_celsius);
+  ESP_LOGI(TAG, "Statistics: %u total ops, %u readings, %.2f avg temp", stats.total_operations,
+           stats.temperature_readings, stats.avg_temperature_celsius);
 
-    // Get diagnostics
-    hf_temp_diagnostics_t diag = {};
-    auto diag_result = test_temp.GetDiagnostics(diag);
-    if (diag_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get diagnostics");
-        return false;
-    }
+  // Get diagnostics
+  hf_temp_diagnostics_t diag = {};
+  auto diag_result = test_temp.GetDiagnostics(diag);
+  if (diag_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get diagnostics");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Diagnostics: healthy=%s, errors=%u", 
-             diag.sensor_healthy ? "true" : "false", diag.consecutive_errors);
+  ESP_LOGI(TAG, "Diagnostics: healthy=%s, errors=%u", diag.sensor_healthy ? "true" : "false",
+           diag.consecutive_errors);
 
-    // Test resetting statistics
-    auto reset_stats_result = test_temp.ResetStatistics();
-    if (reset_stats_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to reset statistics");
-        return false;
-    }
+  // Test resetting statistics
+  auto reset_stats_result = test_temp.ResetStatistics();
+  if (reset_stats_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to reset statistics");
+    return false;
+  }
 
-    // Test resetting diagnostics
-    auto reset_diag_result = test_temp.ResetDiagnostics();
-    if (reset_diag_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to reset diagnostics");
-        return false;
-    }
+  // Test resetting diagnostics
+  auto reset_diag_result = test_temp.ResetDiagnostics();
+  if (reset_diag_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to reset diagnostics");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Statistics and diagnostics tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Statistics and diagnostics tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -560,68 +563,69 @@ bool test_statistics_and_diagnostics() noexcept {
 //==============================================================================
 
 bool test_esp32_specific_features() noexcept {
-    ESP_LOGI(TAG, "Testing ESP32-specific features...");
+  ESP_LOGI(TAG, "Testing ESP32-specific features...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Test ESP32-specific configuration
-    esp_temp_config_t esp_config = ESP_TEMP_CONFIG_DEFAULT();
-    esp_config.range = ESP_TEMP_RANGE_20_100;
-    esp_config.calibration_offset = 1.0f;
-    
-    auto init_esp_result = test_temp.InitializeEsp32(esp_config);
-    if (init_esp_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to initialize with ESP32 config");
-        return false;
-    }
+  // Test ESP32-specific configuration
+  esp_temp_config_t esp_config = ESP_TEMP_CONFIG_DEFAULT();
+  esp_config.range = ESP_TEMP_RANGE_20_100;
+  esp_config.calibration_offset = 1.0f;
 
-    // Test setting measurement range
-    auto set_range_result = test_temp.SetMeasurementRange(ESP_TEMP_RANGE_NEG10_80);
-    if (set_range_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to set measurement range");
-        return false;
-    }
+  auto init_esp_result = test_temp.InitializeEsp32(esp_config);
+  if (init_esp_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to initialize with ESP32 config");
+    return false;
+  }
 
-    // Verify range was set
-    auto current_range = test_temp.GetMeasurementRange();
-    if (current_range != ESP_TEMP_RANGE_NEG10_80) {
-        ESP_LOGE(TAG, "Range not set correctly");
-        return false;
-    }
+  // Test setting measurement range
+  auto set_range_result = test_temp.SetMeasurementRange(ESP_TEMP_RANGE_NEG10_80);
+  if (set_range_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to set measurement range");
+    return false;
+  }
 
-    // Test getting range info
-    float min_temp, max_temp, accuracy;
-    auto range_info_result = test_temp.GetRangeInfo(ESP_TEMP_RANGE_NEG10_80, &min_temp, &max_temp, &accuracy);
-    if (range_info_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to get range info");
-        return false;
-    }
+  // Verify range was set
+  auto current_range = test_temp.GetMeasurementRange();
+  if (current_range != ESP_TEMP_RANGE_NEG10_80) {
+    ESP_LOGE(TAG, "Range not set correctly");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "Range info: %.1f to %.1f°C, ±%.1f°C accuracy", min_temp, max_temp, accuracy);
+  // Test getting range info
+  float min_temp, max_temp, accuracy;
+  auto range_info_result =
+      test_temp.GetRangeInfo(ESP_TEMP_RANGE_NEG10_80, &min_temp, &max_temp, &accuracy);
+  if (range_info_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to get range info");
+    return false;
+  }
 
-    // Test reading raw temperature
-    float raw_temp;
-    auto raw_result = test_temp.ReadRawTemperature(&raw_temp);
-    if (raw_result != hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Failed to read raw temperature");
-        return false;
-    }
+  ESP_LOGI(TAG, "Range info: %.1f to %.1f°C, ±%.1f°C accuracy", min_temp, max_temp, accuracy);
 
-    ESP_LOGI(TAG, "Raw temperature: %.2f°C", raw_temp);
+  // Test reading raw temperature
+  float raw_temp;
+  auto raw_result = test_temp.ReadRawTemperature(&raw_temp);
+  if (raw_result != hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Failed to read raw temperature");
+    return false;
+  }
 
-    // Test getting ESP handle
-    auto esp_handle = test_temp.GetEspHandle();
-    if (esp_handle == nullptr) {
-        ESP_LOGE(TAG, "ESP handle should not be null");
-        return false;
-    }
+  ESP_LOGI(TAG, "Raw temperature: %.2f°C", raw_temp);
 
-    ESP_LOGI(TAG, "[SUCCESS] ESP32-specific features tests passed");
-    return true;
+  // Test getting ESP handle
+  auto esp_handle = test_temp.GetEspHandle();
+  if (esp_handle == nullptr) {
+    ESP_LOGE(TAG, "ESP handle should not be null");
+    return false;
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] ESP32-specific features tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -629,54 +633,54 @@ bool test_esp32_specific_features() noexcept {
 //==============================================================================
 
 bool test_error_handling() noexcept {
-    ESP_LOGI(TAG, "Testing error handling...");
+  ESP_LOGI(TAG, "Testing error handling...");
 
-    EspTemperature test_temp;
+  EspTemperature test_temp;
 
-    // Test operations on uninitialized sensor
-    hf_temp_reading_t reading = {};
-    auto read_result = test_temp.ReadTemperature(&reading);
-    if (read_result == hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Reading should fail on uninitialized sensor");
-        return false;
-    }
+  // Test operations on uninitialized sensor
+  hf_temp_reading_t reading = {};
+  auto read_result = test_temp.ReadTemperature(&reading);
+  if (read_result == hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Reading should fail on uninitialized sensor");
+    return false;
+  }
 
-    // Initialize for further tests
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
-    }
+  // Initialize for further tests
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
 
-    // Test null pointer handling
-    auto null_read_result = test_temp.ReadTemperature(nullptr);
-    if (null_read_result != hf_temp_err_t::TEMP_ERR_NULL_POINTER) {
-        ESP_LOGE(TAG, "Should return null pointer error");
-        return false;
-    }
+  // Test null pointer handling
+  auto null_read_result = test_temp.ReadTemperature(nullptr);
+  if (null_read_result != hf_temp_err_t::TEMP_ERR_NULL_POINTER) {
+    ESP_LOGE(TAG, "Should return null pointer error");
+    return false;
+  }
 
-    // Test invalid range
-    auto invalid_range_result = test_temp.SetRange(100.0f, 50.0f); // min > max
-    if (invalid_range_result == hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Invalid range should fail");
-        return false;
-    }
+  // Test invalid range
+  auto invalid_range_result = test_temp.SetRange(100.0f, 50.0f); // min > max
+  if (invalid_range_result == hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Invalid range should fail");
+    return false;
+  }
 
-    // Test invalid thresholds
-    auto invalid_thresh_result = test_temp.SetThresholds(50.0f, 30.0f); // low > high
-    if (invalid_thresh_result == hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Invalid thresholds should fail");
-        return false;
-    }
+  // Test invalid thresholds
+  auto invalid_thresh_result = test_temp.SetThresholds(50.0f, 30.0f); // low > high
+  if (invalid_thresh_result == hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Invalid thresholds should fail");
+    return false;
+  }
 
-    // Test invalid sample rate
-    auto invalid_rate_result = test_temp.StartContinuousMonitoring(0, monitoring_callback, nullptr);
-    if (invalid_rate_result == hf_temp_err_t::TEMP_SUCCESS) {
-        ESP_LOGE(TAG, "Invalid sample rate should fail");
-        return false;
-    }
+  // Test invalid sample rate
+  auto invalid_rate_result = test_temp.StartContinuousMonitoring(0, monitoring_callback, nullptr);
+  if (invalid_rate_result == hf_temp_err_t::TEMP_SUCCESS) {
+    ESP_LOGE(TAG, "Invalid sample rate should fail");
+    return false;
+  }
 
-    ESP_LOGI(TAG, "[SUCCESS] Error handling tests passed");
-    return true;
+  ESP_LOGI(TAG, "[SUCCESS] Error handling tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -684,54 +688,54 @@ bool test_error_handling() noexcept {
 //==============================================================================
 
 bool test_performance_and_stress() noexcept {
-    ESP_LOGI(TAG, "Testing performance and stress scenarios...");
+  ESP_LOGI(TAG, "Testing performance and stress scenarios...");
 
-    EspTemperature test_temp;
-    if (!test_temp.EnsureInitialized()) {
-        ESP_LOGE(TAG, "Failed to initialize sensor");
-        return false;
+  EspTemperature test_temp;
+  if (!test_temp.EnsureInitialized()) {
+    ESP_LOGE(TAG, "Failed to initialize sensor");
+    return false;
+  }
+
+  // Performance test: rapid readings
+  const int num_readings = 100;
+  hf_u64_t start_time = esp_timer_get_time();
+
+  for (int i = 0; i < num_readings; i++) {
+    hf_temp_reading_t reading = {};
+    auto result = test_temp.ReadTemperature(&reading);
+    if (result != hf_temp_err_t::TEMP_SUCCESS) {
+      ESP_LOGE(TAG, "Reading %d failed", i);
+      return false;
+    }
+  }
+
+  hf_u64_t end_time = esp_timer_get_time();
+  hf_u64_t total_time = end_time - start_time;
+  float avg_time_ms = (total_time / 1000.0f) / num_readings;
+
+  ESP_LOGI(TAG, "Performance: %d readings in %.2f ms (avg: %.2f ms per reading)", num_readings,
+           total_time / 1000.0f, avg_time_ms);
+
+  // Stress test: multiple initialize/deinitialize cycles
+  for (int cycle = 0; cycle < 5; cycle++) {
+    EspTemperature stress_temp;
+    if (!stress_temp.EnsureInitialized()) {
+      ESP_LOGE(TAG, "Stress test init failed on cycle %d", cycle);
+      return false;
     }
 
-    // Performance test: rapid readings
-    const int num_readings = 100;
-    hf_u64_t start_time = esp_timer_get_time();
-    
-    for (int i = 0; i < num_readings; i++) {
-        hf_temp_reading_t reading = {};
-        auto result = test_temp.ReadTemperature(&reading);
-        if (result != hf_temp_err_t::TEMP_SUCCESS) {
-            ESP_LOGE(TAG, "Reading %d failed", i);
-            return false;
-        }
-    }
-    
-    hf_u64_t end_time = esp_timer_get_time();
-    hf_u64_t total_time = end_time - start_time;
-    float avg_time_ms = (total_time / 1000.0f) / num_readings;
-    
-    ESP_LOGI(TAG, "Performance: %d readings in %.2f ms (avg: %.2f ms per reading)", 
-             num_readings, total_time / 1000.0f, avg_time_ms);
-
-    // Stress test: multiple initialize/deinitialize cycles
-    for (int cycle = 0; cycle < 5; cycle++) {
-        EspTemperature stress_temp;
-        if (!stress_temp.EnsureInitialized()) {
-            ESP_LOGE(TAG, "Stress test init failed on cycle %d", cycle);
-            return false;
-        }
-        
-        hf_temp_reading_t reading = {};
-        auto result = stress_temp.ReadTemperature(&reading);
-        if (result != hf_temp_err_t::TEMP_SUCCESS) {
-            ESP_LOGE(TAG, "Stress test reading failed on cycle %d", cycle);
-            return false;
-        }
-        
-        // Destructor will handle deinitialization
+    hf_temp_reading_t reading = {};
+    auto result = stress_temp.ReadTemperature(&reading);
+    if (result != hf_temp_err_t::TEMP_SUCCESS) {
+      ESP_LOGE(TAG, "Stress test reading failed on cycle %d", cycle);
+      return false;
     }
 
-    ESP_LOGI(TAG, "[SUCCESS] Performance and stress tests passed");
-    return true;
+    // Destructor will handle deinitialization
+  }
+
+  ESP_LOGI(TAG, "[SUCCESS] Performance and stress tests passed");
+  return true;
 }
 
 //==============================================================================
@@ -739,38 +743,38 @@ bool test_performance_and_stress() noexcept {
 //==============================================================================
 
 extern "C" void app_main(void) {
-    ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
-    ESP_LOGI(TAG, "║              ESP32-C6 TEMPERATURE COMPREHENSIVE TEST SUITE                  ║");
-    ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
-    
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
+  ESP_LOGI(TAG, "║              ESP32-C6 TEMPERATURE COMPREHENSIVE TEST SUITE                  ║");
+  ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
 
-    // Basic functionality tests
-    RUN_TEST(test_temperature_sensor_initialization);
-    RUN_TEST(test_temperature_reading);
-    RUN_TEST(test_sensor_info);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    // Advanced feature tests
-    RUN_TEST(test_range_management);
-    RUN_TEST(test_threshold_monitoring);
-    RUN_TEST(test_continuous_monitoring);
-    RUN_TEST(test_calibration);
-    RUN_TEST(test_power_management);
-    RUN_TEST(test_self_test_and_health);
-    RUN_TEST(test_statistics_and_diagnostics);
+  // Basic functionality tests
+  RUN_TEST(test_temperature_sensor_initialization);
+  RUN_TEST(test_temperature_reading);
+  RUN_TEST(test_sensor_info);
 
-    // ESP32-specific tests
-    RUN_TEST(test_esp32_specific_features);
+  // Advanced feature tests
+  RUN_TEST(test_range_management);
+  RUN_TEST(test_threshold_monitoring);
+  RUN_TEST(test_continuous_monitoring);
+  RUN_TEST(test_calibration);
+  RUN_TEST(test_power_management);
+  RUN_TEST(test_self_test_and_health);
+  RUN_TEST(test_statistics_and_diagnostics);
 
-    // Error handling and stress tests
-    RUN_TEST(test_error_handling);
-    RUN_TEST(test_performance_and_stress);
+  // ESP32-specific tests
+  RUN_TEST(test_esp32_specific_features);
 
-    // Print final results
-    print_test_summary(g_test_results, "TEMPERATURE", TAG);
-    
-    // Keep running
-    while (true) {
-        vTaskDelay(pdMS_TO_TICKS(10000));
-    }
+  // Error handling and stress tests
+  RUN_TEST(test_error_handling);
+  RUN_TEST(test_performance_and_stress);
+
+  // Print final results
+  print_test_summary(g_test_results, "TEMPERATURE", TAG);
+
+  // Keep running
+  while (true) {
+    vTaskDelay(pdMS_TO_TICKS(10000));
+  }
 }

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -44,7 +44,8 @@ bool test_timer_initialization() noexcept {
     test_timer.Stop();
     ESP_LOGI(TAG, "[SUCCESS] Periodic timer stopped");
   } else {
-    ESP_LOGW(TAG, "Could not start timer: %d, but initialization was successful", static_cast<int>(start_result));
+    ESP_LOGW(TAG, "Could not start timer: %d, but initialization was successful",
+             static_cast<int>(start_result));
   }
 
   return true;

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -132,7 +132,7 @@ bool test_uart_construction() noexcept {
   // Test construction with valid configuration
   hf_uart_config_t config = create_test_config();
   auto uart = std::make_unique<EspUart>(config);
-  
+
   if (!uart) {
     ESP_LOGE(TAG, "Failed to construct EspUart instance");
     return false;
@@ -192,8 +192,8 @@ bool test_uart_basic_communication() noexcept {
 
   // Test transmission and reception
   const char* test_message = "Hello, UART Test!";
-  hf_uart_err_t write_result = g_uart_instance->Write(
-      reinterpret_cast<const hf_u8_t*>(test_message), strlen(test_message));
+  hf_uart_err_t write_result =
+      g_uart_instance->Write(reinterpret_cast<const hf_u8_t*>(test_message), strlen(test_message));
 
   if (write_result != hf_uart_err_t::UART_SUCCESS) {
     ESP_LOGE(TAG, "Write failed with error: %d", static_cast<int>(write_result));
@@ -227,10 +227,10 @@ bool test_uart_baud_rate_configuration() noexcept {
       ESP_LOGE(TAG, "Failed to set baud rate: %lu", test_baud_rates[i]);
       return false;
     }
-    
+
     // Small delay to allow hardware to settle
     vTaskDelay(pdMS_TO_TICKS(10));
-    
+
     ESP_LOGI(TAG, "Successfully set baud rate to: %lu", test_baud_rates[i]);
   }
 
@@ -340,14 +340,12 @@ bool test_uart_buffer_operations() noexcept {
   // Test ReadUntil with terminator
   uint8_t read_buffer[128];
   const char* test_string = "Hello\nWorld";
-  
+
   // Write test string
-  hf_uart_err_t write_result = g_uart_instance->Write(
-    reinterpret_cast<const uint8_t*>(test_string), 
-    static_cast<hf_u16_t>(strlen(test_string)), 
-    1000
-  );
-  
+  hf_uart_err_t write_result =
+      g_uart_instance->Write(reinterpret_cast<const uint8_t*>(test_string),
+                             static_cast<hf_u16_t>(strlen(test_string)), 1000);
+
   if (write_result != hf_uart_err_t::UART_SUCCESS) {
     ESP_LOGW(TAG, "Write failed for ReadUntil test (expected in no-loopback mode)");
   }
@@ -408,15 +406,12 @@ bool test_uart_advanced_features() noexcept {
 
   // Test with loopback enabled
   const char* loopback_msg = "Loopback Test";
-  result = g_uart_instance->Write(
-    reinterpret_cast<const uint8_t*>(loopback_msg), 
-    static_cast<hf_u16_t>(strlen(loopback_msg)), 
-    1000
-  );
-  
+  result = g_uart_instance->Write(reinterpret_cast<const uint8_t*>(loopback_msg),
+                                  static_cast<hf_u16_t>(strlen(loopback_msg)), 1000);
+
   if (result == hf_uart_err_t::UART_SUCCESS) {
     ESP_LOGI(TAG, "Loopback write successful");
-    
+
     // Try to read back (should work in loopback mode)
     uint8_t loopback_buffer[64];
     result = g_uart_instance->Read(loopback_buffer, sizeof(loopback_buffer), 500);
@@ -443,7 +438,7 @@ bool test_uart_advanced_features() noexcept {
   hf_uart_wakeup_config_t wakeup_config = {};
   wakeup_config.enable_wakeup = true;
   wakeup_config.wakeup_threshold = 3;
-  
+
   result = g_uart_instance->ConfigureWakeup(wakeup_config);
   if (result != hf_uart_err_t::UART_SUCCESS) {
     ESP_LOGE(TAG, "Failed to configure wakeup: %d", static_cast<int>(result));
@@ -485,7 +480,7 @@ bool test_uart_communication_modes() noexcept {
   rs485_config.enable_collision_detect = true;
   rs485_config.enable_echo_suppression = false;
   rs485_config.auto_rts_control = false;
-  
+
   result = g_uart_instance->ConfigureRS485(rs485_config);
   if (result != hf_uart_err_t::UART_SUCCESS) {
     ESP_LOGE(TAG, "Failed to configure RS485: %d", static_cast<int>(result));
@@ -498,7 +493,7 @@ bool test_uart_communication_modes() noexcept {
   irda_config.invert_tx = true;
   irda_config.invert_rx = true;
   irda_config.duty_cycle = 50;
-  
+
   result = g_uart_instance->ConfigureIrDA(irda_config);
   if (result != hf_uart_err_t::UART_SUCCESS) {
     ESP_LOGE(TAG, "Failed to configure IrDA: %d", static_cast<int>(result));
@@ -613,7 +608,7 @@ bool test_uart_callbacks() noexcept {
 
   // Note: In normal testing without external devices, callbacks may not trigger
   // This test verifies that callback registration works without errors
-  
+
   ESP_LOGI(TAG, "Callback registration completed");
   ESP_LOGI(TAG, "Event callback triggered: %s", g_event_callback_triggered ? "true" : "false");
   ESP_LOGI(TAG, "Pattern callback triggered: %s", g_pattern_callback_triggered ? "true" : "false");
@@ -665,8 +660,7 @@ bool test_uart_statistics_diagnostics() noexcept {
   bool is_transmitting = g_uart_instance->IsTransmitting();
   bool is_receiving = g_uart_instance->IsReceiving();
 
-  ESP_LOGI(TAG, "Status: TX=%s, RX=%s", 
-           is_transmitting ? "true" : "false",
+  ESP_LOGI(TAG, "Status: TX=%s, RX=%s", is_transmitting ? "true" : "false",
            is_receiving ? "true" : "false");
 
   ESP_LOGI(TAG, "[SUCCESS] Statistics and diagnostics test completed");
@@ -712,7 +706,7 @@ bool test_uart_error_handling() noexcept {
   }
 
   // Test invalid parameters (should handle gracefully)
-  
+
   // Test write with null data
   hf_uart_err_t result = g_uart_instance->Write(nullptr, 10, 1000);
   if (result == hf_uart_err_t::UART_SUCCESS) {

--- a/examples/esp32/main/UtilsComprehensiveTest.cpp
+++ b/examples/esp32/main/UtilsComprehensiveTest.cpp
@@ -121,20 +121,20 @@ bool test_hardware_types() noexcept {
   ESP_LOGI(TAG, "[SUCCESS] Pin: %d, Port: %d, Freq: %lu Hz", test_pin, test_port, test_freq);
   ESP_LOGI(TAG, "[SUCCESS] Timestamp: %llu us, Voltage: %d mV", test_timestamp, test_voltage);
 
-//   // Test GPIO state enum
-//   hf_gpio_state_t test_state = hf_gpio_state_t::HF_GPIO_STATE_ACTIVE;
-//   if (test_state != hf_gpio_state_t::HF_GPIO_STATE_ACTIVE) {
-//     ESP_LOGE(TAG, "GPIO state test failed");
-//     return false;
-//   }
+  //   // Test GPIO state enum
+  //   hf_gpio_state_t test_state = hf_gpio_state_t::HF_GPIO_STATE_ACTIVE;
+  //   if (test_state != hf_gpio_state_t::HF_GPIO_STATE_ACTIVE) {
+  //     ESP_LOGE(TAG, "GPIO state test failed");
+  //     return false;
+  //   }
 
-//   ESP_LOGI(TAG, "[SUCCESS] GPIO state: %s",
-//            test_state == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE ? "ACTIVE" : "INACTIVE");
+  //   ESP_LOGI(TAG, "[SUCCESS] GPIO state: %s",
+  //            test_state == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE ? "ACTIVE" : "INACTIVE");
 
-//   // Test state toggle
-//   test_state = hf_gpio_state_t::HF_GPIO_STATE_INACTIVE;
-//   ESP_LOGI(TAG, "[SUCCESS] GPIO state toggled: %s",
-//            test_state == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE ? "ACTIVE" : "INACTIVE");
+  //   // Test state toggle
+  //   test_state = hf_gpio_state_t::HF_GPIO_STATE_INACTIVE;
+  //   ESP_LOGI(TAG, "[SUCCESS] GPIO state toggled: %s",
+  //            test_state == hf_gpio_state_t::HF_GPIO_STATE_ACTIVE ? "ACTIVE" : "INACTIVE");
 
   return true;
 }

--- a/inc/base/BaseAdc.h
+++ b/inc/base/BaseAdc.h
@@ -164,7 +164,7 @@ struct hf_adc_diagnostics_t {
   float referenceVoltage;      ///< Reference voltage
   bool calibrationValid;       ///< Calibration validity
   hf_u32_t enabled_channels;   ///< Bit mask of enabled channels
-  bool initialization_state;///< Initialization state
+  bool initialization_state;   ///< Initialization state
 
   hf_adc_diagnostics_t()
       : adcHealthy(true), lastErrorCode(hf_adc_err_t::ADC_SUCCESS), lastErrorTimestamp(0),

--- a/inc/base/BaseLogger.h
+++ b/inc/base/BaseLogger.h
@@ -436,7 +436,8 @@ public:
    * @param detailed If true, prints detailed per-level statistics
    * @return hf_logger_err_t Success or error code
    */
-  virtual hf_logger_err_t PrintStatistics(const char* tag = nullptr, bool detailed = true) const noexcept = 0;
+  virtual hf_logger_err_t PrintStatistics(const char* tag = nullptr,
+                                          bool detailed = true) const noexcept = 0;
 
   /**
    * @brief Print diagnostics to log output
@@ -444,7 +445,8 @@ public:
    * @param detailed If true, prints detailed diagnostic information
    * @return hf_logger_err_t Success or error code
    */
-  virtual hf_logger_err_t PrintDiagnostics(const char* tag = nullptr, bool detailed = true) const noexcept = 0;
+  virtual hf_logger_err_t PrintDiagnostics(const char* tag = nullptr,
+                                           bool detailed = true) const noexcept = 0;
 
   /**
    * @brief Print both statistics and diagnostics
@@ -452,7 +454,8 @@ public:
    * @param detailed If true, prints detailed information
    * @return hf_logger_err_t Success or error code
    */
-  virtual hf_logger_err_t PrintStatus(const char* tag = nullptr, bool detailed = true) const noexcept = 0;
+  virtual hf_logger_err_t PrintStatus(const char* tag = nullptr,
+                                      bool detailed = true) const noexcept = 0;
 
 protected:
   /**
@@ -493,10 +496,12 @@ protected:
 inline const char* HfLoggerErrToString(hf_logger_err_t error) noexcept {
   switch (error) {
 #define HF_LOGGER_ERR_TO_STRING(name, value, description) \
-    case hf_logger_err_t::name: return description;
+  case hf_logger_err_t::name:                             \
+    return description;
     HF_LOGGER_ERR_LIST(HF_LOGGER_ERR_TO_STRING)
 #undef HF_LOGGER_ERR_TO_STRING
-    default: return "Unknown error";
+    default:
+      return "Unknown error";
   }
 }
 
@@ -507,13 +512,20 @@ inline const char* HfLoggerErrToString(hf_logger_err_t error) noexcept {
  */
 inline const char* HfLogLevelToString(hf_log_level_t level) noexcept {
   switch (level) {
-    case hf_log_level_t::LOG_LEVEL_NONE: return "NONE";
-    case hf_log_level_t::LOG_LEVEL_ERROR: return "ERROR";
-    case hf_log_level_t::LOG_LEVEL_WARN: return "WARN";
-    case hf_log_level_t::LOG_LEVEL_INFO: return "INFO";
-    case hf_log_level_t::LOG_LEVEL_DEBUG: return "DEBUG";
-    case hf_log_level_t::LOG_LEVEL_VERBOSE: return "VERBOSE";
-    default: return "UNKNOWN";
+    case hf_log_level_t::LOG_LEVEL_NONE:
+      return "NONE";
+    case hf_log_level_t::LOG_LEVEL_ERROR:
+      return "ERROR";
+    case hf_log_level_t::LOG_LEVEL_WARN:
+      return "WARN";
+    case hf_log_level_t::LOG_LEVEL_INFO:
+      return "INFO";
+    case hf_log_level_t::LOG_LEVEL_DEBUG:
+      return "DEBUG";
+    case hf_log_level_t::LOG_LEVEL_VERBOSE:
+      return "VERBOSE";
+    default:
+      return "UNKNOWN";
   }
 }
 
@@ -524,13 +536,20 @@ inline const char* HfLogLevelToString(hf_log_level_t level) noexcept {
  */
 inline const char* HfLogLevelToShortString(hf_log_level_t level) noexcept {
   switch (level) {
-    case hf_log_level_t::LOG_LEVEL_NONE: return "N";
-    case hf_log_level_t::LOG_LEVEL_ERROR: return "E";
-    case hf_log_level_t::LOG_LEVEL_WARN: return "W";
-    case hf_log_level_t::LOG_LEVEL_INFO: return "I";
-    case hf_log_level_t::LOG_LEVEL_DEBUG: return "D";
-    case hf_log_level_t::LOG_LEVEL_VERBOSE: return "V";
-    default: return "?";
+    case hf_log_level_t::LOG_LEVEL_NONE:
+      return "N";
+    case hf_log_level_t::LOG_LEVEL_ERROR:
+      return "E";
+    case hf_log_level_t::LOG_LEVEL_WARN:
+      return "W";
+    case hf_log_level_t::LOG_LEVEL_INFO:
+      return "I";
+    case hf_log_level_t::LOG_LEVEL_DEBUG:
+      return "D";
+    case hf_log_level_t::LOG_LEVEL_VERBOSE:
+      return "V";
+    default:
+      return "?";
   }
 }
 

--- a/inc/mcu/esp32/EspAdc.h
+++ b/inc/mcu/esp32/EspAdc.h
@@ -669,13 +669,13 @@ private:
 
   // Forward declarations and internal structures
   struct MonitorContext {
-    uint8_t monitor_id;             ///< Monitor ID (0-1)
-    hf_channel_id_t channel_id;     ///< Channel ID being monitored
-    uint32_t high_threshold;        ///< High threshold value
-    uint32_t low_threshold;         ///< Low threshold value
+    uint8_t monitor_id;                 ///< Monitor ID (0-1)
+    hf_channel_id_t channel_id;         ///< Channel ID being monitored
+    uint32_t high_threshold;            ///< High threshold value
+    uint32_t low_threshold;             ///< Low threshold value
     hf_adc_monitor_callback_t callback; ///< User callback function
-    void* user_data;                ///< User data for callback
-    EspAdc* adc_instance;           ///< Pointer to ADC instance
+    void* user_data;                    ///< User data for callback
+    EspAdc* adc_instance;               ///< Pointer to ADC instance
   };
 
   // Internal helper methods
@@ -691,12 +691,15 @@ private:
   void UpdateDiagnostics(hf_adc_err_t error) noexcept;
 
   // Static callback functions for ESP-IDF
-  static hf_bool_t IRAM_ATTR ContinuousCallback(adc_continuous_handle_t handle, const adc_continuous_evt_data_t* edata,
+  static hf_bool_t IRAM_ATTR ContinuousCallback(adc_continuous_handle_t handle,
+                                                const adc_continuous_evt_data_t* edata,
                                                 void* user_data) noexcept;
   static hf_bool_t IRAM_ATTR HighThresholdCallback(adc_monitor_handle_t monitor_handle,
-                                                   const adc_monitor_evt_data_t* event_data, void* user_data) noexcept;
+                                                   const adc_monitor_evt_data_t* event_data,
+                                                   void* user_data) noexcept;
   static hf_bool_t IRAM_ATTR LowThresholdCallback(adc_monitor_handle_t monitor_handle,
-                                                  const adc_monitor_evt_data_t* event_data, void* user_data) noexcept;
+                                                  const adc_monitor_evt_data_t* event_data,
+                                                  void* user_data) noexcept;
 
   //==============================================//
   // MEMBER VARIABLES
@@ -723,8 +726,8 @@ private:
   hf_adc_continuous_callback_t continuous_callback_; ///< Continuous callback function
   void* continuous_user_data_;                       ///< Continuous callback user data
   std::array<hf_adc_monitor_callback_t, HF_ADC_MAX_MONITORS>
-      monitor_callbacks_;                                    ///< Monitor callbacks
-  std::array<void*, HF_ADC_MAX_MONITORS> monitor_user_data_; ///< Monitor callback user data
+      monitor_callbacks_;                                            ///< Monitor callbacks
+  std::array<void*, HF_ADC_MAX_MONITORS> monitor_user_data_;         ///< Monitor callback user data
   std::array<MonitorContext, HF_ADC_MAX_MONITORS> monitor_contexts_; ///< Monitor context data
 
   // Statistics and diagnostics

--- a/inc/mcu/esp32/EspLogger.h
+++ b/inc/mcu/esp32/EspLogger.h
@@ -398,7 +398,8 @@ public:
    * @param detailed If true, prints detailed per-level statistics
    * @return hf_logger_err_t Success or error code
    */
-  hf_logger_err_t PrintStatistics(const char* tag = nullptr, bool detailed = true) const noexcept override;
+  hf_logger_err_t PrintStatistics(const char* tag = nullptr,
+                                  bool detailed = true) const noexcept override;
 
   /**
    * @brief Print diagnostics to log output
@@ -406,7 +407,8 @@ public:
    * @param detailed If true, prints detailed diagnostic information
    * @return hf_logger_err_t Success or error code
    */
-  hf_logger_err_t PrintDiagnostics(const char* tag = nullptr, bool detailed = true) const noexcept override;
+  hf_logger_err_t PrintDiagnostics(const char* tag = nullptr,
+                                   bool detailed = true) const noexcept override;
 
   /**
    * @brief Print both statistics and diagnostics
@@ -414,7 +416,8 @@ public:
    * @param detailed If true, prints detailed information
    * @return hf_logger_err_t Success or error code
    */
-  hf_logger_err_t PrintStatus(const char* tag = nullptr, bool detailed = true) const noexcept override;
+  hf_logger_err_t PrintStatus(const char* tag = nullptr,
+                              bool detailed = true) const noexcept override;
 
 private:
   //==============================================================================

--- a/inc/mcu/esp32/utils/EspTypes_GPIO.h
+++ b/inc/mcu/esp32/utils/EspTypes_GPIO.h
@@ -115,8 +115,6 @@ enum class hf_gpio_glitch_filter_clk_src_t : uint8_t {
   HF_GLITCH_FILTER_CLK_SRC_XTAL = 2     ///< XTAL clock (40MHz typically)
 };
 
-
-
 /**
  * @brief Low-Power IO configuration for ultra-low power operation.
  * @details Configuration for LP_IO domain operations during deep sleep.
@@ -335,8 +333,6 @@ typedef struct {
  * @param user_data User-provided data passed to the callback
  */
 using hf_gpio_isr_callback_t = void (*)(uint32_t gpio_num, void* user_data);
-
-
 
 /**
  * @brief GPIO configuration validation result.

--- a/src/mcu/esp32/EspAdc.cpp
+++ b/src/mcu/esp32/EspAdc.cpp
@@ -867,7 +867,7 @@ hf_adc_err_t EspAdc::SetMonitorCallback(hf_u8_t monitor_id, hf_adc_monitor_callb
   // Update the callback and user data in the context
   monitor_contexts_[monitor_id].callback = callback;
   monitor_contexts_[monitor_id].user_data = user_data;
-  
+
   // Also store in the old arrays for backward compatibility
   monitor_callbacks_[monitor_id] = callback;
   monitor_user_data_[monitor_id] = user_data;
@@ -1050,7 +1050,8 @@ hf_adc_err_t EspAdc::ReadMultipleChannels(const hf_channel_id_t* channel_ids, hf
 }
 
 // Static callback functions for ESP-IDF
-hf_bool_t IRAM_ATTR EspAdc::ContinuousCallback(adc_continuous_handle_t handle, const adc_continuous_evt_data_t* edata,
+hf_bool_t IRAM_ATTR EspAdc::ContinuousCallback(adc_continuous_handle_t handle,
+                                               const adc_continuous_evt_data_t* edata,
                                                void* user_data) noexcept {
   auto* esp_adc = static_cast<EspAdc*>(user_data);
 
@@ -1072,7 +1073,8 @@ hf_bool_t IRAM_ATTR EspAdc::ContinuousCallback(adc_continuous_handle_t handle, c
 }
 
 hf_bool_t IRAM_ATTR EspAdc::HighThresholdCallback(adc_monitor_handle_t monitor_handle,
-                                                   const adc_monitor_evt_data_t* event_data, void* user_data) noexcept {
+                                                  const adc_monitor_evt_data_t* event_data,
+                                                  void* user_data) noexcept {
   // user_data points to the MonitorContext
   auto* context = static_cast<MonitorContext*>(user_data);
 
@@ -1086,8 +1088,8 @@ hf_bool_t IRAM_ATTR EspAdc::HighThresholdCallback(adc_monitor_handle_t monitor_h
   hf_event.channel_id = context->channel_id;
   hf_event.raw_value = 0; // Event data structure is reserved for extensibility in ESP-IDF v5.5
   hf_event.event_type = hf_adc_monitor_event_type_t::HIGH_THRESH;
-  hf_event.timestamp_us = (context->adc_instance != nullptr) ? 
-                         context->adc_instance->GetCurrentTimeUs() : 0;
+  hf_event.timestamp_us =
+      (context->adc_instance != nullptr) ? context->adc_instance->GetCurrentTimeUs() : 0;
 
   // Call user callback using context
   context->callback(&hf_event, context->user_data);
@@ -1096,7 +1098,8 @@ hf_bool_t IRAM_ATTR EspAdc::HighThresholdCallback(adc_monitor_handle_t monitor_h
 }
 
 hf_bool_t IRAM_ATTR EspAdc::LowThresholdCallback(adc_monitor_handle_t monitor_handle,
-                                                  const adc_monitor_evt_data_t* event_data, void* user_data) noexcept {
+                                                 const adc_monitor_evt_data_t* event_data,
+                                                 void* user_data) noexcept {
   // user_data points to the MonitorContext
   auto* context = static_cast<MonitorContext*>(user_data);
 
@@ -1110,8 +1113,8 @@ hf_bool_t IRAM_ATTR EspAdc::LowThresholdCallback(adc_monitor_handle_t monitor_ha
   hf_event.channel_id = context->channel_id;
   hf_event.raw_value = 0; // Event data structure is reserved for extensibility in ESP-IDF v5.5
   hf_event.event_type = hf_adc_monitor_event_type_t::LOW_THRESH;
-  hf_event.timestamp_us = (context->adc_instance != nullptr) ? 
-                         context->adc_instance->GetCurrentTimeUs() : 0;
+  hf_event.timestamp_us =
+      (context->adc_instance != nullptr) ? context->adc_instance->GetCurrentTimeUs() : 0;
 
   // Call user callback using context
   context->callback(&hf_event, context->user_data);

--- a/src/mcu/esp32/EspGpio.cpp
+++ b/src/mcu/esp32/EspGpio.cpp
@@ -1345,7 +1345,7 @@ hf_gpio_status_info_t EspGpio::GetConfigurationDump() const noexcept {
   dump.filter_type = glitch_filter_type_;
   dump.glitch_filter_enabled = pin_glitch_filter_enabled_ || flex_glitch_filter_enabled_;
   dump.interrupt_count = interrupt_count_.load();
-  dump.is_wake_source = false;     // Set as appropriate
+  dump.is_wake_source = false; // Set as appropriate
 
   dump.sleep_hold_active = false;  // Set as appropriate
   dump.last_interrupt_time_us = 0; // Set as appropriate

--- a/src/mcu/esp32/EspLogger.cpp
+++ b/src/mcu/esp32/EspLogger.cpp
@@ -553,15 +553,16 @@ hf_logger_err_t EspLogger::ResetDiagnostics() noexcept {
 
   // Reset diagnostics to default values while preserving initialization state
   hf_logger_diagnostics_t reset_diagnostics = {};
-  reset_diagnostics.is_initialized = true;  // Keep initialized state
-  reset_diagnostics.is_healthy = true;      // Reset to healthy
+  reset_diagnostics.is_initialized = true; // Keep initialized state
+  reset_diagnostics.is_healthy = true;     // Reset to healthy
   reset_diagnostics.last_error = hf_logger_err_t::LOGGER_SUCCESS;
   reset_diagnostics.last_error_timestamp = GetCurrentTimestamp();
   reset_diagnostics.consecutive_errors = 0;
   reset_diagnostics.error_recovery_count = 0;
-  reset_diagnostics.uptime_seconds = 0;    // Will be recalculated in GetDiagnostics
+  reset_diagnostics.uptime_seconds = 0; // Will be recalculated in GetDiagnostics
   reset_diagnostics.last_health_check = GetCurrentTimestamp();
-  std::memset(reset_diagnostics.last_error_message, 0, sizeof(reset_diagnostics.last_error_message));
+  std::memset(reset_diagnostics.last_error_message, 0,
+              sizeof(reset_diagnostics.last_error_message));
 
   diagnostics_ = reset_diagnostics;
   ESP_LOGI(TAG, "Diagnostics reset");
@@ -673,7 +674,7 @@ hf_logger_err_t EspLogger::PrintDiagnostics(const char* tag, bool detailed) cons
     ESP_LOGI(print_tag, "  Consecutive errors: %u", diag.consecutive_errors);
     ESP_LOGI(print_tag, "  Error recovery count: %u", diag.error_recovery_count);
     ESP_LOGI(print_tag, "  Last health check: %llu µs", diag.last_health_check);
-    
+
     if (strlen(diag.last_error_message) > 0) {
       ESP_LOGI(print_tag, "  Last error message: %s", diag.last_error_message);
     } else {
@@ -689,7 +690,7 @@ hf_logger_err_t EspLogger::PrintStatus(const char* tag, bool detailed) const noe
   const char* print_tag = tag ? tag : "LOGGER_STATUS";
 
   ESP_LOGI(print_tag, "=== Logger Complete Status ===");
-  ESP_LOGI(print_tag, "Logger Version: %d (%s)", GetLogVersion(), 
+  ESP_LOGI(print_tag, "Logger Version: %d (%s)", GetLogVersion(),
            IsLogV2Available() ? "Log V2 Available" : "Log V1 Only");
 
   hf_logger_err_t result = PrintStatistics(print_tag, detailed);
@@ -836,13 +837,13 @@ hf_logger_err_t EspLogger::WriteMessageV(hf_log_level_t level, const char* tag, 
 void EspLogger::UpdateStatistics(hf_log_level_t level, hf_u32_t message_length,
                                  bool success) noexcept {
   statistics_.total_messages++;
-  
+
   // Update per-level statistics with bounds checking
   hf_u8_t level_index = static_cast<hf_u8_t>(level);
-  if (level_index < 6) {  // Array size is 6 (indices 0-5)
+  if (level_index < 6) { // Array size is 6 (indices 0-5)
     statistics_.messages_by_level[level_index]++;
   }
-  
+
   statistics_.total_bytes_written += message_length;
   statistics_.last_message_timestamp = GetCurrentTimestamp();
 


### PR DESCRIPTION
Apply clang-format to source files to enforce consistent code style.

---
<a href="https://cursor.com/background-agent?bcId=bc-e687c04c-89b5-40f9-89a7-580c528702b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e687c04c-89b5-40f9-89a7-580c528702b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

