### PR TITLE
Investigate hashfiles error in esp32 component ci

### DIFF
--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -182,7 +182,7 @@ jobs:
             ~/.cache/apt
             /var/cache/apt
             ~/.cache/clang-tidy
-          key: static-analysis-${{ runner.os }}-${{ hashFiles('**/*.cpp', '**/*.h', '.clang-tidy') }}
+          key: static-analysis-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'inc/**/*.h', 'examples/**/*.cpp', 'examples/**/*.h', '.clang-tidy') }}
           restore-keys: |
             static-analysis-${{ runner.os }}-
 

--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -182,7 +182,9 @@ jobs:
             ~/.cache/apt
             /var/cache/apt
             ~/.cache/clang-tidy
-          key: static-analysis-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'inc/**/*.h', 'examples/**/*.cpp', 'examples/**/*.h', '.clang-tidy') }}
+          key: >-
+            static-analysis-${{ runner.os }}-${{ hashFiles('src/**/*.cpp', 'inc/**/*.h', 
+            'examples/**/*.cpp', 'examples/**/*.h', '.clang-tidy') }}
           restore-keys: |
             static-analysis-${{ runner.os }}-
 


### PR DESCRIPTION
Update `hashFiles` patterns in `esp32-component-ci.yml` to correctly match source files and prevent CI failures.

The previous broad patterns (`**/*.cpp`, `**/*.h`) were failing to find files, causing the `hashFiles` function to error out during the static analysis CI job. The updated patterns are more specific to the repository's directory structure (`src/`, `inc/`, `examples/`) ensuring all relevant C++ source and header files are included for proper cache key generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-21fb3a8d-008d-4186-84a6-3eac04346f06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21fb3a8d-008d-4186-84a6-3eac04346f06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

