### PR TITLE
Add extern c to esp library includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ target_compile_options(${COMPONENT_LIB} PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
     $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
     $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>
+    # Suppress ESP-IDF specific warnings in C++ builds
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-pedantic>
 )
 
 # Define component version (optional)

--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -21,14 +21,23 @@
  * @copyright HardFOC
  */
 
+#include "base/BaseAdc.h"
+#include "mcu/esp32/EspAdc.h"
+#include "mcu/esp32/utils/EspTypes_ADC.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "freertos/task.h"
 
-#include "base/BaseAdc.h"
-#include "mcu/esp32/EspAdc.h"
-#include "mcu/esp32/utils/EspTypes_ADC.h"
+#ifdef __cplusplus
+}
+#endif
 
 // Shared test framework
 #include "TestFramework.h"

--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -28,16 +28,8 @@
 // Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
-// Additional ESP-IDF C headers needed by this test
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "freertos/queue.h"
-
-#ifdef __cplusplus
-}
-#endif
+// Note: All ESP-IDF functionality accessed through EspAdc class interface
+// No direct ESP-IDF includes needed - TestFramework.h provides common functions
 
 static const char* TAG = "ADC_Test";
 

--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -25,11 +25,7 @@
 #include "mcu/esp32/EspAdc.h"
 #include "mcu/esp32/utils/EspTypes_ADC.h"
 
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
-
-// Note: All ESP-IDF functionality accessed through EspAdc class interface
-// No direct ESP-IDF includes needed - TestFramework.h provides common functions
 
 static const char* TAG = "ADC_Test";
 

--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -25,22 +25,19 @@
 #include "mcu/esp32/EspAdc.h"
 #include "mcu/esp32/utils/EspTypes_ADC.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
+#include "TestFramework.h"
+
+// Additional ESP-IDF C headers needed by this test
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
-#include "freertos/task.h"
 
 #ifdef __cplusplus
 }
 #endif
-
-// Shared test framework
-#include "TestFramework.h"
 
 static const char* TAG = "ADC_Test";
 

--- a/examples/esp32/main/BluetoothComprehensiveTest.cpp
+++ b/examples/esp32/main/BluetoothComprehensiveTest.cpp
@@ -14,13 +14,23 @@
  * @copyright HardFOC
  */
 
+#include "base/BaseBluetooth.h"
+#include "mcu/esp32/EspBluetooth.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include <vector>
 
-#include "base/BaseBluetooth.h"
-#include "mcu/esp32/EspBluetooth.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include <vector>
 
 // Shared test framework
 #include "TestFramework.h"

--- a/examples/esp32/main/BluetoothComprehensiveTest.cpp
+++ b/examples/esp32/main/BluetoothComprehensiveTest.cpp
@@ -17,22 +17,9 @@
 #include "base/BaseBluetooth.h"
 #include "mcu/esp32/EspBluetooth.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
 #include <vector>
 
-// Shared test framework
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "BT_Test";

--- a/examples/esp32/main/BluetoothComprehensiveTest.cpp
+++ b/examples/esp32/main/BluetoothComprehensiveTest.cpp
@@ -18,8 +18,6 @@
 #include "mcu/esp32/EspBluetooth.h"
 
 #include <vector>
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "BT_Test";

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -4,10 +4,20 @@
  */
 
 #include "base/BaseCan.h"
+#include "mcu/esp32/EspCan.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspCan.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "TestFramework.h"
 

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -5,8 +5,6 @@
 
 #include "base/BaseCan.h"
 #include "mcu/esp32/EspCan.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "CAN_Test";

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -6,19 +6,7 @@
 #include "base/BaseCan.h"
 #include "mcu/esp32/EspCan.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "CAN_Test";

--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -18,21 +18,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-// Additional ESP-IDF headers specific to GPIO testing
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "driver/gpio.h"
-#include "esp_sleep.h"
-#include "esp_system.h"
-
-#ifdef __cplusplus
-}
-#endif
+// Note: All ESP-IDF functionality accessed through EspGpio class interface
+// No direct ESP-IDF includes needed - TestFramework.h provides common functions
 
 #include <memory>
 #include <vector>

--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -18,15 +18,13 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include <memory>
-#include <vector>
-
 // ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "driver/gpio.h"
 #include "esp_log.h"
@@ -37,6 +35,9 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include <memory>
+#include <vector>
 
 // Include base classes
 #include "base/BaseGpio.h"

--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -18,9 +18,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 
-// Note: All ESP-IDF functionality accessed through EspGpio class interface
-// No direct ESP-IDF includes needed - TestFramework.h provides common functions
-
 #include <memory>
 #include <vector>
 
@@ -36,7 +33,6 @@
 #include "mcu/esp32/EspGpio.h"
 #include "mcu/esp32/utils/EspTypes_GPIO.h"
 
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 #pragma GCC diagnostic pop

--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -23,14 +23,12 @@
 extern "C" {
 #endif
 
+// Additional ESP-IDF headers specific to GPIO testing
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-
 #include "driver/gpio.h"
-#include "esp_log.h"
 #include "esp_sleep.h"
 #include "esp_system.h"
-#include "esp_timer.h"
 
 #ifdef __cplusplus
 }
@@ -51,7 +49,7 @@ extern "C" {
 #include "mcu/esp32/EspGpio.h"
 #include "mcu/esp32/utils/EspTypes_GPIO.h"
 
-// Shared test framework
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 #pragma GCC diagnostic pop

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -23,24 +23,22 @@
 #include "mcu/esp32/EspI2c.h"
 #include "mcu/esp32/utils/EspTypes_I2C.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+// Additional ESP-IDF C headers needed by this test
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include "driver/i2c_master.h"
-#include "esp_log.h"
-#include "esp_timer.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 
 #ifdef __cplusplus
 }
 #endif
+
 #include <algorithm>
 #include <memory>
 #include <vector>
 
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "I2C_Test";

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -23,16 +23,8 @@
 #include "mcu/esp32/EspI2c.h"
 #include "mcu/esp32/utils/EspTypes_I2C.h"
 
-// Additional ESP-IDF C headers needed by this test
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "driver/i2c_master.h"
-
-#ifdef __cplusplus
-}
-#endif
+// Note: All ESP-IDF functionality accessed through EspI2c class interface
+// No direct ESP-IDF includes needed - TestFramework.h provides common functions
 
 #include <algorithm>
 #include <memory>

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -20,13 +20,23 @@
  */
 
 #include "base/BaseI2c.h"
+#include "mcu/esp32/EspI2c.h"
+#include "mcu/esp32/utils/EspTypes_I2C.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "driver/i2c_master.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspI2c.h"
-#include "mcu/esp32/utils/EspTypes_I2C.h"
+
+#ifdef __cplusplus
+}
+#endif
 #include <algorithm>
 #include <memory>
 #include <vector>

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -23,14 +23,10 @@
 #include "mcu/esp32/EspI2c.h"
 #include "mcu/esp32/utils/EspTypes_I2C.h"
 
-// Note: All ESP-IDF functionality accessed through EspI2c class interface
-// No direct ESP-IDF includes needed - TestFramework.h provides common functions
-
 #include <algorithm>
 #include <memory>
 #include <vector>
 
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "I2C_Test";

--- a/examples/esp32/main/LoggerComprehensiveTest.cpp
+++ b/examples/esp32/main/LoggerComprehensiveTest.cpp
@@ -16,8 +16,6 @@
 
 #include "base/BaseLogger.h"
 #include "mcu/esp32/EspLogger.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 #include "utils/memory_utils.h"
 

--- a/examples/esp32/main/LoggerComprehensiveTest.cpp
+++ b/examples/esp32/main/LoggerComprehensiveTest.cpp
@@ -17,19 +17,7 @@
 #include "base/BaseLogger.h"
 #include "mcu/esp32/EspLogger.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 #include "utils/memory_utils.h"
 

--- a/examples/esp32/main/LoggerComprehensiveTest.cpp
+++ b/examples/esp32/main/LoggerComprehensiveTest.cpp
@@ -14,12 +14,21 @@
  * @copyright HardFOC
  */
 
+#include "base/BaseLogger.h"
+#include "mcu/esp32/EspLogger.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#include "base/BaseLogger.h"
-#include "mcu/esp32/EspLogger.h"
+#ifdef __cplusplus
+}
+#endif
 
 #include "TestFramework.h"
 #include "utils/memory_utils.h"

--- a/examples/esp32/main/NvsComprehensiveTest.cpp
+++ b/examples/esp32/main/NvsComprehensiveTest.cpp
@@ -12,10 +12,20 @@
  */
 
 #include "base/BaseNvs.h"
+#include "mcu/esp32/EspNvs.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspNvs.h"
+
+#ifdef __cplusplus
+}
+#endif
 #include <cstring>
 #include <cstdio>
 #include <random>

--- a/examples/esp32/main/NvsComprehensiveTest.cpp
+++ b/examples/esp32/main/NvsComprehensiveTest.cpp
@@ -16,8 +16,6 @@
 #include <cstring>
 #include <cstdio>
 #include <random>
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "NVS_Test";

--- a/examples/esp32/main/NvsComprehensiveTest.cpp
+++ b/examples/esp32/main/NvsComprehensiveTest.cpp
@@ -13,23 +13,11 @@
 
 #include "base/BaseNvs.h"
 #include "mcu/esp32/EspNvs.h"
-
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
 #include <cstring>
 #include <cstdio>
 #include <random>
 
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "NVS_Test";

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -17,8 +17,6 @@
 
 #include "base/BasePwm.h"
 #include "mcu/esp32/EspPwm.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "PWM_Test";

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -16,10 +16,20 @@
  */
 
 #include "base/BasePwm.h"
+#include "mcu/esp32/EspPwm.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspPwm.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "TestFramework.h"
 

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -18,19 +18,7 @@
 #include "base/BasePwm.h"
 #include "mcu/esp32/EspPwm.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "PWM_Test";

--- a/examples/esp32/main/SpiComprehensiveTest.cpp
+++ b/examples/esp32/main/SpiComprehensiveTest.cpp
@@ -22,15 +22,24 @@
  * @copyright HardFOC
  */
 
+#include "base/BaseSpi.h"
+#include "mcu/esp32/EspSpi.h"
+#include "mcu/esp32/utils/EspTypes_SPI.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "driver/spi_master.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#include "base/BaseSpi.h"
-#include "esp_timer.h"
-#include "mcu/esp32/EspSpi.h"
-#include "mcu/esp32/utils/EspTypes_SPI.h"
+#ifdef __cplusplus
+}
+#endif
 #include <algorithm>
 #include <cstring>
 #include <memory>

--- a/examples/esp32/main/SpiComprehensiveTest.cpp
+++ b/examples/esp32/main/SpiComprehensiveTest.cpp
@@ -26,16 +26,8 @@
 #include "mcu/esp32/EspSpi.h"
 #include "mcu/esp32/utils/EspTypes_SPI.h"
 
-// Additional ESP-IDF C headers needed by this test
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "driver/spi_master.h"
-
-#ifdef __cplusplus
-}
-#endif
+// Note: All ESP-IDF functionality accessed through EspSpi class interface
+// No direct ESP-IDF includes needed - TestFramework.h provides common functions
 #include <algorithm>
 #include <cstring>
 #include <memory>

--- a/examples/esp32/main/SpiComprehensiveTest.cpp
+++ b/examples/esp32/main/SpiComprehensiveTest.cpp
@@ -25,15 +25,11 @@
 #include "base/BaseSpi.h"
 #include "mcu/esp32/EspSpi.h"
 #include "mcu/esp32/utils/EspTypes_SPI.h"
-
-// Note: All ESP-IDF functionality accessed through EspSpi class interface
-// No direct ESP-IDF includes needed - TestFramework.h provides common functions
 #include <algorithm>
 #include <cstring>
 #include <memory>
 #include <vector>
 
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "SPI_Test";

--- a/examples/esp32/main/SpiComprehensiveTest.cpp
+++ b/examples/esp32/main/SpiComprehensiveTest.cpp
@@ -26,16 +26,12 @@
 #include "mcu/esp32/EspSpi.h"
 #include "mcu/esp32/utils/EspTypes_SPI.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+// Additional ESP-IDF C headers needed by this test
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include "driver/spi_master.h"
-#include "esp_log.h"
-#include "esp_timer.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 
 #ifdef __cplusplus
 }
@@ -45,6 +41,7 @@ extern "C" {
 #include <memory>
 #include <vector>
 
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "SPI_Test";

--- a/examples/esp32/main/TemperatureComprehensiveTest.cpp
+++ b/examples/esp32/main/TemperatureComprehensiveTest.cpp
@@ -4,11 +4,21 @@
  */
 
 #include "base/BaseTemperature.h"
+#include "mcu/esp32/EspTemperature.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspTemperature.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "TestFramework.h"
 #include <atomic>

--- a/examples/esp32/main/TemperatureComprehensiveTest.cpp
+++ b/examples/esp32/main/TemperatureComprehensiveTest.cpp
@@ -6,20 +6,7 @@
 #include "base/BaseTemperature.h"
 #include "mcu/esp32/EspTemperature.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "esp_timer.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 #include <atomic>
 

--- a/examples/esp32/main/TemperatureComprehensiveTest.cpp
+++ b/examples/esp32/main/TemperatureComprehensiveTest.cpp
@@ -5,8 +5,6 @@
 
 #include "base/BaseTemperature.h"
 #include "mcu/esp32/EspTemperature.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 #include <atomic>
 

--- a/examples/esp32/main/TestFramework.h
+++ b/examples/esp32/main/TestFramework.h
@@ -13,10 +13,19 @@
 
 #pragma once
 
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @brief Test execution tracking and results accumulation

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -10,20 +10,7 @@
 #include "base/BasePeriodicTimer.h"
 #include "mcu/esp32/EspPeriodicTimer.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "esp_timer.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "TIMER_Test";

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -9,8 +9,6 @@
 
 #include "base/BasePeriodicTimer.h"
 #include "mcu/esp32/EspPeriodicTimer.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "TIMER_Test";

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -8,11 +8,21 @@
  */
 
 #include "base/BasePeriodicTimer.h"
+#include "mcu/esp32/EspPeriodicTimer.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspPeriodicTimer.h"
-#include "esp_timer.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "TestFramework.h"
 

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -18,19 +18,7 @@
 #include "mcu/esp32/EspUart.h"
 #include "mcu/esp32/utils/EspTypes_UART.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "UART_Test";

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -17,8 +17,6 @@
 #include "base/BaseUart.h"
 #include "mcu/esp32/EspUart.h"
 #include "mcu/esp32/utils/EspTypes_UART.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "UART_Test";

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -14,13 +14,22 @@
  * @copyright HardFOC
  */
 
+#include "base/BaseUart.h"
+#include "mcu/esp32/EspUart.h"
+#include "mcu/esp32/utils/EspTypes_UART.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#include "base/BaseUart.h"
-#include "mcu/esp32/EspUart.h"
-#include "mcu/esp32/utils/EspTypes_UART.h"
+#ifdef __cplusplus
+}
+#endif
 
 #include "TestFramework.h"
 

--- a/examples/esp32/main/UtilsComprehensiveTest.cpp
+++ b/examples/esp32/main/UtilsComprehensiveTest.cpp
@@ -14,26 +14,13 @@
  * @copyright HardFOC
  */
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
-
 #include <memory>
 
 #include "base/HardwareTypes.h"
 #include "utils/AsciiArtGenerator.h"
 #include "utils/memory_utils.h"
 
-// Shared test framework
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "UTILS_Test";

--- a/examples/esp32/main/UtilsComprehensiveTest.cpp
+++ b/examples/esp32/main/UtilsComprehensiveTest.cpp
@@ -14,9 +14,19 @@
  * @copyright HardFOC
  */
 
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+
+#ifdef __cplusplus
+}
+#endif
+
 #include <memory>
 
 #include "base/HardwareTypes.h"

--- a/examples/esp32/main/UtilsComprehensiveTest.cpp
+++ b/examples/esp32/main/UtilsComprehensiveTest.cpp
@@ -19,8 +19,6 @@
 #include "base/HardwareTypes.h"
 #include "utils/AsciiArtGenerator.h"
 #include "utils/memory_utils.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "UTILS_Test";

--- a/examples/esp32/main/WifiComprehensiveTest.cpp
+++ b/examples/esp32/main/WifiComprehensiveTest.cpp
@@ -5,10 +5,20 @@
 
 #include "TestFramework.h"
 #include "base/BaseWifi.h"
+#include "mcu/esp32/EspWifi.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "mcu/esp32/EspWifi.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 static const char* TAG = "WIFI_Test";
 

--- a/examples/esp32/main/WifiComprehensiveTest.cpp
+++ b/examples/esp32/main/WifiComprehensiveTest.cpp
@@ -5,8 +5,6 @@
 
 #include "base/BaseWifi.h"
 #include "mcu/esp32/EspWifi.h"
-
-// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
 #include "TestFramework.h"
 
 static const char* TAG = "WIFI_Test";

--- a/examples/esp32/main/WifiComprehensiveTest.cpp
+++ b/examples/esp32/main/WifiComprehensiveTest.cpp
@@ -3,22 +3,11 @@
  * @brief Comprehensive WiFi testing suite for ESP32-C6 DevKit-M-1 (noexcept)
  */
 
-#include "TestFramework.h"
 #include "base/BaseWifi.h"
 #include "mcu/esp32/EspWifi.h"
 
-// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "esp_log.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-
-#ifdef __cplusplus
-}
-#endif
+// Shared test framework (provides esp_log.h, esp_timer.h, freertos/FreeRTOS.h, freertos/task.h)
+#include "TestFramework.h"
 
 static const char* TAG = "WIFI_Test";
 

--- a/inc/mcu/esp32/EspBluetooth.h
+++ b/inc/mcu/esp32/EspBluetooth.h
@@ -29,9 +29,17 @@
 #include "BaseBluetooth.h"
 #include "HardwareTypes.h"
 
-// ESP-IDF includes
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "nvs_flash.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 // ESP32 variant detection and feature matrix
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S3)

--- a/inc/mcu/esp32/EspSpi.h
+++ b/inc/mcu/esp32/EspSpi.h
@@ -35,6 +35,12 @@
 #include <memory>
 #include <vector>
 
+// Suppress pedantic warnings for ESP-IDF headers
+#ifdef __cplusplus
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 // ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
 #ifdef __cplusplus
 extern "C" {
@@ -44,6 +50,11 @@ extern "C" {
 #include "esp_log.h"
 #ifdef __cplusplus
 }
+#endif
+
+// Restore warnings after ESP-IDF headers
+#ifdef __cplusplus
+#pragma GCC diagnostic pop
 #endif
 
 class EspSpiBus;

--- a/inc/mcu/esp32/EspWifi.h
+++ b/inc/mcu/esp32/EspWifi.h
@@ -19,6 +19,12 @@
 
 #pragma once
 
+// Suppress pedantic warnings for ESP-IDF headers
+#ifdef __cplusplus
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 // ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +43,11 @@ extern "C" {
 
 #ifdef __cplusplus
 }
+#endif
+
+// Restore warnings after ESP-IDF headers
+#ifdef __cplusplus
+#pragma GCC diagnostic pop
 #endif
 
 // C++ headers

--- a/inc/utils/RtosMutex.h
+++ b/inc/utils/RtosMutex.h
@@ -17,6 +17,13 @@
 #pragma once
 
 #include "McuSelect.h"
+
+// Suppress pedantic warnings for ESP-IDF headers
+#ifdef __cplusplus
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 // ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +49,11 @@ extern "C" {
 
 #ifdef __cplusplus
 }
+#endif
+
+// Restore warnings after ESP-IDF headers
+#ifdef __cplusplus
+#pragma GCC diagnostic pop
 #endif
 
 #include <atomic>

--- a/src/mcu/esp32/EspWifi.cpp
+++ b/src/mcu/esp32/EspWifi.cpp
@@ -16,6 +16,12 @@
  */
 
 #include "mcu/esp32/EspWifi.h"
+
+// ESP-IDF C headers must be wrapped in extern "C" for C++ compatibility
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "esp_log.h"
 #include "esp_mac.h"
 #include "esp_system.h"
@@ -23,6 +29,11 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
+
+#ifdef __cplusplus
+}
+#endif
+
 #include <algorithm>
 #include <cstring>
 


### PR DESCRIPTION
Wrap all ESP-IDF C library includes in `extern "C"` blocks to ensure proper C++ linkage and prevent symbol mangling.