### PR TITLE
Flash and monitor example builds

### DIFF
--- a/examples/esp32/README_BUILD_SYSTEM.md
+++ b/examples/esp32/README_BUILD_SYSTEM.md
@@ -39,6 +39,49 @@ The project contains example applications that demonstrate different aspects of 
 ./build_example.sh utils_test Release
 ```
 
+### Using the Flash and Monitor Scripts
+
+The project includes dedicated scripts for flashing and monitoring that can automatically build if needed.
+
+#### Windows (PowerShell)
+```powershell
+# Flash and monitor ASCII art example (default)
+.\flash_example.ps1
+
+# Flash specific examples with different operations
+.\flash_example.ps1 gpio_test Release flash_monitor  # Flash and monitor
+.\flash_example.ps1 bluetooth_test Debug flash       # Flash only
+.\flash_example.ps1 utils_test Release monitor       # Monitor only
+
+# Auto-build examples if binary doesn't exist
+.\flash_example.ps1 pio_test Debug flash_monitor     # Builds first if needed
+```
+
+#### Linux/macOS (Bash)
+```bash
+# Flash and monitor ASCII art example (default)
+./flash_example.sh
+
+# Flash specific examples with different operations
+./flash_example.sh gpio_test Release flash_monitor   # Flash and monitor
+./flash_example.sh bluetooth_test Debug flash        # Flash only
+./flash_example.sh utils_test Release monitor        # Monitor only
+
+# Auto-build examples if binary doesn't exist
+./flash_example.sh pio_test Debug flash_monitor      # Builds first if needed
+```
+
+#### Flash Script Features
+
+- **Auto-build**: If no valid build exists, automatically builds the example before flashing
+- **Build Detection**: Uses existing builds when available (follows `build_${EXAMPLE_TYPE}_${BUILD_TYPE}` naming)
+- **Multiple Operations**: 
+  - `flash` - Flash firmware only
+  - `monitor` - Monitor serial output only  
+  - `flash_monitor` - Flash then monitor (default)
+- **Error Handling**: Comprehensive validation and error reporting
+- **Cross-platform**: Both Bash and PowerShell versions available
+
 ## Detailed Examples
 
 ### 1. ASCII Art Generator (`ascii_art`)

--- a/examples/esp32/flash_example.ps1
+++ b/examples/esp32/flash_example.ps1
@@ -1,0 +1,204 @@
+# Flash and monitor script for different ESP32 examples (PowerShell version)
+# Usage: .\flash_example.ps1 [example_type] [build_type] [operation]
+# 
+# Example types:
+#   ascii_art      - ASCII art generator example
+#   pio_test       - Comprehensive PIO/RMT testing suite with WS2812 and logic analyzer
+#   bluetooth_test - Comprehensive Bluetooth testing suite
+#   utils_test     - Utilities testing suite
+#
+# Build types: Debug, Release (default: Release)
+# Operations: flash, monitor, flash_monitor (default: flash_monitor)
+
+param(
+    [string]$ExampleType = "ascii_art",
+    [string]$BuildType = "Release",
+    [string]$Operation = "flash_monitor"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Configuration
+$ProjectDir = $PSScriptRoot
+$ValidExampleTypes = @(
+    "ascii_art",
+    "gpio_test", "adc_test", "i2c_test", "spi_test", "uart_test", 
+    "can_test", "pwm_test", "timer_test", "logger_test", "nvs_test", 
+    "wifi_test", "pio_test", "temperature_test", "bluetooth_test", "interrupts_test",
+    "utils_test"
+)
+$ValidBuildTypes = @("Debug", "Release")
+$ValidOperations = @("flash", "monitor", "flash_monitor")
+
+# Ensure ESP32-C6 target is set
+$env:IDF_TARGET = "esp32c6"
+
+Write-Host "=== ESP32 HardFOC Interface Wrapper Flash System ===" -ForegroundColor Green
+Write-Host "Project Directory: $ProjectDir"
+Write-Host "Example Type: $ExampleType"
+Write-Host "Build Type: $BuildType"
+Write-Host "Operation: $Operation"
+Write-Host "Target: $($env:IDF_TARGET)"
+Write-Host "======================================================" -ForegroundColor Green
+
+# Validate example type
+if ($ExampleType -notin $ValidExampleTypes) {
+    Write-Host "ERROR: Invalid example type: $ExampleType" -ForegroundColor Red
+    Write-Host "Available types: $($ValidExampleTypes -join ', ')" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host "Valid example type: $ExampleType" -ForegroundColor Green
+
+# Validate build type
+if ($BuildType -notin $ValidBuildTypes) {
+    Write-Host "ERROR: Invalid build type: $BuildType" -ForegroundColor Red
+    Write-Host "Available types: $($ValidBuildTypes -join ', ')" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host "Valid build type: $BuildType" -ForegroundColor Green
+
+# Validate operation
+if ($Operation -notin $ValidOperations) {
+    Write-Host "ERROR: Invalid operation: $Operation" -ForegroundColor Red
+    Write-Host "Available operations: $($ValidOperations -join ', ')" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host "Valid operation: $Operation" -ForegroundColor Green
+
+# Switch to project directory
+Set-Location $ProjectDir
+
+# Set build directory
+$BuildDir = "build_${ExampleType}_${BuildType}"
+Write-Host "Build directory: $BuildDir" -ForegroundColor Blue
+
+# Get project information
+$ProjectName = "esp32_iid_${ExampleType}_example"
+$BinFile = "$BuildDir\$ProjectName.bin"
+
+# Check if build exists and is valid
+$BuildExists = $false
+if (Test-Path $BuildDir) {
+    if ((Test-Path $BinFile) -or (Test-Path "$BuildDir\bootloader\bootloader.bin")) {
+        Write-Host "Found existing build in $BuildDir" -ForegroundColor Green
+        $BuildExists = $true
+    } else {
+        Write-Host "Build directory exists but no valid binary found" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "No build directory found" -ForegroundColor Yellow
+}
+
+# Auto-build if necessary
+if (-not $BuildExists) {
+    Write-Host ""
+    Write-Host "======================================================" -ForegroundColor Red
+    Write-Host "NO VALID BUILD FOUND - STARTING AUTO-BUILD" -ForegroundColor Red
+    Write-Host "======================================================" -ForegroundColor Red
+    Write-Host "Building $ExampleType ($BuildType) before flashing..." -ForegroundColor Yellow
+    
+    # Clean any existing incomplete build
+    if (Test-Path $BuildDir) {
+        Write-Host "Cleaning incomplete build..." -ForegroundColor Yellow
+        Remove-Item -Recurse -Force $BuildDir
+    }
+    
+    try {
+        # Configure and build
+        Write-Host "Configuring project for $($env:IDF_TARGET)..." -ForegroundColor Blue
+        & idf.py -B $BuildDir -D CMAKE_BUILD_TYPE=$BuildType -D EXAMPLE_TYPE=$ExampleType reconfigure
+        
+        if ($LASTEXITCODE -ne 0) {
+            throw "Configuration failed"
+        }
+        
+        Write-Host "Building project..." -ForegroundColor Blue
+        & idf.py -B $BuildDir build
+        
+        if ($LASTEXITCODE -ne 0) {
+            throw "Build failed"
+        }
+        
+        Write-Host "Build completed successfully!" -ForegroundColor Green
+        Write-Host "======================================================" -ForegroundColor Green
+    } catch {
+        Write-Host "ERROR: Auto-build failed: $_" -ForegroundColor Red
+        exit 1
+    }
+} else {
+    Write-Host "Using existing build in $BuildDir" -ForegroundColor Green
+}
+
+# Verify binary exists after build
+if (-not (Test-Path $BinFile) -and -not (Test-Path "$BuildDir\bootloader\bootloader.bin")) {
+    Write-Host "ERROR: No valid binary found after build attempt" -ForegroundColor Red
+    Write-Host "Expected: $BinFile" -ForegroundColor Yellow
+    Write-Host "Build directory contents:" -ForegroundColor Yellow
+    try {
+        Get-ChildItem $BuildDir | Format-Table Name, Length, LastWriteTime
+    } catch {
+        Write-Host "Build directory not accessible" -ForegroundColor Red
+    }
+    exit 1
+}
+
+# Execute the requested operation
+Write-Host ""
+Write-Host "======================================================" -ForegroundColor Cyan
+Write-Host "EXECUTING OPERATION: $Operation" -ForegroundColor Cyan
+Write-Host "======================================================" -ForegroundColor Cyan
+
+try {
+    switch ($Operation) {
+        "flash" {
+            Write-Host "Flashing $ExampleType example..." -ForegroundColor Blue
+            & idf.py -B $BuildDir flash
+            if ($LASTEXITCODE -ne 0) {
+                throw "Flash operation failed"
+            }
+            Write-Host "Flash completed successfully!" -ForegroundColor Green
+        }
+        "monitor" {
+            Write-Host "Starting monitor for $ExampleType example..." -ForegroundColor Blue
+            Write-Host "Press Ctrl+] to exit monitor" -ForegroundColor Yellow
+            & idf.py -B $BuildDir monitor
+            if ($LASTEXITCODE -ne 0) {
+                throw "Monitor operation failed"
+            }
+        }
+        "flash_monitor" {
+            Write-Host "Flashing and monitoring $ExampleType example..." -ForegroundColor Blue
+            Write-Host "Press Ctrl+] to exit monitor after flashing" -ForegroundColor Yellow
+            & idf.py -B $BuildDir flash monitor
+            if ($LASTEXITCODE -ne 0) {
+                throw "Flash and monitor operation failed"
+            }
+        }
+    }
+
+    Write-Host ""
+    Write-Host "======================================================" -ForegroundColor Green
+    Write-Host "OPERATION COMPLETED SUCCESSFULLY" -ForegroundColor Green
+    Write-Host "======================================================" -ForegroundColor Green
+    Write-Host "Example Type: $ExampleType" -ForegroundColor Cyan
+    Write-Host "Build Type: $BuildType" -ForegroundColor Cyan
+    Write-Host "Operation: $Operation" -ForegroundColor Cyan
+    Write-Host "Target: $($env:IDF_TARGET)" -ForegroundColor Cyan
+    Write-Host "Build Directory: $BuildDir" -ForegroundColor Cyan
+    Write-Host "Project Name: $ProjectName" -ForegroundColor Cyan
+    if (Test-Path $BinFile) {
+        Write-Host "Binary: $BinFile" -ForegroundColor Cyan
+    }
+    Write-Host ""
+    Write-Host "Available operations:" -ForegroundColor Yellow
+    Write-Host "  Flash only:        .\flash_example.ps1 $ExampleType $BuildType flash" -ForegroundColor White
+    Write-Host "  Monitor only:      .\flash_example.ps1 $ExampleType $BuildType monitor" -ForegroundColor White
+    Write-Host "  Flash & monitor:   .\flash_example.ps1 $ExampleType $BuildType flash_monitor" -ForegroundColor White
+    Write-Host "  Build only:        .\build_example.ps1 $ExampleType $BuildType" -ForegroundColor White
+    Write-Host "======================================================" -ForegroundColor Green
+
+} catch {
+    Write-Host "OPERATION FAILED: $_" -ForegroundColor Red
+    Write-Host "Check the error messages above for details." -ForegroundColor Yellow
+    exit 1
+}

--- a/examples/esp32/flash_example.sh
+++ b/examples/esp32/flash_example.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Flash and monitor script for different ESP32 examples (Bash version)
+# Usage: ./flash_example.sh [example_type] [build_type] [operation]
+# 
+# Example types:
+#   ascii_art      - ASCII art generator example
+#   pio_test       - Comprehensive PIO/RMT testing suite with WS2812 and logic analyzer
+#   bluetooth_test - Comprehensive Bluetooth testing suite
+#   utils_test     - Utilities testing suite
+#
+# Build types: Debug, Release (default: Release)
+# Operations: flash, monitor, flash_monitor (default: flash_monitor)
+
+set -e  # Exit on any error
+
+# Configuration
+EXAMPLE_TYPE=${1:-ascii_art}
+BUILD_TYPE=${2:-Release}
+OPERATION=${3:-flash_monitor}
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure ESP32-C6 target is set
+export IDF_TARGET=esp32c6
+
+echo "=== ESP32 HardFOC Interface Wrapper Flash System ==="
+echo "Project Directory: $PROJECT_DIR"
+echo "Example Type: $EXAMPLE_TYPE"
+echo "Build Type: $BUILD_TYPE"
+echo "Operation: $OPERATION"
+echo "Target: $IDF_TARGET"
+echo "======================================================"
+
+# Validate example type
+case $EXAMPLE_TYPE in
+    ascii_art|gpio_test|adc_test|i2c_test|spi_test|uart_test|can_test|pwm_test|timer_test|logger_test|nvs_test|wifi_test|pio_test|temperature_test|bluetooth_test|interrupts_test|utils_test)
+        echo "Valid example type: $EXAMPLE_TYPE"
+        ;;
+    *)
+        echo "ERROR: Invalid example type: $EXAMPLE_TYPE"
+        echo "Available types: ascii_art, gpio_test, adc_test, i2c_test, spi_test, uart_test, can_test, pwm_test, pio_test, timer_test, logger_test, nvs_test, wifi_test, temperature_test, bluetooth_test, interrupts_test, utils_test"
+        exit 1
+        ;;
+esac
+
+# Validate build type
+case $BUILD_TYPE in
+    Debug|Release)
+        echo "Valid build type: $BUILD_TYPE"
+        ;;
+    *)
+        echo "ERROR: Invalid build type: $BUILD_TYPE"
+        echo "Available types: Debug, Release"
+        exit 1
+        ;;
+esac
+
+# Validate operation
+case $OPERATION in
+    flash|monitor|flash_monitor)
+        echo "Valid operation: $OPERATION"
+        ;;
+    *)
+        echo "ERROR: Invalid operation: $OPERATION"
+        echo "Available operations: flash, monitor, flash_monitor"
+        exit 1
+        ;;
+esac
+
+# Switch to project directory
+cd "$PROJECT_DIR"
+
+# Set build directory
+BUILD_DIR="build_${EXAMPLE_TYPE}_${BUILD_TYPE}"
+echo "Build directory: $BUILD_DIR"
+
+# Get project information
+PROJECT_NAME="esp32_iid_${EXAMPLE_TYPE}_example"
+BIN_FILE="$BUILD_DIR/$PROJECT_NAME.bin"
+
+# Check if build exists and is valid
+BUILD_EXISTS=false
+if [ -d "$BUILD_DIR" ]; then
+    if [ -f "$BIN_FILE" ] || [ -f "$BUILD_DIR/bootloader/bootloader.bin" ]; then
+        echo "Found existing build in $BUILD_DIR"
+        BUILD_EXISTS=true
+    else
+        echo "Build directory exists but no valid binary found"
+    fi
+else
+    echo "No build directory found"
+fi
+
+# Auto-build if necessary
+if [ "$BUILD_EXISTS" = false ]; then
+    echo ""
+    echo "======================================================"
+    echo "NO VALID BUILD FOUND - STARTING AUTO-BUILD"
+    echo "======================================================"
+    echo "Building $EXAMPLE_TYPE ($BUILD_TYPE) before flashing..."
+    
+    # Clean any existing incomplete build
+    if [ -d "$BUILD_DIR" ]; then
+        echo "Cleaning incomplete build..."
+        rm -rf "$BUILD_DIR"
+    fi
+    
+    # Configure and build
+    echo "Configuring project for $IDF_TARGET..."
+    if ! idf.py -B "$BUILD_DIR" -D CMAKE_BUILD_TYPE="$BUILD_TYPE" -D EXAMPLE_TYPE="$EXAMPLE_TYPE" reconfigure; then
+        echo "ERROR: Configuration failed"
+        exit 1
+    fi
+    
+    echo "Building project..."
+    if ! idf.py -B "$BUILD_DIR" build; then
+        echo "ERROR: Build failed"
+        exit 1
+    fi
+    
+    echo "Build completed successfully!"
+    echo "======================================================"
+else
+    echo "Using existing build in $BUILD_DIR"
+fi
+
+# Verify binary exists after build
+if [ ! -f "$BIN_FILE" ] && [ ! -f "$BUILD_DIR/bootloader/bootloader.bin" ]; then
+    echo "ERROR: No valid binary found after build attempt"
+    echo "Expected: $BIN_FILE"
+    echo "Build directory contents:"
+    ls -la "$BUILD_DIR" 2>/dev/null || echo "Build directory not accessible"
+    exit 1
+fi
+
+# Execute the requested operation
+echo ""
+echo "======================================================"
+echo "EXECUTING OPERATION: $OPERATION"
+echo "======================================================"
+
+case $OPERATION in
+    flash)
+        echo "Flashing $EXAMPLE_TYPE example..."
+        if ! idf.py -B "$BUILD_DIR" flash; then
+            echo "ERROR: Flash operation failed"
+            exit 1
+        fi
+        echo "Flash completed successfully!"
+        ;;
+    monitor)
+        echo "Starting monitor for $EXAMPLE_TYPE example..."
+        echo "Press Ctrl+] to exit monitor"
+        if ! idf.py -B "$BUILD_DIR" monitor; then
+            echo "ERROR: Monitor operation failed"
+            exit 1
+        fi
+        ;;
+    flash_monitor)
+        echo "Flashing and monitoring $EXAMPLE_TYPE example..."
+        echo "Press Ctrl+] to exit monitor after flashing"
+        if ! idf.py -B "$BUILD_DIR" flash monitor; then
+            echo "ERROR: Flash and monitor operation failed"
+            exit 1
+        fi
+        ;;
+esac
+
+echo ""
+echo "======================================================"
+echo "OPERATION COMPLETED SUCCESSFULLY"
+echo "======================================================"
+echo "Example Type: $EXAMPLE_TYPE"
+echo "Build Type: $BUILD_TYPE"
+echo "Operation: $OPERATION"
+echo "Target: $IDF_TARGET"
+echo "Build Directory: $BUILD_DIR"
+echo "Project Name: $PROJECT_NAME"
+if [ -f "$BIN_FILE" ]; then
+    echo "Binary: $BIN_FILE"
+fi
+echo ""
+echo "Available operations:"
+echo "  Flash only:        ./flash_example.sh $EXAMPLE_TYPE $BUILD_TYPE flash"
+echo "  Monitor only:      ./flash_example.sh $EXAMPLE_TYPE $BUILD_TYPE monitor"
+echo "  Flash & monitor:   ./flash_example.sh $EXAMPLE_TYPE $BUILD_TYPE flash_monitor"
+echo "  Build only:        ./build_example.sh $EXAMPLE_TYPE $BUILD_TYPE"
+echo "======================================================"


### PR DESCRIPTION
Add `flash_example.sh` and `flash_example.ps1` scripts to flash and monitor ESP32 examples with auto-build capability.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cf1e8ed-b551-4a66-a1b8-e7848af39c47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3cf1e8ed-b551-4a66-a1b8-e7848af39c47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

