### PR TITLE
Verify EspPwm doxygen documentation and inheritance

### DIFF
--- a/inc/mcu/esp32/EspPwm.h
+++ b/inc/mcu/esp32/EspPwm.h
@@ -114,6 +114,13 @@ public:
    * @note Uses lazy initialization - no hardware action until first operation
    */
   explicit EspPwm(const hf_pwm_unit_config_t& config = hf_pwm_unit_config_t{}) noexcept;
+  
+  /**
+   * @brief Legacy constructor for ESP32C6 PWM controller with base clock frequency
+   * @param base_clock_hz Base clock frequency in Hz (0 = use default)
+   * @note Uses lazy initialization - no hardware action until first operation
+   * @note This constructor is provided for backwards compatibility
+   */
   EspPwm(hf_u32_t base_clock_hz) noexcept;
 
   /**
@@ -145,6 +152,8 @@ public:
    * @warning Multiple calls return PWM_ERR_ALREADY_INITIALIZED (safe to call repeatedly)
    * 
    * @see Deinitialize() for cleanup and resource release
+   * 
+   * @implements BasePwm::Initialize() - ESP32-specific implementation using LEDC peripheral
    */
   hf_pwm_err_t Initialize() noexcept override;
   
@@ -163,6 +172,8 @@ public:
    * @warning All PWM outputs will stop and GPIOs will be reset to default state
    * 
    * @see Initialize() for PWM subsystem initialization
+   * 
+   * @implements BasePwm::Deinitialize() - ESP32-specific cleanup with LEDC peripheral reset
    */
   hf_pwm_err_t Deinitialize() noexcept override;
 
@@ -311,6 +322,8 @@ public:
    * 
    * @note For phase relationships, consider using timer offsets or software timing
    * @warning This method will always fail on ESP32 LEDC peripheral
+   * 
+   * @implements BasePwm::SetPhaseShift() - Required by base class interface but not supported by ESP32 LEDC hardware
    */
   hf_pwm_err_t SetPhaseShift(hf_channel_id_t channel_id,
                              float phase_shift_degrees) noexcept override;
@@ -453,6 +466,8 @@ public:
    * @warning Complementary operation is implemented in software, not hardware
    * 
    * @see ConfigureChannel() to set up both channels before pairing
+   * 
+   * @implements BasePwm::SetComplementaryOutput() - Software-based complementary PWM for motor control
    */
   hf_pwm_err_t SetComplementaryOutput(hf_channel_id_t primary_channel,
                                       hf_channel_id_t complementary_channel,


### PR DESCRIPTION
Add missing Doxygen for a constructor and explicitly document inherited methods in `EspPwm` to improve clarity and completeness.

---
<a href="https://cursor.com/background-agent?bcId=bc-b964cf49-bf79-49c5-a168-bf08ea0a5b8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b964cf49-bf79-49c5-a168-bf08ea0a5b8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

