### PR TITLE
Investigate EspI2C resource acquisition and destruction

### DIFF
--- a/inc/mcu/esp32/EspI2c.h
+++ b/inc/mcu/esp32/EspI2c.h
@@ -128,8 +128,20 @@ public:
   bool Initialize() noexcept override;
 
   /**
-   * @brief Deinitialize the I2C device and free resources.
-   * @return true if successful, false otherwise
+   * @brief Mark device as deinitialized without ESP-IDF cleanup
+   * @return true if successful
+   * 
+   * This method is called by the bus when it handles ESP-IDF cleanup.
+   * The device should not attempt to remove itself from the ESP-IDF bus.
+   */
+  bool MarkAsDeinitialized() noexcept;
+
+  /**
+   * @brief Deinitialize the device (internal cleanup only)
+   * @return true if successful
+   * 
+   * This method only handles internal device cleanup.
+   * ESP-IDF cleanup is handled by the parent bus.
    */
   bool Deinitialize() noexcept override;
 


### PR DESCRIPTION
Refactor EspI2C resource management to fix `xQueueTake` errors and resets.

The previous design caused double removal of I2C devices from the ESP-IDF bus during deinitialization, leading to queue corruption and system resets. This PR centralizes ESP-IDF device cleanup responsibility to the `EspI2cBus` to ensure proper resource management and prevent these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-4aeb631c-49d7-4d2d-87be-bcee8d99323c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4aeb631c-49d7-4d2d-87be-bcee8d99323c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

