### PR TITLE
Organize matrix generation script location

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ strategy:
 - name: Generate Matrix
   id: matrix
   run: |
-    python3 .github/workflows/scripts/generate_matrix.py
+    python3 examples/esp32/scripts/generate_matrix.py
 ```
 
 ### **Security Audit** (`security-audit.yml`)
@@ -97,13 +97,13 @@ Dynamic CI matrix generator that creates build combinations based on `examples/e
 **Usage**:
 ```bash
 # Generate matrix for GitHub Actions
-python3 .github/workflows/scripts/generate_matrix.py
+python3 examples/esp32/scripts/generate_matrix.py
 
 # Pretty-printed output for debugging
-python3 .github/workflows/scripts/generate_matrix.py --pretty
+python3 examples/esp32/scripts/generate_matrix.py --pretty
 
 # Hierarchical configuration analysis
-python3 .github/workflows/scripts/generate_matrix.py --hierarchical-info
+python3 examples/esp32/scripts/generate_matrix.py --hierarchical-info
 ```
 
 **For detailed documentation, see**: [`scripts/README.md`](scripts/README.md)
@@ -203,13 +203,13 @@ Each matrix entry contains:
 ### **Matrix Analysis**
 ```bash
 # Check total build count
-python3 .github/workflows/scripts/generate_matrix.py --pretty | jq '.include | length'
+python3 examples/esp32/scripts/generate_matrix.py --pretty | jq '.include | length'
 
 # Analyze specific app builds
-python3 .github/workflows/scripts/generate_matrix.py --pretty | jq '.include[] | select(.app_name == "app_name")'
+python3 examples/esp32/scripts/generate_matrix.py --pretty | jq '.include[] | select(.app_name == "app_name")'
 
 # Hierarchical configuration analysis
-python3 .github/workflows/scripts/generate_matrix.py --hierarchical-info
+python3 examples/esp32/scripts/generate_matrix.py --hierarchical-info
 ```
 
 ### **Build Artifacts**
@@ -282,13 +282,13 @@ python3 .github/workflows/scripts/generate_matrix.py --hierarchical-info
 ### **Debug Commands**
 ```bash
 # Validate configuration
-python3 .github/workflows/scripts/generate_matrix.py --metadata
+python3 examples/esp32/scripts/generate_matrix.py --metadata
 
 # Check matrix structure
-python3 .github/workflows/scripts/generate_matrix.py --pretty
+python3 examples/esp32/scripts/generate_matrix.py --pretty
 
 # Analyze configuration hierarchy
-python3 .github/workflows/scripts/generate_matrix.py --hierarchical-info
+python3 examples/esp32/scripts/generate_matrix.py --hierarchical-info
 ```
 
 ---

--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Generate matrix
         id: generate-matrix
         run: |
-          MATRIX=$(python3 .github/workflows/scripts/generate_matrix.py)
+          MATRIX=$(python3 examples/esp32/scripts/generate_matrix.py)
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "Generated matrix:"
-          python3 .github/workflows/scripts/generate_matrix.py --pretty | jq .
+          python3 examples/esp32/scripts/generate_matrix.py --pretty | jq .
 
   build:
     name: Build ➜ ${{ matrix.idf_version }} · ${{ matrix.build_type }} · ${{ matrix.app_name }}

--- a/.github/workflows/scripts/README.md
+++ b/.github/workflows/scripts/README.md
@@ -327,7 +327,7 @@ jobs:
       - name: Generate Matrix
         id: matrix
         run: |
-          python3 .github/workflows/scripts/generate_matrix.py
+          python3 examples/esp32/scripts/generate_matrix.py
         shell: bash
 ```
 

--- a/examples/esp32/scripts/generate_matrix.py
+++ b/examples/esp32/scripts/generate_matrix.py
@@ -16,10 +16,14 @@ def load_config():
     possible_paths = [
         # When run from workspace root
         Path("examples/esp32/app_config.yml"),
+        # When run from examples/esp32 directory
+        Path("app_config.yml"),
+        # When run from examples/esp32/scripts directory
+        Path("../app_config.yml"),
         # When run from .github/workflows directory  
         Path("../../examples/esp32/app_config.yml"),
         # Absolute path calculation from script location
-        Path(__file__).resolve().parent.parent / "examples" / "esp32" / "app_config.yml"
+        Path(__file__).resolve().parent.parent / "app_config.yml"
     ]
     
     config_file = None


### PR DESCRIPTION
Move `generate_matrix.py` to `examples/esp32/scripts/` to logically group it with ESP32-specific configuration scripts and enhance reusability.

The script is tightly coupled to `examples/esp32/app_config.yml`, making its previous location in `.github/workflows/scripts/` misleading. This move improves separation of concerns by co-locating it with other ESP32 example support scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-88ab4f75-026e-4b10-83d2-0964c83c0876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88ab4f75-026e-4b10-83d2-0964c83c0876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

