### PR TITLE
Fix esp-idf version cloning format

### DIFF
--- a/examples/esp32/app_config.yml
+++ b/examples/esp32/app_config.yml
@@ -29,7 +29,7 @@ apps:
     description: "GPIO peripheral comprehensive testing"
     source_file: "GpioComprehensiveTest.cpp"
     category: "peripheral"
-    idf_versions: ["release/v5.5"]
+    idf_versions: ["release/v5.5", "release/v5.4"]
     build_types: ["Debug", "Release"]
     ci_enabled: true
     featured: true
@@ -38,7 +38,7 @@ apps:
     description: "ADC peripheral comprehensive testing"
     source_file: "AdcComprehensiveTest.cpp"
     category: "peripheral"
-    idf_versions: ["release/v5.5"]
+    idf_versions: ["release/v5.5", "release/v5.4"]
     build_types: ["Debug", "Release"]
     ci_enabled: true
     featured: true


### PR DESCRIPTION
Update CI setup to correctly install and source specific ESP-IDF versions in Docker and expand app test coverage.

Fixes "Remote branch not found" errors in CI by preventing concatenation of ESP-IDF versions during installation, ensuring each job uses its designated version from the matrix.

---
<a href="https://cursor.com/background-agent?bcId=bc-dceb269b-3b0d-49e2-8f02-1c23abe70920">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dceb269b-3b0d-49e2-8f02-1c23abe70920">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

