### PR TITLE
Fix artifact upload directory name

### DIFF
--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -228,8 +228,7 @@ jobs:
             build_dir="build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-${{ matrix.target }}-idf-"
             build_dir="${build_dir}${{ matrix.idf_version_file }}"
             
-            # Set output for the upload step to use
-            echo "build_dir_name=$build_dir" >> $GITHUB_OUTPUT
+
             
             echo "Looking for build directory: $build_dir"
             
@@ -252,7 +251,9 @@ jobs:
         with:
           name: fw-${{ matrix.app_name }}-${{ matrix.idf_version_docker }}-${{ matrix.build_type }}
           retention-days: 7
-          path: ${{ env.BUILD_PATH }}/${{ steps.build.outputs.build_dir_name }}
+          path: |
+            ${{ env.BUILD_PATH }}/build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-
+            ${{ matrix.target }}-idf-${{ matrix.idf_version_file }}
 
   static-analysis:
     name: Static Analysis (cppcheck + clang-tidy)

--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -251,7 +251,7 @@ jobs:
         with:
           name: fw-${{ matrix.app_name }}-${{ matrix.idf_version_docker }}-${{ matrix.build_type }}
           retention-days: 7
-          path: |
+          path: >-
             ${{ env.BUILD_PATH }}/build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-
             ${{ matrix.target }}-idf-${{ matrix.idf_version_file }}
 

--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -251,9 +251,7 @@ jobs:
         with:
           name: fw-${{ matrix.app_name }}-${{ matrix.idf_version_docker }}-${{ matrix.build_type }}
           retention-days: 7
-          path: >-
-            ${{ env.BUILD_PATH }}/build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-
-            ${{ matrix.target }}-idf-${{ matrix.idf_version_file }}
+          path: ${{ env.BUILD_PATH }}/${{ env.ESP32_BUILD_APP_MOST_RECENT_DIRECTORY }}
 
   static-analysis:
     name: Static Analysis (cppcheck + clang-tidy)

--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -228,6 +228,9 @@ jobs:
             build_dir="build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-${{ matrix.target }}-idf-"
             build_dir="${build_dir}${{ matrix.idf_version_file }}"
             
+            # Export build_dir as environment variable for the upload step
+            echo "BUILD_DIR_NAME=$build_dir" >> $GITHUB_ENV
+            
             echo "Looking for build directory: $build_dir"
             
             # Check if the build directory exists
@@ -249,9 +252,7 @@ jobs:
         with:
           name: fw-${{ matrix.app_name }}-${{ matrix.idf_version_docker }}-${{ matrix.build_type }}
           retention-days: 7
-          path: >-
-            ${{ env.BUILD_PATH }}/build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-
-            ${{ matrix.target }}-idf-${{ matrix.idf_version_file }}
+          path: ${{ env.BUILD_PATH }}/${{ env.BUILD_DIR_NAME }}
 
   static-analysis:
     name: Static Analysis (cppcheck + clang-tidy)

--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -228,8 +228,8 @@ jobs:
             build_dir="build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-${{ matrix.target }}-idf-"
             build_dir="${build_dir}${{ matrix.idf_version_file }}"
             
-            # Export build_dir as environment variable for the upload step
-            echo "BUILD_DIR_NAME=$build_dir" >> $GITHUB_ENV
+            # Set output for the upload step to use
+            echo "build_dir_name=$build_dir" >> $GITHUB_OUTPUT
             
             echo "Looking for build directory: $build_dir"
             
@@ -252,7 +252,7 @@ jobs:
         with:
           name: fw-${{ matrix.app_name }}-${{ matrix.idf_version_docker }}-${{ matrix.build_type }}
           retention-days: 7
-          path: ${{ env.BUILD_PATH }}/${{ env.BUILD_DIR_NAME }}
+          path: ${{ env.BUILD_PATH }}/${{ steps.build.outputs.build_dir_name }}
 
   static-analysis:
     name: Static Analysis (cppcheck + clang-tidy)


### PR DESCRIPTION

Refactor build artifact path construction to avoid yamllint line length violations.

The previous method of concatenating the build artifact path using `>-` resulted in a single line exceeding 120 characters, which violated yamllint rules. This PR exports the already constructed and exported build directory in build_app.sh! This resolves the lint error and allows build_app.sh to be source of truth for build directory.