### PR TITLE
Rename artifacts with fw- prefix

### DIFF
--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -238,9 +238,6 @@ jobs:
               echo "Build artifacts:"
               ls -la "$build_dir/"
               echo "Build directory ready for artifact upload"
-              
-              # Export the build directory for artifact upload
-              echo "ESP32_BUILD_APP_MOST_RECENT_DIRECTORY=$build_dir" >> $GITHUB_ENV
             else
               echo "ERROR: Build directory not found: $build_dir"
               echo "Available directories:"
@@ -252,9 +249,9 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: fw-${{ env.ESP32_BUILD_APP_MOST_RECENT_DIRECTORY }}
+          name: fw-build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-${{ matrix.target }}-idf-${{ matrix.idf_version_file }}
           retention-days: 7
-          path: ${{ env.BUILD_PATH }}/${{ env.ESP32_BUILD_APP_MOST_RECENT_DIRECTORY }}
+          path: ${{ env.BUILD_PATH }}/build-app-${{ matrix.app_name }}-type-${{ matrix.build_type }}-target-${{ matrix.target }}-idf-${{ matrix.idf_version_file }}
 
   static-analysis:
     name: Static Analysis (cppcheck + clang-tidy)


### PR DESCRIPTION
Prefix GitHub Actions artifact names with "fw-" to clearly identify them as firmware-related.

---
<a href="https://cursor.com/background-agent?bcId=bc-56c8463d-5e41-4e42-842d-34011d23a5f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56c8463d-5e41-4e42-842d-34011d23a5f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

