### PR TITLE
Verify EspGpio usage in comprehensive tests

### DIFF
--- a/examples/esp32/main/AdcComprehensiveTest.cpp
+++ b/examples/esp32/main/AdcComprehensiveTest.cpp
@@ -67,10 +67,13 @@ static volatile uint64_t last_monitor_event_time = 0;
 // Enable/disable specific test categories by setting to true or false
 
 // Core ADC functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Hardware validation, initialization, configuration
-static constexpr bool ENABLE_CONVERSION_TESTS = true;     // Basic conversion, calibration, multiple channels
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Averaging, continuous mode, monitor thresholds
-static constexpr bool ENABLE_PERFORMANCE_TESTS = true;    // Error handling, statistics, performance
+static constexpr bool ENABLE_CORE_TESTS =
+    true; // Hardware validation, initialization, configuration
+static constexpr bool ENABLE_CONVERSION_TESTS =
+    true; // Basic conversion, calibration, multiple channels
+static constexpr bool ENABLE_ADVANCED_TESTS =
+    true; // Averaging, continuous mode, monitor thresholds
+static constexpr bool ENABLE_PERFORMANCE_TESTS = true; // Error handling, statistics, performance
 
 // Forward declarations
 bool test_hardware_validation() noexcept;
@@ -1201,13 +1204,12 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("continuous_mode", test_adc_continuous_mode, 8192, 1);
       RUN_TEST_IN_TASK("monitor_thresholds", test_adc_monitor_thresholds, 8192, 1););
 
-  RUN_TEST_SECTION_IF_ENABLED(
-      ENABLE_PERFORMANCE_TESTS, "ADC PERFORMANCE TESTS",
-      // Performance and error handling tests
-      ESP_LOGI(TAG, "Running performance and error handling tests...");
-      RUN_TEST_IN_TASK("error_handling", test_adc_error_handling, 8192, 1);
-      RUN_TEST_IN_TASK("statistics", test_adc_statistics, 8192, 1);
-      RUN_TEST_IN_TASK("performance", test_adc_performance, 8192, 1););
+  RUN_TEST_SECTION_IF_ENABLED(ENABLE_PERFORMANCE_TESTS, "ADC PERFORMANCE TESTS",
+                              // Performance and error handling tests
+                              ESP_LOGI(TAG, "Running performance and error handling tests...");
+                              RUN_TEST_IN_TASK("error_handling", test_adc_error_handling, 8192, 1);
+                              RUN_TEST_IN_TASK("statistics", test_adc_statistics, 8192, 1);
+                              RUN_TEST_IN_TASK("performance", test_adc_performance, 8192, 1););
 
   print_test_summary(g_test_results, "ADC", TAG);
 

--- a/examples/esp32/main/AsciiArtComprehensiveTest.cpp
+++ b/examples/esp32/main/AsciiArtComprehensiveTest.cpp
@@ -37,11 +37,11 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core ASCII art functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Basic generation, uppercase conversion
-static constexpr bool ENABLE_CHARACTER_TESTS = true;      // Special characters, numbers, symbols
-static constexpr bool ENABLE_EDGE_CASE_TESTS = true;      // Empty cases, edge cases
-static constexpr bool ENABLE_CUSTOM_TESTS = true;         // Custom character management, validation
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Complex text generation, performance
+static constexpr bool ENABLE_CORE_TESTS = true;      // Basic generation, uppercase conversion
+static constexpr bool ENABLE_CHARACTER_TESTS = true; // Special characters, numbers, symbols
+static constexpr bool ENABLE_EDGE_CASE_TESTS = true; // Empty cases, edge cases
+static constexpr bool ENABLE_CUSTOM_TESTS = true;    // Custom character management, validation
+static constexpr bool ENABLE_ADVANCED_TESTS = true;  // Complex text generation, performance
 
 // Forward declarations
 bool test_basic_ascii_art_generation() noexcept;

--- a/examples/esp32/main/BluetoothComprehensiveTest.cpp
+++ b/examples/esp32/main/BluetoothComprehensiveTest.cpp
@@ -33,9 +33,9 @@ static EspBluetooth bluetooth_instance;
 // Enable/disable specific test categories by setting to true or false
 
 // Core Bluetooth functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Initialization, basic operations
-static constexpr bool ENABLE_SCANNING_TESTS = true;       // Scanning, device discovery
-static constexpr bool ENABLE_MANAGEMENT_TESTS = true;     // State management, cleanup
+static constexpr bool ENABLE_CORE_TESTS = true;       // Initialization, basic operations
+static constexpr bool ENABLE_SCANNING_TESTS = true;   // Scanning, device discovery
+static constexpr bool ENABLE_MANAGEMENT_TESTS = true; // State management, cleanup
 
 // Event callback function for Bluetooth events
 void bluetooth_event_callback(hf_bluetooth_event_t event, void* event_data) noexcept {
@@ -334,11 +334,10 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("initialization", test_bluetooth_initialization, 8192, 1);
       RUN_TEST_IN_TASK("basic_operations", test_bluetooth_basic_operations, 8192, 1););
 
-  RUN_TEST_SECTION_IF_ENABLED(
-      ENABLE_SCANNING_TESTS, "BLUETOOTH SCANNING TESTS",
-      // Scanning tests
-      ESP_LOGI(TAG, "Running Bluetooth scanning tests...");
-      RUN_TEST_IN_TASK("scanning", test_bluetooth_scanning, 8192, 1););
+  RUN_TEST_SECTION_IF_ENABLED(ENABLE_SCANNING_TESTS, "BLUETOOTH SCANNING TESTS",
+                              // Scanning tests
+                              ESP_LOGI(TAG, "Running Bluetooth scanning tests...");
+                              RUN_TEST_IN_TASK("scanning", test_bluetooth_scanning, 8192, 1););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_MANAGEMENT_TESTS, "BLUETOOTH MANAGEMENT TESTS",

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -85,11 +85,12 @@ static hf_can_message_t last_received_message{};
 // Enable/disable specific test categories by setting to true or false
 
 // Core CAN functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Initialization, self-test, message transmission
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Acceptance filtering, advanced timing
-static constexpr bool ENABLE_ERROR_TESTS = true;          // Error handling, bus recovery
-static constexpr bool ENABLE_PERFORMANCE_TESTS = true;    // Batch transmission, high throughput
-static constexpr bool ENABLE_TRANSCEIVER_TESTS = true;    // SN65 transceiver integration, signal quality
+static constexpr bool ENABLE_CORE_TESTS = true; // Initialization, self-test, message transmission
+static constexpr bool ENABLE_ADVANCED_TESTS = true;    // Acceptance filtering, advanced timing
+static constexpr bool ENABLE_ERROR_TESTS = true;       // Error handling, bus recovery
+static constexpr bool ENABLE_PERFORMANCE_TESTS = true; // Batch transmission, high throughput
+static constexpr bool ENABLE_TRANSCEIVER_TESTS =
+    true; // SN65 transceiver integration, signal quality
 
 //=============================================================================
 // TEST HELPER FUNCTIONS
@@ -900,12 +901,11 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("acceptance_filtering", test_can_acceptance_filtering, 8192, 1);
       RUN_TEST_IN_TASK("advanced_timing", test_can_advanced_timing, 8192, 1););
 
-  RUN_TEST_SECTION_IF_ENABLED(
-      ENABLE_ERROR_TESTS, "CAN ERROR TESTS",
-      // Error handling tests
-      ESP_LOGI(TAG, "Running CAN error handling tests...");
-      RUN_TEST_IN_TASK("error_handling", test_can_error_handling, 8192, 1);
-      RUN_TEST_IN_TASK("bus_recovery", test_can_bus_recovery, 8192, 1););
+  RUN_TEST_SECTION_IF_ENABLED(ENABLE_ERROR_TESTS, "CAN ERROR TESTS",
+                              // Error handling tests
+                              ESP_LOGI(TAG, "Running CAN error handling tests...");
+                              RUN_TEST_IN_TASK("error_handling", test_can_error_handling, 8192, 1);
+                              RUN_TEST_IN_TASK("bus_recovery", test_can_bus_recovery, 8192, 1););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_PERFORMANCE_TESTS, "CAN PERFORMANCE TESTS",

--- a/examples/esp32/main/GpioComprehensiveTest.cpp
+++ b/examples/esp32/main/GpioComprehensiveTest.cpp
@@ -65,12 +65,15 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core GPIO functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Basic functionality, initialization, I/O operations
-static constexpr bool ENABLE_INTERRUPT_TESTS = true;      // Interrupt functionality and loopback
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Advanced features, drive capabilities, RTC
-static constexpr bool ENABLE_ESP_SPECIFIC_TESTS = true;   // ESP32-C6 specific features (glitch filters, sleep, hold)
-static constexpr bool ENABLE_ROBUSTNESS_TESTS = true;     // Error handling, validation, stress testing
-static constexpr bool ENABLE_SPECIALIZED_TESTS = true;    // Loopback operations, concurrent operations, diagnostics
+static constexpr bool ENABLE_CORE_TESTS =
+    true; // Basic functionality, initialization, I/O operations
+static constexpr bool ENABLE_INTERRUPT_TESTS = true; // Interrupt functionality and loopback
+static constexpr bool ENABLE_ADVANCED_TESTS = true;  // Advanced features, drive capabilities, RTC
+static constexpr bool ENABLE_ESP_SPECIFIC_TESTS =
+    true; // ESP32-C6 specific features (glitch filters, sleep, hold)
+static constexpr bool ENABLE_ROBUSTNESS_TESTS = true; // Error handling, validation, stress testing
+static constexpr bool ENABLE_SPECIALIZED_TESTS =
+    true; // Loopback operations, concurrent operations, diagnostics
 
 // Forward declarations of test functions
 bool test_basic_gpio_functionality() noexcept;
@@ -1365,7 +1368,8 @@ extern "C" void app_main(void) {
       // Basic functionality tests
       ESP_LOGI(TAG, "Running basic GPIO functionality tests...");
       RUN_TEST_IN_TASK("basic_functionality", test_basic_gpio_functionality, 8192, 1);
-      RUN_TEST_IN_TASK("initialization_config", test_gpio_initialization_and_configuration, 8192, 1);
+      RUN_TEST_IN_TASK("initialization_config", test_gpio_initialization_and_configuration, 8192,
+                       1);
       RUN_TEST_IN_TASK("input_output_ops", test_gpio_input_output_operations, 8192, 1);
       RUN_TEST_IN_TASK("pull_resistors", test_gpio_pull_resistors, 8192, 1););
 

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -2421,27 +2421,29 @@ extern "C" void app_main(void) {
       // ESP-IDF verification tests
       ESP_LOGI(TAG, "Running ESP-IDF verification tests...");
       RUN_TEST_IN_TASK("espidf_direct_api", test_i2c_espidf_direct_api, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("espidf_wrapper_replica", test_i2c_espidf_wrapper_replica, 8192, 1);
- RUN_TEST_IN_TASK(
-          "espidf_wrapper_continuous", test_i2c_espidf_wrapper_replica_continuous, 8192, 1);
+      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("espidf_wrapper_continuous", test_i2c_espidf_wrapper_replica_continuous, 8192, 1);
+      flip_test_progress_indicator();
 
 
       // Bus and device tests
       ESP_LOGI(TAG, "Running bus and device tests...");
       RUN_TEST_IN_TASK("bus_initialization", test_i2c_bus_initialization, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("bus_deinitialization", test_i2c_bus_deinitialization, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("configuration_validation", test_i2c_configuration_validation, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("device_creation", test_i2c_device_creation, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("device_management", test_i2c_device_management, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("device_probing", test_i2c_device_probing, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("bus_scanning", test_i2c_bus_scanning, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2449,19 +2451,20 @@ extern "C" void app_main(void) {
       // Read/write operations
       ESP_LOGI(TAG, "Running read/write operation tests...");
       RUN_TEST_IN_TASK("write_operations", test_i2c_write_operations, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("read_operations", test_i2c_read_operations, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("write_read_operations", test_i2c_write_read_operations, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Error handling and timeouts
       ESP_LOGI(TAG, "Running error handling and timeout tests...");
       RUN_TEST_IN_TASK("error_handling", test_i2c_error_handling, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("timeout_handling", test_i2c_timeout_handling, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("multi_device_operations", test_i2c_multi_device_operations, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2469,15 +2472,16 @@ extern "C" void app_main(void) {
       // ESP-specific features
       ESP_LOGI(TAG, "Running ESP-specific feature tests...");
       RUN_TEST_IN_TASK("esp_specific_features", test_i2c_esp_specific_features, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("thread_safety", test_i2c_thread_safety, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Clock speeds and address modes
       ESP_LOGI(TAG, "Running clock speed and address mode tests...");
       RUN_TEST_IN_TASK("clock_speeds", test_i2c_clock_speeds, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("address_modes", test_i2c_address_modes, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2485,9 +2489,11 @@ extern "C" void app_main(void) {
       // Performance and edge cases
       ESP_LOGI(TAG, "Running performance and edge case tests...");
       RUN_TEST_IN_TASK("performance", test_i2c_performance, 8192, 1);
- RUN_TEST_IN_TASK("edge_cases", test_i2c_edge_cases, 8192, 1);
-
+      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("edge_cases", test_i2c_edge_cases, 8192, 1);
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("power_management", test_i2c_power_management, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2495,23 +2501,27 @@ extern "C" void app_main(void) {
       // Async operations
       ESP_LOGI(TAG, "Running async operation tests...");
       RUN_TEST_IN_TASK("async_operations", test_i2c_async_operations, 16384, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("async_timeout_handling", test_i2c_async_timeout_handling, 16384, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("async_multiple_operations", test_i2c_async_multiple_operations, 16384, 1);
+      flip_test_progress_indicator();
 
 
       // Mode and access patterns
       ESP_LOGI(TAG, "Running mode and access pattern tests...");
       RUN_TEST_IN_TASK("index_based_access", test_i2c_index_based_access, 8192, 1);
- RUN_TEST_IN_TASK("sync_mode", test_i2c_sync_mode, 8192, 1);
- RUN_TEST_IN_TASK("async_mode", test_i2c_async_mode, 8192, 1);
-
+      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("sync_mode", test_i2c_sync_mode, 8192, 1);
+      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("async_mode", test_i2c_async_mode, 8192, 1);
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("mode_switching", test_i2c_mode_switching, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("basic_functionality", test_i2c_basic_functionality, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("probe_methods_comparison", test_i2c_probe_methods_comparison, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   print_test_summary(g_test_results, "I2C", TAG);

--- a/examples/esp32/main/I2cComprehensiveTest.cpp
+++ b/examples/esp32/main/I2cComprehensiveTest.cpp
@@ -53,7 +53,6 @@ static TestResults g_test_results;
 //=============================================================================
 // TEST PROGRESSION INDICATOR
 
-
 //=============================================================================
 // TEST CONFIGURATION
 //=============================================================================
@@ -173,8 +172,6 @@ void log_test_separator(const char* test_name) noexcept;
 //=============================================================================
 // TEST FUNCTIONS IMPLEMENTATION
 //=============================================================================
-
-
 
 bool test_i2c_bus_initialization() noexcept {
   log_test_separator("I2C Bus Initialization");
@@ -2423,10 +2420,9 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("espidf_direct_api", test_i2c_espidf_direct_api, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("espidf_wrapper_replica", test_i2c_espidf_wrapper_replica, 8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "espidf_wrapper_continuous", test_i2c_espidf_wrapper_replica_continuous, 8192, 1);
       flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("espidf_wrapper_continuous", test_i2c_espidf_wrapper_replica_continuous, 8192, 1);
-      flip_test_progress_indicator();
-
 
       // Bus and device tests
       ESP_LOGI(TAG, "Running bus and device tests...");
@@ -2443,8 +2439,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("device_probing", test_i2c_device_probing, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("bus_scanning", test_i2c_bus_scanning, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_OPERATION_TESTS, "I2C OPERATION TESTS",
@@ -2464,8 +2459,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("timeout_handling", test_i2c_timeout_handling, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("multi_device_operations", test_i2c_multi_device_operations, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ADVANCED_TESTS, "I2C ADVANCED TESTS",
@@ -2481,20 +2475,17 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("clock_speeds", test_i2c_clock_speeds, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("address_modes", test_i2c_address_modes, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_PERFORMANCE_TESTS, "I2C PERFORMANCE TESTS",
       // Performance and edge cases
       ESP_LOGI(TAG, "Running performance and edge case tests...");
       RUN_TEST_IN_TASK("performance", test_i2c_performance, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("edge_cases", test_i2c_edge_cases, 8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK("edge_cases", test_i2c_edge_cases, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("power_management", test_i2c_power_management, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_SPECIALIZED_TESTS, "I2C SPECIALIZED TESTS",
@@ -2507,22 +2498,18 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("async_multiple_operations", test_i2c_async_multiple_operations, 16384, 1);
       flip_test_progress_indicator();
 
-
       // Mode and access patterns
       ESP_LOGI(TAG, "Running mode and access pattern tests...");
       RUN_TEST_IN_TASK("index_based_access", test_i2c_index_based_access, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("sync_mode", test_i2c_sync_mode, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("async_mode", test_i2c_async_mode, 8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK("sync_mode", test_i2c_sync_mode, 8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK("async_mode", test_i2c_async_mode, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("mode_switching", test_i2c_mode_switching, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("basic_functionality", test_i2c_basic_functionality, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("probe_methods_comparison", test_i2c_probe_methods_comparison, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   print_test_summary(g_test_results, "I2C", TAG);
 

--- a/examples/esp32/main/LoggerComprehensiveTest.cpp
+++ b/examples/esp32/main/LoggerComprehensiveTest.cpp
@@ -39,11 +39,13 @@ static std::unique_ptr<EspLogger> g_logger_instance = nullptr;
 // Enable/disable specific test categories by setting to true or false
 
 // Core logger functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Construction, initialization, basic logging
-static constexpr bool ENABLE_LEVEL_TESTS = true;          // Level management, formatted logging
-static constexpr bool ENABLE_FEATURE_TESTS = true;        // Log V2 features, buffer logging, location logging
-static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Statistics, diagnostics, health monitoring
-static constexpr bool ENABLE_STRESS_TESTS = true;         // Error handling, performance testing, utility functions
+static constexpr bool ENABLE_CORE_TESTS = true;  // Construction, initialization, basic logging
+static constexpr bool ENABLE_LEVEL_TESTS = true; // Level management, formatted logging
+static constexpr bool ENABLE_FEATURE_TESTS =
+    true; // Log V2 features, buffer logging, location logging
+static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true; // Statistics, diagnostics, health monitoring
+static constexpr bool ENABLE_STRESS_TESTS =
+    true; // Error handling, performance testing, utility functions
 
 // Forward declarations
 bool test_logger_construction() noexcept;

--- a/examples/esp32/main/NvsComprehensiveTest.cpp
+++ b/examples/esp32/main/NvsComprehensiveTest.cpp
@@ -37,11 +37,12 @@ static const uint8_t TEST_BLOB_DATA[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0
 // Enable/disable specific test categories by setting to true or false
 
 // Core NVS functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Initialization, deinitialization, basic operations
-static constexpr bool ENABLE_DATA_TESTS = true;           // U32, string, blob operations
-static constexpr bool ENABLE_MANAGEMENT_TESTS = true;     // Key operations, commit operations
-static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Statistics, diagnostics, metadata
-static constexpr bool ENABLE_STRESS_TESTS = true;         // Edge cases, stress testing
+static constexpr bool ENABLE_CORE_TESTS =
+    true; // Initialization, deinitialization, basic operations
+static constexpr bool ENABLE_DATA_TESTS = true;       // U32, string, blob operations
+static constexpr bool ENABLE_MANAGEMENT_TESTS = true; // Key operations, commit operations
+static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true; // Statistics, diagnostics, metadata
+static constexpr bool ENABLE_STRESS_TESTS = true;     // Edge cases, stress testing
 
 // === Initialization and Deinitialization Tests ===
 
@@ -1096,12 +1097,11 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("statistics_diagnostics", test_nvs_statistics_diagnostics, 8192, 1);
       RUN_TEST_IN_TASK("metadata", test_nvs_metadata, 8192, 1););
 
-  RUN_TEST_SECTION_IF_ENABLED(
-      ENABLE_STRESS_TESTS, "NVS STRESS TESTS",
-      // Stress and edge case tests
-      ESP_LOGI(TAG, "Running NVS stress tests...");
-      RUN_TEST_IN_TASK("edge_cases", test_nvs_edge_cases, 8192, 1);
-      RUN_TEST_IN_TASK("stress", test_nvs_stress, 8192, 1););
+  RUN_TEST_SECTION_IF_ENABLED(ENABLE_STRESS_TESTS, "NVS STRESS TESTS",
+                              // Stress and edge case tests
+                              ESP_LOGI(TAG, "Running NVS stress tests...");
+                              RUN_TEST_IN_TASK("edge_cases", test_nvs_edge_cases, 8192, 1);
+                              RUN_TEST_IN_TASK("stress", test_nvs_stress, 8192, 1););
 
   // Print summary
   print_test_summary(g_test_results, "NVS", TAG);

--- a/examples/esp32/main/PioComprehensiveTest.cpp
+++ b/examples/esp32/main/PioComprehensiveTest.cpp
@@ -50,19 +50,17 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core PIO functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Constructor/destructor, lifecycle, initialization
-static constexpr bool ENABLE_VARIANT_TESTS = true;        // ESP32 variant detection, channel allocation
-static constexpr bool ENABLE_CHANNEL_TESTS = true;        // Channel configuration, multiple channels
-static constexpr bool ENABLE_TRANSMISSION_TESTS = true;   // Basic symbol transmission, edge cases
-static constexpr bool ENABLE_WS2812_TESTS = true;         // WS2812 LED protocol, color testing
-static constexpr bool ENABLE_ANALYZER_TESTS = true;       // Logic analyzer patterns, frequency sweep
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Advanced RMT features, encoder, carrier
-static constexpr bool ENABLE_LOOPBACK_TESTS = true;       // Loopback functionality, hardware loopback
-static constexpr bool ENABLE_CALLBACK_TESTS = true;       // Channel-specific callbacks
-static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Statistics, diagnostics, system validation
-static constexpr bool ENABLE_STRESS_TESTS = true;         // Stress transmission, performance
-
-
+static constexpr bool ENABLE_CORE_TESTS = true; // Constructor/destructor, lifecycle, initialization
+static constexpr bool ENABLE_VARIANT_TESTS = true; // ESP32 variant detection, channel allocation
+static constexpr bool ENABLE_CHANNEL_TESTS = true; // Channel configuration, multiple channels
+static constexpr bool ENABLE_TRANSMISSION_TESTS = true; // Basic symbol transmission, edge cases
+static constexpr bool ENABLE_WS2812_TESTS = true;       // WS2812 LED protocol, color testing
+static constexpr bool ENABLE_ANALYZER_TESTS = true;     // Logic analyzer patterns, frequency sweep
+static constexpr bool ENABLE_ADVANCED_TESTS = true;     // Advanced RMT features, encoder, carrier
+static constexpr bool ENABLE_LOOPBACK_TESTS = true;     // Loopback functionality, hardware loopback
+static constexpr bool ENABLE_CALLBACK_TESTS = true;     // Channel-specific callbacks
+static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true; // Statistics, diagnostics, system validation
+static constexpr bool ENABLE_STRESS_TESTS = true;     // Stress transmission, performance
 
 //==============================================================================
 // WS2812 PROTOCOL CONSTANTS (for RGB LED testing)
@@ -85,8 +83,6 @@ static constexpr hf_gpio_num_t TEST_GPIO_RX = 18; // GPIO18 for reception (RMT c
 static constexpr uint32_t TEST_RESOLUTION_WS2812_NS = 125;   // 8 MHz -> 125ns per tick
 static constexpr uint32_t TEST_RESOLUTION_STANDARD_NS = 500; // 2 MHz -> 500ns per tick
 static constexpr uint32_t TEST_RESOLUTION_LOW_NS = 10000;    // 100 kHz -> 10µs per tick
-
-
 
 //==============================================================================
 // CALLBACK TEST INFRASTRUCTURE
@@ -2088,8 +2084,7 @@ extern "C" void app_main() {
       RUN_TEST_IN_TASK("channel_direction_validation", test_channel_direction_validation, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("resolution_ns_usage", test_resolution_ns_usage, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CORE_TESTS, "PIO CORE TESTS",
@@ -2105,18 +2100,16 @@ extern "C" void app_main() {
       RUN_TEST_IN_TASK("initialization_states", test_initialization_states, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("lazy_initialization", test_lazy_initialization, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CHANNEL_TESTS, "PIO CHANNEL TESTS",
       // Channel Configuration Tests
       ESP_LOGI(TAG, "Running channel configuration tests...");
       RUN_TEST_IN_TASK("channel_configuration", test_channel_configuration, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("multiple_channel_configuration", test_multiple_channel_configuration, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "multiple_channel_configuration", test_multiple_channel_configuration, 8192, 1);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_TRANSMISSION_TESTS, "PIO TRANSMISSION TESTS",
@@ -2125,8 +2118,7 @@ extern "C" void app_main() {
       RUN_TEST_IN_TASK("basic_symbol_transmission", test_basic_symbol_transmission, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("transmission_edge_cases", test_transmission_edge_cases, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_WS2812_TESTS, "PIO WS2812 TESTS",
@@ -2144,8 +2136,7 @@ extern "C" void app_main() {
       RUN_TEST_IN_TASK("ws2812_pattern_validation", test_ws2812_pattern_validation, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("ws2812_rainbow_transition", test_ws2812_rainbow_transition, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ANALYZER_TESTS, "PIO ANALYZER TESTS",
@@ -2154,8 +2145,7 @@ extern "C" void app_main() {
       RUN_TEST_IN_TASK("logic_analyzer_patterns", test_logic_analyzer_patterns, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("frequency_sweep", test_frequency_sweep, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ADVANCED_TESTS, "PIO ADVANCED TESTS",
@@ -2166,26 +2156,23 @@ extern "C" void app_main() {
       RUN_TEST_IN_TASK("rmt_carrier_modulation", test_rmt_carrier_modulation, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("rmt_advanced_configuration", test_rmt_advanced_configuration, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_LOOPBACK_TESTS, "PIO LOOPBACK TESTS",
       // Loopback and Reception Tests
       ESP_LOGI(TAG, "Running loopback and reception tests...");
       RUN_TEST_IN_TASK("loopback_functionality", test_loopback_functionality, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("hardware_loopback_gpio8_to_gpio18", test_hardware_loopback_gpio8_to_gpio18, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "hardware_loopback_gpio8_to_gpio18", test_hardware_loopback_gpio8_to_gpio18, 8192, 1);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CALLBACK_TESTS, "PIO CALLBACK TESTS",
       // Callback Tests
       ESP_LOGI(TAG, "Running callback tests...");
       RUN_TEST_IN_TASK("callback_functionality", test_callback_functionality, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_DIAGNOSTIC_TESTS, "PIO DIAGNOSTIC TESTS",
@@ -2197,16 +2184,14 @@ extern "C" void app_main() {
       // System Validation
       ESP_LOGI(TAG, "Running system validation tests...");
       RUN_TEST_IN_TASK("pio_system_validation", test_pio_system_validation, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_STRESS_TESTS, "PIO STRESS TESTS",
       // Stress and Performance Tests
       ESP_LOGI(TAG, "Running stress and performance tests...");
       RUN_TEST_IN_TASK("stress_transmission", test_stress_transmission, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   // Print final summary
   print_test_summary(g_test_results, "PIO", TAG);

--- a/examples/esp32/main/PioComprehensiveTest.cpp
+++ b/examples/esp32/main/PioComprehensiveTest.cpp
@@ -2082,12 +2082,13 @@ extern "C" void app_main() {
       // ESP32 Variant Information Tests
       ESP_LOGI(TAG, "Running ESP32 variant information tests...");
       RUN_TEST_IN_TASK("variant_detection", test_esp32_variant_detection, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("channel_allocation_helpers", test_channel_allocation_helpers, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("channel_direction_validation", test_channel_direction_validation, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("resolution_ns_usage", test_resolution_ns_usage, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2095,15 +2096,16 @@ extern "C" void app_main() {
       // Constructor/Destructor Tests
       ESP_LOGI(TAG, "Running constructor/destructor tests...");
       RUN_TEST_IN_TASK("constructor_default", test_constructor_default, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("destructor_cleanup", test_destructor_cleanup, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Lifecycle Tests
       ESP_LOGI(TAG, "Running lifecycle tests...");
       RUN_TEST_IN_TASK("initialization_states", test_initialization_states, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("lazy_initialization", test_lazy_initialization, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2111,8 +2113,9 @@ extern "C" void app_main() {
       // Channel Configuration Tests
       ESP_LOGI(TAG, "Running channel configuration tests...");
       RUN_TEST_IN_TASK("channel_configuration", test_channel_configuration, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("multiple_channel_configuration", test_multiple_channel_configuration, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2120,8 +2123,9 @@ extern "C" void app_main() {
       // Basic Transmission Tests
       ESP_LOGI(TAG, "Running basic transmission tests...");
       RUN_TEST_IN_TASK("basic_symbol_transmission", test_basic_symbol_transmission, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("transmission_edge_cases", test_transmission_edge_cases, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2129,16 +2133,18 @@ extern "C" void app_main() {
       // WS2812 LED Protocol Tests
       ESP_LOGI(TAG, "Running WS2812 LED protocol tests...");
       RUN_TEST_IN_TASK("ws2812_single_led", test_ws2812_single_led, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("ws2812_multiple_leds", test_ws2812_multiple_leds, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("ws2812_color_cycle", test_ws2812_color_cycle, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("ws2812_brightness_sweep", test_ws2812_brightness_sweep, 8192, 1);
+      flip_test_progress_indicator();
 
       RUN_TEST_IN_TASK("ws2812_pattern_validation", test_ws2812_pattern_validation, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("ws2812_rainbow_transition", test_ws2812_rainbow_transition, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2146,8 +2152,9 @@ extern "C" void app_main() {
       // Logic Analyzer Test Scenarios
       ESP_LOGI(TAG, "Running logic analyzer test scenarios...");
       RUN_TEST_IN_TASK("logic_analyzer_patterns", test_logic_analyzer_patterns, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("frequency_sweep", test_frequency_sweep, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2155,10 +2162,11 @@ extern "C" void app_main() {
       // Advanced RMT Feature Tests
       ESP_LOGI(TAG, "Running advanced RMT feature tests...");
       RUN_TEST_IN_TASK("rmt_encoder_configuration", test_rmt_encoder_configuration, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("rmt_carrier_modulation", test_rmt_carrier_modulation, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("rmt_advanced_configuration", test_rmt_advanced_configuration, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2166,8 +2174,9 @@ extern "C" void app_main() {
       // Loopback and Reception Tests
       ESP_LOGI(TAG, "Running loopback and reception tests...");
       RUN_TEST_IN_TASK("loopback_functionality", test_loopback_functionality, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("hardware_loopback_gpio8_to_gpio18", test_hardware_loopback_gpio8_to_gpio18, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2175,6 +2184,7 @@ extern "C" void app_main() {
       // Callback Tests
       ESP_LOGI(TAG, "Running callback tests...");
       RUN_TEST_IN_TASK("callback_functionality", test_callback_functionality, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2182,11 +2192,12 @@ extern "C" void app_main() {
       // Statistics and Diagnostics Tests
       ESP_LOGI(TAG, "Running statistics and diagnostics tests...");
       RUN_TEST_IN_TASK("statistics_and_diagnostics", test_statistics_and_diagnostics, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // System Validation
       ESP_LOGI(TAG, "Running system validation tests...");
       RUN_TEST_IN_TASK("pio_system_validation", test_pio_system_validation, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2194,6 +2205,7 @@ extern "C" void app_main() {
       // Stress and Performance Tests
       ESP_LOGI(TAG, "Running stress and performance tests...");
       RUN_TEST_IN_TASK("stress_transmission", test_stress_transmission, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   // Print final summary

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -2806,15 +2806,17 @@ extern "C" void app_main(void) {
       // Constructor/Destructor Tests
       ESP_LOGI(TAG, "Running constructor/destructor tests...");
       RUN_TEST_IN_TASK("constructor_default", test_constructor_default, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("destructor_cleanup", test_destructor_cleanup, 8192, 1);
+      flip_test_progress_indicator();
 
 
       // Lifecycle Tests
       ESP_LOGI(TAG, "Running lifecycle tests...");
       RUN_TEST_IN_TASK("initialization_states", test_initialization_states, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("lazy_initialization", test_lazy_initialization, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2822,10 +2824,11 @@ extern "C" void app_main(void) {
       // Configuration Tests
       ESP_LOGI(TAG, "Running configuration tests...");
       RUN_TEST_IN_TASK("mode_configuration", test_mode_configuration, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("clock_source_configuration", test_clock_source_configuration, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("basic_mode_without_fade", test_basic_mode_without_fade, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2833,8 +2836,9 @@ extern "C" void app_main(void) {
       // Channel Management Tests
       ESP_LOGI(TAG, "Running channel management tests...");
       RUN_TEST_IN_TASK("channel_configuration", test_channel_configuration, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("channel_enable_disable", test_channel_enable_disable, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2842,10 +2846,11 @@ extern "C" void app_main(void) {
       // PWM Control Tests
       ESP_LOGI(TAG, "Running PWM control tests...");
       RUN_TEST_IN_TASK("duty_cycle_control", test_duty_cycle_control, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("frequency_control", test_frequency_control, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("phase_shift_control", test_phase_shift_control, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2853,8 +2858,9 @@ extern "C" void app_main(void) {
       // Advanced Features Tests
       ESP_LOGI(TAG, "Running advanced feature tests...");
       RUN_TEST_IN_TASK("synchronized_operations", test_synchronized_operations, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("complementary_outputs", test_complementary_outputs, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2862,12 +2868,13 @@ extern "C" void app_main(void) {
       // ESP32-Specific Features Tests
       ESP_LOGI(TAG, "Running ESP32-specific feature tests...");
       RUN_TEST_IN_TASK("hardware_fade", test_hardware_fade, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("fade_mode_functionality", test_fade_mode_functionality, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("idle_level_control", test_idle_level_control, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("timer_management", test_timer_management, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2875,16 +2882,17 @@ extern "C" void app_main(void) {
       // Resolution and Validation Tests
       ESP_LOGI(TAG, "Running resolution and validation tests...");
       RUN_TEST_IN_TASK("resolution_specific_duty_cycles", test_resolution_specific_duty_cycles, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("frequency_resolution_validation", test_frequency_resolution_validation, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("enhanced_validation_system", test_enhanced_validation_system, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("percentage_consistency_across_resolutions", test_percentage_consistency_across_resolutions, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("resolution_control_methods", test_resolution_control_methods, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("resolution_aware_duty_calculations", test_resolution_aware_duty_calculations, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2892,13 +2900,14 @@ extern "C" void app_main(void) {
       // Status and Diagnostics Tests
       ESP_LOGI(TAG, "Running status and diagnostics tests...");
       RUN_TEST_IN_TASK("status_reporting", test_status_reporting, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("statistics_and_diagnostics", test_statistics_and_diagnostics, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Callback Tests
       ESP_LOGI(TAG, "Running callback tests...");
       RUN_TEST_IN_TASK("callbacks", test_callbacks, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2906,18 +2915,19 @@ extern "C" void app_main(void) {
       // Edge Cases and Stress Tests
       ESP_LOGI(TAG, "Running edge cases and stress tests...");
       RUN_TEST_IN_TASK("edge_cases", test_edge_cases, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("stress_scenarios", test_stress_scenarios, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Advanced Timer Management Tests
       ESP_LOGI(TAG, "Running advanced timer management tests...");
       RUN_TEST_IN_TASK("timer_health_check_and_recovery", test_timer_health_check_and_recovery, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Critical Safety Tests
       ESP_LOGI(TAG, "Running critical safety tests...");
       RUN_TEST_IN_TASK("safe_eviction_policies", test_safe_eviction_policies, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   // Print final summary

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -57,60 +57,13 @@ static constexpr bool ENABLE_RESOLUTION_TESTS = true;     // Resolution-specific
 static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Status reporting, statistics, callbacks
 static constexpr bool ENABLE_STRESS_TESTS = true;         // Edge cases, stress scenarios, safety tests
 
-// Test progression indicator GPIO
-static EspGpio* g_test_progress_gpio = nullptr;
-static bool g_test_progress_state = false;
+
 
 //==============================================================================
 // HELPER FUNCTIONS
 //==============================================================================
 
-/**
- * @brief Initialize the test progression indicator GPIO
- */
-bool init_test_progress_indicator() noexcept {
-  // Use GPIO14 as the test progression indicator (visible LED on most ESP32 dev boards)
-  g_test_progress_gpio = new EspGpio(14, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
-                                     hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH);
 
-  if (!g_test_progress_gpio->EnsureInitialized()) {
-    ESP_LOGE(TAG, "Failed to initialize test progression indicator GPIO");
-    return false;
-  }
-
-  // Start with LOW state
-  g_test_progress_gpio->SetInactive();
-  g_test_progress_state = false;
-
-  ESP_LOGI(TAG, "Test progression indicator initialized on GPIO14");
-  return true;
-}
-
-/**
- * @brief Flip the test progression indicator to show next test
- */
-void flip_test_progress_indicator() noexcept {
-  if (g_test_progress_gpio) {
-    g_test_progress_state = !g_test_progress_state;
-    if (g_test_progress_state) {
-      g_test_progress_gpio->SetActive();
-    } else {
-      g_test_progress_gpio->SetInactive();
-    }
-    ESP_LOGI(TAG, "Test progression indicator: %s", g_test_progress_state ? "HIGH" : "LOW");
-  }
-}
-
-/**
- * @brief Cleanup the test progression indicator GPIO
- */
-void cleanup_test_progress_indicator() noexcept {
-  if (g_test_progress_gpio) {
-    g_test_progress_gpio->SetInactive(); // Ensure pin is low
-    delete g_test_progress_gpio;
-    g_test_progress_gpio = nullptr;
-  }
-}
 
 /**
  * @brief Create a default PWM configuration for testing
@@ -2842,13 +2795,7 @@ extern "C" void app_main(void) {
 
   vTaskDelay(pdMS_TO_TICKS(1000));
 
-  // Initialize test progression indicator GPIO14
-  // This pin will toggle between HIGH/LOW each time a test completes
-  // providing visual feedback for test progression on oscilloscope/logic analyzer
-  if (!init_test_progress_indicator()) {
-    ESP_LOGE(TAG,
-             "Failed to initialize test progression indicator GPIO. Tests may not be visible.");
-  }
+  // Test progression indicator is automatically initialized by the test framework
 
   // Report test section configuration
   print_test_section_status(TAG, "PWM");
@@ -2859,119 +2806,119 @@ extern "C" void app_main(void) {
       // Constructor/Destructor Tests
       ESP_LOGI(TAG, "Running constructor/destructor tests...");
       RUN_TEST_IN_TASK("constructor_default", test_constructor_default, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("destructor_cleanup", test_destructor_cleanup, 8192, 1);
-      flip_test_progress_indicator();
+
 
       // Lifecycle Tests
       ESP_LOGI(TAG, "Running lifecycle tests...");
       RUN_TEST_IN_TASK("initialization_states", test_initialization_states, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("lazy_initialization", test_lazy_initialization, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CONFIGURATION_TESTS, "PWM CONFIGURATION TESTS",
       // Configuration Tests
       ESP_LOGI(TAG, "Running configuration tests...");
       RUN_TEST_IN_TASK("mode_configuration", test_mode_configuration, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("clock_source_configuration", test_clock_source_configuration, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("basic_mode_without_fade", test_basic_mode_without_fade, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CHANNEL_TESTS, "PWM CHANNEL TESTS",
       // Channel Management Tests
       ESP_LOGI(TAG, "Running channel management tests...");
       RUN_TEST_IN_TASK("channel_configuration", test_channel_configuration, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("channel_enable_disable", test_channel_enable_disable, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CONTROL_TESTS, "PWM CONTROL TESTS",
       // PWM Control Tests
       ESP_LOGI(TAG, "Running PWM control tests...");
       RUN_TEST_IN_TASK("duty_cycle_control", test_duty_cycle_control, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("frequency_control", test_frequency_control, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("phase_shift_control", test_phase_shift_control, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ADVANCED_TESTS, "PWM ADVANCED TESTS",
       // Advanced Features Tests
       ESP_LOGI(TAG, "Running advanced feature tests...");
       RUN_TEST_IN_TASK("synchronized_operations", test_synchronized_operations, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("complementary_outputs", test_complementary_outputs, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ESP_SPECIFIC_TESTS, "PWM ESP-SPECIFIC TESTS",
       // ESP32-Specific Features Tests
       ESP_LOGI(TAG, "Running ESP32-specific feature tests...");
       RUN_TEST_IN_TASK("hardware_fade", test_hardware_fade, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("fade_mode_functionality", test_fade_mode_functionality, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("idle_level_control", test_idle_level_control, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("timer_management", test_timer_management, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_RESOLUTION_TESTS, "PWM RESOLUTION TESTS",
       // Resolution and Validation Tests
       ESP_LOGI(TAG, "Running resolution and validation tests...");
       RUN_TEST_IN_TASK("resolution_specific_duty_cycles", test_resolution_specific_duty_cycles, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("frequency_resolution_validation", test_frequency_resolution_validation, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("enhanced_validation_system", test_enhanced_validation_system, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("percentage_consistency_across_resolutions", test_percentage_consistency_across_resolutions, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("resolution_control_methods", test_resolution_control_methods, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("resolution_aware_duty_calculations", test_resolution_aware_duty_calculations, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_DIAGNOSTIC_TESTS, "PWM DIAGNOSTIC TESTS",
       // Status and Diagnostics Tests
       ESP_LOGI(TAG, "Running status and diagnostics tests...");
       RUN_TEST_IN_TASK("status_reporting", test_status_reporting, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("statistics_and_diagnostics", test_statistics_and_diagnostics, 8192, 1);
-      flip_test_progress_indicator();
+
 
       // Callback Tests
       ESP_LOGI(TAG, "Running callback tests...");
       RUN_TEST_IN_TASK("callbacks", test_callbacks, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_STRESS_TESTS, "PWM STRESS TESTS",
       // Edge Cases and Stress Tests
       ESP_LOGI(TAG, "Running edge cases and stress tests...");
       RUN_TEST_IN_TASK("edge_cases", test_edge_cases, 8192, 1);
-      flip_test_progress_indicator();
+
       RUN_TEST_IN_TASK("stress_scenarios", test_stress_scenarios, 8192, 1);
-      flip_test_progress_indicator();
+
 
       // Advanced Timer Management Tests
       ESP_LOGI(TAG, "Running advanced timer management tests...");
       RUN_TEST_IN_TASK("timer_health_check_and_recovery", test_timer_health_check_and_recovery, 8192, 1);
-      flip_test_progress_indicator();
+
 
       // Critical Safety Tests
       ESP_LOGI(TAG, "Running critical safety tests...");
       RUN_TEST_IN_TASK("safe_eviction_policies", test_safe_eviction_policies, 8192, 1);
-      flip_test_progress_indicator(););
+);
 
   // Print final summary
   ESP_LOGI(TAG, "\n");
@@ -2991,8 +2938,7 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG,
            "╚════════════════════════════════════════════════════════════════════════════════╝");
 
-  // Cleanup test progression indicator
-  cleanup_test_progress_indicator();
+  // Test progression indicator is automatically cleaned up by the test framework
 
   while (true) {
     vTaskDelay(pdMS_TO_TICKS(10000));

--- a/examples/esp32/main/PwmComprehensiveTest.cpp
+++ b/examples/esp32/main/PwmComprehensiveTest.cpp
@@ -47,23 +47,22 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core PWM functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Constructor/destructor, lifecycle, initialization
-static constexpr bool ENABLE_CONFIGURATION_TESTS = true;   // Mode, clock source, basic mode configuration
-static constexpr bool ENABLE_CHANNEL_TESTS = true;        // Channel management, enable/disable
-static constexpr bool ENABLE_CONTROL_TESTS = true;        // Duty cycle, frequency, phase shift control
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Synchronized operations, complementary outputs
-static constexpr bool ENABLE_ESP_SPECIFIC_TESTS = true;   // Hardware fade, idle levels, timer management
-static constexpr bool ENABLE_RESOLUTION_TESTS = true;     // Resolution-specific duty cycles, validation
-static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Status reporting, statistics, callbacks
-static constexpr bool ENABLE_STRESS_TESTS = true;         // Edge cases, stress scenarios, safety tests
-
-
+static constexpr bool ENABLE_CORE_TESTS = true; // Constructor/destructor, lifecycle, initialization
+static constexpr bool ENABLE_CONFIGURATION_TESTS =
+    true;                                          // Mode, clock source, basic mode configuration
+static constexpr bool ENABLE_CHANNEL_TESTS = true; // Channel management, enable/disable
+static constexpr bool ENABLE_CONTROL_TESTS = true; // Duty cycle, frequency, phase shift control
+static constexpr bool ENABLE_ADVANCED_TESTS =
+    true; // Synchronized operations, complementary outputs
+static constexpr bool ENABLE_ESP_SPECIFIC_TESTS =
+    true; // Hardware fade, idle levels, timer management
+static constexpr bool ENABLE_RESOLUTION_TESTS = true; // Resolution-specific duty cycles, validation
+static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true; // Status reporting, statistics, callbacks
+static constexpr bool ENABLE_STRESS_TESTS = true;     // Edge cases, stress scenarios, safety tests
 
 //==============================================================================
 // HELPER FUNCTIONS
 //==============================================================================
-
-
 
 /**
  * @brief Create a default PWM configuration for testing
@@ -2810,14 +2809,12 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("destructor_cleanup", test_destructor_cleanup, 8192, 1);
       flip_test_progress_indicator();
 
-
       // Lifecycle Tests
       ESP_LOGI(TAG, "Running lifecycle tests...");
       RUN_TEST_IN_TASK("initialization_states", test_initialization_states, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("lazy_initialization", test_lazy_initialization, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CONFIGURATION_TESTS, "PWM CONFIGURATION TESTS",
@@ -2828,8 +2825,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("clock_source_configuration", test_clock_source_configuration, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("basic_mode_without_fade", test_basic_mode_without_fade, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CHANNEL_TESTS, "PWM CHANNEL TESTS",
@@ -2838,8 +2834,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("channel_configuration", test_channel_configuration, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("channel_enable_disable", test_channel_enable_disable, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CONTROL_TESTS, "PWM CONTROL TESTS",
@@ -2850,8 +2845,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("frequency_control", test_frequency_control, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("phase_shift_control", test_phase_shift_control, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ADVANCED_TESTS, "PWM ADVANCED TESTS",
@@ -2860,8 +2854,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("synchronized_operations", test_synchronized_operations, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("complementary_outputs", test_complementary_outputs, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ESP_SPECIFIC_TESTS, "PWM ESP-SPECIFIC TESTS",
@@ -2874,26 +2867,26 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("idle_level_control", test_idle_level_control, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("timer_management", test_timer_management, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_RESOLUTION_TESTS, "PWM RESOLUTION TESTS",
       // Resolution and Validation Tests
       ESP_LOGI(TAG, "Running resolution and validation tests...");
-      RUN_TEST_IN_TASK("resolution_specific_duty_cycles", test_resolution_specific_duty_cycles, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("frequency_resolution_validation", test_frequency_resolution_validation, 8192, 1);
+      RUN_TEST_IN_TASK("resolution_specific_duty_cycles", test_resolution_specific_duty_cycles,
+                       8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "frequency_resolution_validation", test_frequency_resolution_validation, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("enhanced_validation_system", test_enhanced_validation_system, 8192, 1);
       flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("percentage_consistency_across_resolutions", test_percentage_consistency_across_resolutions, 8192, 1);
+      RUN_TEST_IN_TASK("percentage_consistency_across_resolutions",
+                       test_percentage_consistency_across_resolutions, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("resolution_control_methods", test_resolution_control_methods, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("resolution_aware_duty_calculations", test_resolution_aware_duty_calculations, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "resolution_aware_duty_calculations", test_resolution_aware_duty_calculations, 8192, 1);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_DIAGNOSTIC_TESTS, "PWM DIAGNOSTIC TESTS",
@@ -2906,29 +2899,25 @@ extern "C" void app_main(void) {
 
       // Callback Tests
       ESP_LOGI(TAG, "Running callback tests...");
-      RUN_TEST_IN_TASK("callbacks", test_callbacks, 8192, 1);
-      flip_test_progress_indicator();
-);
+      RUN_TEST_IN_TASK("callbacks", test_callbacks, 8192, 1); flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_STRESS_TESTS, "PWM STRESS TESTS",
       // Edge Cases and Stress Tests
       ESP_LOGI(TAG, "Running edge cases and stress tests...");
-      RUN_TEST_IN_TASK("edge_cases", test_edge_cases, 8192, 1);
-      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("edge_cases", test_edge_cases, 8192, 1); flip_test_progress_indicator();
       RUN_TEST_IN_TASK("stress_scenarios", test_stress_scenarios, 8192, 1);
       flip_test_progress_indicator();
 
       // Advanced Timer Management Tests
-      ESP_LOGI(TAG, "Running advanced timer management tests...");
-      RUN_TEST_IN_TASK("timer_health_check_and_recovery", test_timer_health_check_and_recovery, 8192, 1);
+      ESP_LOGI(TAG, "Running advanced timer management tests..."); RUN_TEST_IN_TASK(
+          "timer_health_check_and_recovery", test_timer_health_check_and_recovery, 8192, 1);
       flip_test_progress_indicator();
 
       // Critical Safety Tests
       ESP_LOGI(TAG, "Running critical safety tests...");
       RUN_TEST_IN_TASK("safe_eviction_policies", test_safe_eviction_policies, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   // Print final summary
   ESP_LOGI(TAG, "\n");

--- a/examples/esp32/main/SpiComprehensiveTest.cpp
+++ b/examples/esp32/main/SpiComprehensiveTest.cpp
@@ -52,7 +52,7 @@ static constexpr bool ENABLE_STRESS_TESTS =
     true; // Error handling, timeouts, edge cases, power management
 
 // NEW: Pure ESP-IDF vs C++ Wrapper comparison tests
-static constexpr bool ENABLE_ESPIDF_DIRECT_TEST = true; // Pure ESP-IDF SPI test (FIRST)
+static constexpr bool ENABLE_ESPIDF_DIRECT_TEST = true;     // Pure ESP-IDF SPI test (FIRST)
 static constexpr bool ENABLE_ESPIDF_WRAPPER_REPLICA = true; // C++ wrapper replica test (SECOND)
 
 // Test configuration constants
@@ -63,7 +63,8 @@ static constexpr hf_pin_num_t TEST_CS_PIN = 21; // Use CS_PIN_1 for the comparis
 static constexpr hf_pin_num_t TEST_CS_PIN_1 = 21;
 static constexpr hf_pin_num_t TEST_CS_PIN_2 = 20;
 static constexpr hf_pin_num_t TEST_CS_PIN_3 = 19;
-static constexpr hf_host_id_t SPI_HOST_NUM = static_cast<hf_host_id_t>(1); // ESP32-C6 only has SPI2_HOST (value 1)
+static constexpr hf_host_id_t SPI_HOST_NUM =
+    static_cast<hf_host_id_t>(1);                  // ESP32-C6 only has SPI2_HOST (value 1)
 static constexpr uint32_t SLOW_SPEED = 1000000;    // 1MHz
 static constexpr uint32_t MEDIUM_SPEED = 10000000; // 10MHz
 static constexpr uint32_t FAST_SPEED = 40000000;   // 40MHz
@@ -96,8 +97,10 @@ hf_spi_bus_config_t create_test_bus_config(uint32_t speed = MEDIUM_SPEED, bool u
                                            spi_host_device_t host = SPI2_HOST) noexcept;
 bool verify_transfer_data(const uint8_t* tx_data, const uint8_t* rx_data, size_t length) noexcept;
 void generate_test_pattern(uint8_t* buffer, size_t length, uint8_t seed = 0xAA) noexcept;
-void generate_sequential_pattern(uint8_t* buffer, size_t length, uint8_t start_value = 0x01) noexcept;
-void generate_alternating_pattern(uint8_t* buffer, size_t length, uint8_t value1 = 0x55, uint8_t value2 = 0xAA) noexcept;
+void generate_sequential_pattern(uint8_t* buffer, size_t length,
+                                 uint8_t start_value = 0x01) noexcept;
+void generate_alternating_pattern(uint8_t* buffer, size_t length, uint8_t value1 = 0x55,
+                                  uint8_t value2 = 0xAA) noexcept;
 void log_test_separator(const char* test_name) noexcept;
 
 bool test_spi_bus_initialization() noexcept {
@@ -500,7 +503,7 @@ bool test_spi_transfer_modes() noexcept {
     }
 
     // Test transfer with this mode (use different pattern for each mode)
-    uint8_t tx_data[] = {static_cast<uint8_t>(0x12 + mode), static_cast<uint8_t>(0x34 + mode), 
+    uint8_t tx_data[] = {static_cast<uint8_t>(0x12 + mode), static_cast<uint8_t>(0x34 + mode),
                          static_cast<uint8_t>(0x56 + mode), static_cast<uint8_t>(0x78 + mode)};
     uint8_t rx_data[sizeof(tx_data)] = {0};
     hf_spi_err_t result = device->Transfer(tx_data, rx_data, sizeof(tx_data), 0);
@@ -565,7 +568,8 @@ bool test_spi_transfer_sizes() noexcept {
     if (size <= 16) {
       generate_sequential_pattern(tx_buffer.get(), size, 0x10); // Start at 0x10 for small transfers
     } else if (size <= 256) {
-      generate_alternating_pattern(tx_buffer.get(), size, 0x55, 0xAA); // Alternating pattern for medium transfers
+      generate_alternating_pattern(tx_buffer.get(), size, 0x55,
+                                   0xAA); // Alternating pattern for medium transfers
     } else {
       generate_test_pattern(tx_buffer.get(), size, 0x01); // Sequential pattern for large transfers
     }
@@ -1063,19 +1067,18 @@ bool test_spi_iomux_optimization() noexcept {
           ESP_LOGW(TAG, "Failed to initialize GPIO device");
           // Skip this test but continue with the function
         } else {
+          start_time = esp_timer_get_time();
+          result = device_gpio->Transfer(tx_buffer.get(), rx_buffer.get(), test_size, 0);
+          end_time = esp_timer_get_time();
+          uint64_t gpio_time = end_time - start_time;
 
-        start_time = esp_timer_get_time();
-        result = device_gpio->Transfer(tx_buffer.get(), rx_buffer.get(), test_size, 0);
-        end_time = esp_timer_get_time();
-        uint64_t gpio_time = end_time - start_time;
+          ESP_LOGI(TAG, "GPIO matrix transfer %zu bytes: %s (time: %llu μs)", test_size,
+                   HfSpiErrToString(result).data(), gpio_time);
 
-        ESP_LOGI(TAG, "GPIO matrix transfer %zu bytes: %s (time: %llu μs)", test_size,
-                 HfSpiErrToString(result).data(), gpio_time);
-
-        if (iomux_time < gpio_time) {
-          ESP_LOGI(TAG, "IOMUX performance improvement: %.1f%%",
-                   ((float)(gpio_time - iomux_time) / gpio_time) * 100.0f);
-        }
+          if (iomux_time < gpio_time) {
+            ESP_LOGI(TAG, "IOMUX performance improvement: %.1f%%",
+                     ((float)(gpio_time - iomux_time) / gpio_time) * 100.0f);
+          }
         } // Close the else block
       }
     }
@@ -1385,8 +1388,9 @@ bool test_spi_espidf_direct_api() noexcept {
   constexpr uint32_t SPI_MASTER_FREQ_HZ = 10000000; // 10MHz for compatibility
   constexpr uint32_t SPI_MASTER_TIMEOUT_MS = 1000;
 
-  ESP_LOGI(TAG, "ESP-IDF Config: MOSI=GPIO%d, MISO=GPIO%d, SCLK=GPIO%d, CS=GPIO%d, Host=%d, Freq=%lu Hz",
-           SPI_MASTER_MOSI_IO, SPI_MASTER_MISO_IO, SPI_MASTER_SCLK_IO, SPI_MASTER_CS_IO, 
+  ESP_LOGI(TAG,
+           "ESP-IDF Config: MOSI=GPIO%d, MISO=GPIO%d, SCLK=GPIO%d, CS=GPIO%d, Host=%d, Freq=%lu Hz",
+           SPI_MASTER_MOSI_IO, SPI_MASTER_MISO_IO, SPI_MASTER_SCLK_IO, SPI_MASTER_CS_IO,
            SPI_MASTER_HOST, SPI_MASTER_FREQ_HZ);
 
   // Step 1: Initialize SPI bus
@@ -1463,10 +1467,11 @@ bool test_spi_espidf_direct_api() noexcept {
 
     err = spi_device_transmit(dev_handle, &trans);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "ESP-IDF: Single byte transfer %u failed: %s", operation_count, esp_err_to_name(err));
+      ESP_LOGW(TAG, "ESP-IDF: Single byte transfer %u failed: %s", operation_count,
+               esp_err_to_name(err));
       failed_operations++;
     } else {
-      ESP_LOGI(TAG, "ESP-IDF: Single byte transfer %u successful: TX=0x%02X, RX=0x%02X", 
+      ESP_LOGI(TAG, "ESP-IDF: Single byte transfer %u successful: TX=0x%02X, RX=0x%02X",
                operation_count, tx_byte, rx_byte);
       successful_operations++;
     }
@@ -1480,14 +1485,16 @@ bool test_spi_espidf_direct_api() noexcept {
 
     err = spi_device_transmit(dev_handle, &trans);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "ESP-IDF: Multi-byte transfer %u failed: %s", operation_count, esp_err_to_name(err));
+      ESP_LOGW(TAG, "ESP-IDF: Multi-byte transfer %u failed: %s", operation_count,
+               esp_err_to_name(err));
       failed_operations++;
     } else {
-      ESP_LOGI(TAG, "ESP-IDF: Multi-byte transfer %u successful: %zu bytes", operation_count, sizeof(tx_data));
-      ESP_LOGI(TAG, "ESP-IDF: TX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", 
-               tx_data[0], tx_data[1], tx_data[2], tx_data[3], tx_data[4]);
-      ESP_LOGI(TAG, "ESP-IDF: RX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", 
-               rx_data[0], rx_data[1], rx_data[2], rx_data[3], rx_data[4]);
+      ESP_LOGI(TAG, "ESP-IDF: Multi-byte transfer %u successful: %zu bytes", operation_count,
+               sizeof(tx_data));
+      ESP_LOGI(TAG, "ESP-IDF: TX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", tx_data[0], tx_data[1],
+               tx_data[2], tx_data[3], tx_data[4]);
+      ESP_LOGI(TAG, "ESP-IDF: RX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", rx_data[0], rx_data[1],
+               rx_data[2], rx_data[3], rx_data[4]);
       successful_operations++;
     }
 
@@ -1503,13 +1510,14 @@ bool test_spi_espidf_direct_api() noexcept {
 
     err = spi_device_transmit(dev_handle, &trans);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "ESP-IDF: Sequential pattern transfer %u failed: %s", operation_count, 
+      ESP_LOGW(TAG, "ESP-IDF: Sequential pattern transfer %u failed: %s", operation_count,
                esp_err_to_name(err));
       failed_operations++;
     } else {
-      ESP_LOGI(TAG, "ESP-IDF: Sequential pattern transfer %u successful: %zu bytes", operation_count, sizeof(tx_seq));
-      ESP_LOGI(TAG, "ESP-IDF: TX pattern: [0x%02X, 0x%02X, 0x%02X, 0x%02X...]", 
-               tx_seq[0], tx_seq[1], tx_seq[2], tx_seq[3]);
+      ESP_LOGI(TAG, "ESP-IDF: Sequential pattern transfer %u successful: %zu bytes",
+               operation_count, sizeof(tx_seq));
+      ESP_LOGI(TAG, "ESP-IDF: TX pattern: [0x%02X, 0x%02X, 0x%02X, 0x%02X...]", tx_seq[0],
+               tx_seq[1], tx_seq[2], tx_seq[3]);
       successful_operations++;
     }
 
@@ -1581,9 +1589,11 @@ bool test_spi_espidf_wrapper_replica() noexcept {
   constexpr uint32_t SPI_MASTER_FREQ_HZ = 10000000; // 10MHz for compatibility
   constexpr uint32_t SPI_MASTER_TIMEOUT_MS = 1000;
 
-  ESP_LOGI(TAG, "EspSpiBus Config: MOSI=GPIO%d, MISO=GPIO%d, SCLK=GPIO%d, CS=GPIO%d, Host=%d, Freq=%lu Hz",
-           SPI_MASTER_MOSI_IO, SPI_MASTER_MISO_IO, SPI_MASTER_SCLK_IO, SPI_MASTER_CS_IO, 
-           SPI_MASTER_HOST, SPI_MASTER_FREQ_HZ);
+  ESP_LOGI(
+      TAG,
+      "EspSpiBus Config: MOSI=GPIO%d, MISO=GPIO%d, SCLK=GPIO%d, CS=GPIO%d, Host=%d, Freq=%lu Hz",
+      SPI_MASTER_MOSI_IO, SPI_MASTER_MISO_IO, SPI_MASTER_SCLK_IO, SPI_MASTER_CS_IO, SPI_MASTER_HOST,
+      SPI_MASTER_FREQ_HZ);
 
   // Step 1: Create EspSpiBus configuration (matching ESP-IDF direct test)
   ESP_LOGI(TAG, "Step 1: Creating EspSpiBus configuration...");
@@ -1665,7 +1675,8 @@ bool test_spi_espidf_wrapper_replica() noexcept {
   uint32_t successful_operations = 0;
   uint32_t failed_operations = 0;
 
-  ESP_LOGI(TAG, "EspSpiBus: Test loop will run for 10 seconds with 500ms delays between operations");
+  ESP_LOGI(TAG,
+           "EspSpiBus: Test loop will run for 10 seconds with 500ms delays between operations");
   ESP_LOGI(TAG, "EspSpiBus: This provides sufficient time to thoroughly test SPI functionality");
 
   while ((xTaskGetTickCount() - start_time) < test_duration) {
@@ -1677,11 +1688,11 @@ bool test_spi_espidf_wrapper_replica() noexcept {
     uint8_t rx_byte = 0x00;
     hf_spi_err_t result = device->Transfer(&tx_byte, &rx_byte, 1, 0);
     if (result != hf_spi_err_t::SPI_SUCCESS) {
-      ESP_LOGW(TAG, "EspSpiBus: Single byte transfer %u failed: %s", operation_count, 
+      ESP_LOGW(TAG, "EspSpiBus: Single byte transfer %u failed: %s", operation_count,
                HfSpiErrToString(result).data());
       failed_operations++;
     } else {
-      ESP_LOGI(TAG, "EspSpiBus: Single byte transfer %u successful: TX=0x%02X, RX=0x%02X", 
+      ESP_LOGI(TAG, "EspSpiBus: Single byte transfer %u successful: TX=0x%02X, RX=0x%02X",
                operation_count, tx_byte, rx_byte);
       successful_operations++;
     }
@@ -1691,15 +1702,16 @@ bool test_spi_espidf_wrapper_replica() noexcept {
     uint8_t rx_data[sizeof(tx_data)] = {0};
     result = device->Transfer(tx_data, rx_data, sizeof(tx_data), 0);
     if (result != hf_spi_err_t::SPI_SUCCESS) {
-      ESP_LOGW(TAG, "EspSpiBus: Multi-byte transfer %u failed: %s", operation_count, 
+      ESP_LOGW(TAG, "EspSpiBus: Multi-byte transfer %u failed: %s", operation_count,
                HfSpiErrToString(result).data());
       failed_operations++;
     } else {
-      ESP_LOGI(TAG, "EspSpiBus: Multi-byte transfer %u successful: %zu bytes", operation_count, sizeof(tx_data));
-      ESP_LOGI(TAG, "EspSpiBus: TX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", 
-               tx_data[0], tx_data[1], tx_data[2], tx_data[3], tx_data[4]);
-      ESP_LOGI(TAG, "EspSpiBus: RX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", 
-               rx_data[0], rx_data[1], rx_data[2], rx_data[3], rx_data[4]);
+      ESP_LOGI(TAG, "EspSpiBus: Multi-byte transfer %u successful: %zu bytes", operation_count,
+               sizeof(tx_data));
+      ESP_LOGI(TAG, "EspSpiBus: TX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", tx_data[0],
+               tx_data[1], tx_data[2], tx_data[3], tx_data[4]);
+      ESP_LOGI(TAG, "EspSpiBus: RX: [0x%02X, 0x%02X, 0x%02X, 0x%02X, 0x%02X]", rx_data[0],
+               rx_data[1], rx_data[2], rx_data[3], rx_data[4]);
       successful_operations++;
     }
 
@@ -1711,13 +1723,14 @@ bool test_spi_espidf_wrapper_replica() noexcept {
     }
     result = device->Transfer(tx_seq, rx_seq, sizeof(tx_seq), 0);
     if (result != hf_spi_err_t::SPI_SUCCESS) {
-      ESP_LOGW(TAG, "EspSpiBus: Sequential pattern transfer %u failed: %s", operation_count, 
+      ESP_LOGW(TAG, "EspSpiBus: Sequential pattern transfer %u failed: %s", operation_count,
                HfSpiErrToString(result).data());
       failed_operations++;
     } else {
-      ESP_LOGI(TAG, "EspSpiBus: Sequential pattern transfer %u successful: %zu bytes", operation_count, sizeof(tx_seq));
-      ESP_LOGI(TAG, "EspSpiBus: TX pattern: [0x%02X, 0x%02X, 0x%02X, 0x%02X...]", 
-               tx_seq[0], tx_seq[1], tx_seq[2], tx_seq[3]);
+      ESP_LOGI(TAG, "EspSpiBus: Sequential pattern transfer %u successful: %zu bytes",
+               operation_count, sizeof(tx_seq));
+      ESP_LOGI(TAG, "EspSpiBus: TX pattern: [0x%02X, 0x%02X, 0x%02X, 0x%02X...]", tx_seq[0],
+               tx_seq[1], tx_seq[2], tx_seq[3]);
       successful_operations++;
     }
 
@@ -1781,7 +1794,7 @@ void generate_test_pattern(uint8_t* buffer, size_t length, uint8_t seed) noexcep
     // Use a pattern that's easy to identify on logic analyzer
     // Pattern: 0x01, 0x02, 0x03, ..., 0xFF, then repeat
     buffer[i] = static_cast<uint8_t>((seed + i) % 256);
-    
+
     // Ensure we don't have 0x00 which might be interpreted as end of string
     if (buffer[i] == 0x00) {
       buffer[i] = 0x01;
@@ -1799,7 +1812,8 @@ void generate_sequential_pattern(uint8_t* buffer, size_t length, uint8_t start_v
   }
 }
 
-void generate_alternating_pattern(uint8_t* buffer, size_t length, uint8_t value1, uint8_t value2) noexcept {
+void generate_alternating_pattern(uint8_t* buffer, size_t length, uint8_t value1,
+                                  uint8_t value2) noexcept {
   if (!buffer)
     return;
 
@@ -1835,7 +1849,7 @@ extern "C" void app_main(void) {
       ESP_LOGI(TAG, "Running ESP-IDF Direct SPI API test (FIRST)...");
       RUN_TEST_IN_TASK("espidf_direct_api", test_spi_espidf_direct_api, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after ESP-IDF test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_ESPIDF_WRAPPER_REPLICA, "ESP-IDF WRAPPER REPLICA TEST (SECOND)", 5,
@@ -1843,7 +1857,7 @@ extern "C" void app_main(void) {
       ESP_LOGI(TAG, "Running EspSpiBus Wrapper Replica test (SECOND)...");
       RUN_TEST_IN_TASK("espidf_wrapper_replica", test_spi_espidf_wrapper_replica, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after wrapper test
-      );
+  );
 
   // Run all SPI tests based on configuration
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
@@ -1860,7 +1874,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after device creation test
       RUN_TEST_IN_TASK("device_management", test_spi_device_management, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after device management test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_TRANSFER_TESTS, "SPI TRANSFER TESTS", 5,
@@ -1874,7 +1888,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after sizes test
       RUN_TEST_IN_TASK("dma_operations", test_spi_dma_operations, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after DMA test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_PERFORMANCE_TESTS, "SPI PERFORMANCE TESTS", 5,
@@ -1886,7 +1900,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after multi-device test
       RUN_TEST_IN_TASK("performance_benchmarks", test_spi_performance_benchmarks, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after performance test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_ADVANCED_TESTS, "SPI ADVANCED TESTS", 5,
@@ -1898,7 +1912,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after IOMUX test
       RUN_TEST_IN_TASK("thread_safety", test_spi_thread_safety, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after thread safety test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_STRESS_TESTS, "SPI STRESS TESTS", 5,
@@ -1914,7 +1928,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after bus acquisition test
       RUN_TEST_IN_TASK("power_management", test_spi_power_management, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after power management test
-      );
+  );
 
   print_test_summary(g_test_results, "SPI", TAG);
 

--- a/examples/esp32/main/TemperatureComprehensiveTest.cpp
+++ b/examples/esp32/main/TemperatureComprehensiveTest.cpp
@@ -23,11 +23,14 @@ static std::atomic<float> g_last_callback_temperature{0.0f};
 // Enable/disable specific test categories by setting to true or false
 
 // Core temperature functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Initialization, reading, sensor info
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Range management, threshold monitoring, continuous monitoring
-static constexpr bool ENABLE_FEATURE_TESTS = true;        // Calibration, power management, self-test, health monitoring
-static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Statistics, diagnostics, ESP32-specific features
-static constexpr bool ENABLE_STRESS_TESTS = true;         // Error handling, performance, stress testing
+static constexpr bool ENABLE_CORE_TESTS = true; // Initialization, reading, sensor info
+static constexpr bool ENABLE_ADVANCED_TESTS =
+    true; // Range management, threshold monitoring, continuous monitoring
+static constexpr bool ENABLE_FEATURE_TESTS =
+    true; // Calibration, power management, self-test, health monitoring
+static constexpr bool ENABLE_DIAGNOSTIC_TESTS =
+    true; // Statistics, diagnostics, ESP32-specific features
+static constexpr bool ENABLE_STRESS_TESTS = true; // Error handling, performance, stress testing
 
 //==============================================================================
 // CALLBACK FUNCTIONS FOR TESTING

--- a/examples/esp32/main/TestFramework.h
+++ b/examples/esp32/main/TestFramework.h
@@ -69,13 +69,11 @@ inline bool init_test_progress_indicator() noexcept {
   }
 
   // Create GPIO14 instance for test progression indicator
-  g_test_progress_gpio = new EspGpio(
-      TEST_PROGRESS_PIN,
-      hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
-      hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
-      hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
-      hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_DOWN
-  );
+  g_test_progress_gpio =
+      new EspGpio(TEST_PROGRESS_PIN, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+                  hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
+                  hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
+                  hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_DOWN);
 
   if (!g_test_progress_gpio) {
     return false; // Failed to allocate
@@ -106,9 +104,9 @@ inline void flip_test_progress_indicator() noexcept {
 
   // Toggle GPIO14 state
   g_test_progress_state = !g_test_progress_state;
-  
+
   if (g_test_progress_state) {
-    g_test_progress_gpio->SetActive();   // Set HIGH
+    g_test_progress_gpio->SetActive(); // Set HIGH
   } else {
     g_test_progress_gpio->SetInactive(); // Set LOW
   }
@@ -128,7 +126,7 @@ inline void cleanup_test_progress_indicator() noexcept {
   if (g_test_progress_gpio) {
     // Ensure GPIO14 is LOW before cleanup
     g_test_progress_gpio->SetInactive();
-    
+
     // Delete the GPIO instance
     delete g_test_progress_gpio;
     g_test_progress_gpio = nullptr;
@@ -149,10 +147,10 @@ inline void output_section_indicator(uint8_t blink_count = 5) noexcept {
   // Blink the specified number of times for section identification
   for (uint8_t i = 0; i < blink_count; ++i) {
     g_test_progress_gpio->SetActive();   // HIGH
-    vTaskDelay(pdMS_TO_TICKS(50));     // ON
+    vTaskDelay(pdMS_TO_TICKS(50));       // ON
     g_test_progress_gpio->SetInactive(); // LOW
-    vTaskDelay(pdMS_TO_TICKS(50));     // OFF
-    
+    vTaskDelay(pdMS_TO_TICKS(50));       // OFF
+
     // // Pause between blinks (except after the last one)
     // if (i < blink_count - 1) {
     //   vTaskDelay(pdMS_TO_TICKS(200)); // 200ms pause between blinks
@@ -377,17 +375,25 @@ inline void print_test_section_status(const char* tag, const char* test_suite_na
  * @param section_name Name of the test section
  * @param enabled Whether the section is enabled
  */
-inline void print_test_section_header(const char* tag, const char* section_name, bool enabled = true) noexcept {
+inline void print_test_section_header(const char* tag, const char* section_name,
+                                      bool enabled = true) noexcept {
   if (enabled) {
     ESP_LOGI(tag, "\n");
-    ESP_LOGI(tag, "╔══════════════════════════════════════════════════════════════════════════════╗");
-    ESP_LOGI(tag, "║                              %s                                              ║", section_name);
-    ESP_LOGI(tag, "╠══════════════════════════════════════════════════════════════════════════════╣");
+    ESP_LOGI(tag,
+             "╔══════════════════════════════════════════════════════════════════════════════╗");
+    ESP_LOGI(tag,
+             "║                              %s                                              ║",
+             section_name);
+    ESP_LOGI(tag,
+             "╠══════════════════════════════════════════════════════════════════════════════╣");
   } else {
     ESP_LOGI(tag, "\n");
-    ESP_LOGI(tag, "╔══════════════════════════════════════════════════════════════════════════════╗");
-    ESP_LOGI(tag, "║                              %s (DISABLED)                                  ║", section_name);
-    ESP_LOGI(tag, "╚══════════════════════════════════════════════════════════════════════════════╝");
+    ESP_LOGI(tag,
+             "╔══════════════════════════════════════════════════════════════════════════════╗");
+    ESP_LOGI(tag, "║                              %s (DISABLED)                                  ║",
+             section_name);
+    ESP_LOGI(tag,
+             "╚══════════════════════════════════════════════════════════════════════════════╝");
   }
 }
 
@@ -396,9 +402,11 @@ inline void print_test_section_header(const char* tag, const char* section_name,
  * @param section_name Name of the test section
  * @param enabled Whether the section is enabled
  */
-inline void print_test_section_footer(const char* tag, const char* section_name, bool enabled = true) noexcept {
+inline void print_test_section_footer(const char* tag, const char* section_name,
+                                      bool enabled = true) noexcept {
   if (enabled) {
-    ESP_LOGI(tag, "╚══════════════════════════════════════════════════════════════════════════════╝");
+    ESP_LOGI(tag,
+             "╚══════════════════════════════════════════════════════════════════════════════╝");
   }
 }
 /**
@@ -454,13 +462,13 @@ inline void print_test_section_footer(const char* tag, const char* section_name,
   do {                                                                                           \
     ensure_gpio14_initialized();                                                                 \
     if (define_name) {                                                                           \
-      print_test_section_header(TAG, section_name, true);                                         \
+      print_test_section_header(TAG, section_name, true);                                        \
       __VA_ARGS__                                                                                \
       if (progress_func)                                                                         \
         progress_func();                                                                         \
-      print_test_section_footer(TAG, section_name, true);                                         \
+      print_test_section_footer(TAG, section_name, true);                                        \
     } else {                                                                                     \
-      print_test_section_header(TAG, section_name, false);                                        \
+      print_test_section_header(TAG, section_name, false);                                       \
       ESP_LOGI(TAG, "Section disabled by configuration");                                        \
     }                                                                                            \
   } while (0)
@@ -472,18 +480,18 @@ inline void print_test_section_footer(const char* tag, const char* section_name,
 
 // Macro to conditionally run a test section with section indicator
 #define RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(define_name, section_name, blink_count, ...) \
-  do {                                                                                               \
-    ensure_gpio14_initialized();                                                                     \
-    if (define_name) {                                                                               \
-      print_test_section_header(TAG, section_name, true);                                            \
-      output_section_indicator(blink_count); /* Section start indicator */                           \
-      __VA_ARGS__                                                                                    \
-      output_section_indicator(blink_count); /* Section end indicator */                             \
-      print_test_section_footer(TAG, section_name, true);                                            \
-    } else {                                                                                         \
-      print_test_section_header(TAG, section_name, false);                                           \
-      ESP_LOGI(TAG, "Section disabled by configuration");                                            \
-    }                                                                                                \
+  do {                                                                                        \
+    ensure_gpio14_initialized();                                                              \
+    if (define_name) {                                                                        \
+      print_test_section_header(TAG, section_name, true);                                     \
+      output_section_indicator(blink_count); /* Section start indicator */                    \
+      __VA_ARGS__                                                                             \
+      output_section_indicator(blink_count); /* Section end indicator */                      \
+      print_test_section_footer(TAG, section_name, true);                                     \
+    } else {                                                                                  \
+      print_test_section_header(TAG, section_name, false);                                    \
+      ESP_LOGI(TAG, "Section disabled by configuration");                                     \
+    }                                                                                         \
   } while (0)
 
 /**
@@ -528,7 +536,7 @@ inline void print_test_section_footer(const char* tag, const char* section_name,
  * RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(ENABLE_CORE_FEATURE_TESTS, "CORE FEATURE TESTS", 5,
  *   RUN_TEST_IN_TASK("test2", test_function2, 8192, 1);
  * );
- * 
+ *
  * // GPIO14 test indicator is automatically initialized by the test framework
  * // You can add flip_test_progress_indicator() calls between tests if desired
  * // Example: flip_test_progress_indicator(); // Toggle GPIO14 after each test

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -46,10 +46,10 @@ static CallbackTestData g_callback_data;
 // Enable/disable specific test categories by setting to true or false
 
 // Core timer functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Initialization, start/stop, period validation
-static constexpr bool ENABLE_CALLBACK_TESTS = true;       // Callback functionality and validation
-static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true;     // Statistics, information, error conditions
-static constexpr bool ENABLE_STRESS_TESTS = true;         // Stress testing, resource management
+static constexpr bool ENABLE_CORE_TESTS = true;     // Initialization, start/stop, period validation
+static constexpr bool ENABLE_CALLBACK_TESTS = true; // Callback functionality and validation
+static constexpr bool ENABLE_DIAGNOSTIC_TESTS = true; // Statistics, information, error conditions
+static constexpr bool ENABLE_STRESS_TESTS = true;     // Stress testing, resource management
 
 // Precision timer callback for testing
 static void precision_timer_callback(void* user_data) {
@@ -797,11 +797,10 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("start_stop", test_timer_start_stop, 8192, 1);
       RUN_TEST_IN_TASK("period_validation", test_timer_period_validation, 8192, 1););
 
-  RUN_TEST_SECTION_IF_ENABLED(
-      ENABLE_CALLBACK_TESTS, "TIMER CALLBACK TESTS",
-      // Callback functionality tests
-      ESP_LOGI(TAG, "Running timer callback tests...");
-      RUN_TEST_IN_TASK("callbacks", test_timer_callbacks, 8192, 1););
+  RUN_TEST_SECTION_IF_ENABLED(ENABLE_CALLBACK_TESTS, "TIMER CALLBACK TESTS",
+                              // Callback functionality tests
+                              ESP_LOGI(TAG, "Running timer callback tests...");
+                              RUN_TEST_IN_TASK("callbacks", test_timer_callbacks, 8192, 1););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_DIAGNOSTIC_TESTS, "TIMER DIAGNOSTIC TESTS",

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -33,8 +33,6 @@ extern "C" {
 static const char* TAG = "UART_Test";
 static TestResults g_test_results;
 
-
-
 // Test configuration constants
 // static constexpr hf_u8_t TEST_UART_PORT_0 = 0; Debug UART
 static constexpr hf_u8_t TEST_UART_PORT_1 = 1;
@@ -66,13 +64,15 @@ static bool g_stop_event_task = false;
 // Enable/disable specific test categories by setting to true or false
 
 // Core UART functionality tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Construction, initialization, basic communication
-static constexpr bool ENABLE_BASIC_TESTS = true;          // Baud rate, flow control, buffer operations
-static constexpr bool ENABLE_ADVANCED_TESTS = true;       // Advanced features, communication modes, async operations
-static constexpr bool ENABLE_CALLBACK_TESTS = true;       // Callbacks, statistics, diagnostics, printf support
-static constexpr bool ENABLE_ESP_SPECIFIC_TESTS = true;   // ESP32-C6 specific features, performance
-static constexpr bool ENABLE_EVENT_TESTS = true;          // User event task, event-driven pattern detection
-static constexpr bool ENABLE_CLEANUP_TESTS = true;        // Cleanup and final tests
+static constexpr bool ENABLE_CORE_TESTS = true; // Construction, initialization, basic communication
+static constexpr bool ENABLE_BASIC_TESTS = true; // Baud rate, flow control, buffer operations
+static constexpr bool ENABLE_ADVANCED_TESTS =
+    true; // Advanced features, communication modes, async operations
+static constexpr bool ENABLE_CALLBACK_TESTS =
+    true; // Callbacks, statistics, diagnostics, printf support
+static constexpr bool ENABLE_ESP_SPECIFIC_TESTS = true; // ESP32-C6 specific features, performance
+static constexpr bool ENABLE_EVENT_TESTS = true; // User event task, event-driven pattern detection
+static constexpr bool ENABLE_CLEANUP_TESTS = true; // Cleanup and final tests
 
 // Forward declarations
 bool test_uart_construction() noexcept;
@@ -310,8 +310,6 @@ bool verify_uart_state(EspUart& uart, bool should_be_initialized) noexcept {
   }
   return true;
 }
-
-
 
 //==============================================================================
 // TEST FUNCTIONS
@@ -1950,7 +1948,6 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("uart_initialization", test_uart_initialization, 8192, 1);
       flip_test_progress_indicator();
 
-
       // Basic Communication Tests
       ESP_LOGI(TAG, "Running basic communication tests...");
       RUN_TEST_IN_TASK("basic_communication", test_uart_basic_communication, 8192, 1);
@@ -1961,15 +1958,14 @@ extern "C" void app_main(void) {
       // Temporarily skip flow control test due to ESP32-C6 compatibility issues
       // RUN_TEST_IN_TASK("flow_control", test_uart_flow_control, 8192, 1);
       // );
-);
+  );
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_BASIC_TESTS, "UART BASIC TESTS",
       // Buffer Operations Tests
       ESP_LOGI(TAG, "Running buffer operations tests...");
       RUN_TEST_IN_TASK("buffer_operations", test_uart_buffer_operations, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ADVANCED_TESTS, "UART ADVANCED TESTS",
@@ -1983,22 +1979,19 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("communication_modes", test_uart_communication_modes, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("async_operations", test_uart_async_operations, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_CALLBACK_TESTS, "UART CALLBACK TESTS",
       // Callback and Support Tests
       ESP_LOGI(TAG, "Running callback and support tests...");
-      RUN_TEST_IN_TASK("callbacks", test_uart_callbacks, 8192, 1);
-      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("callbacks", test_uart_callbacks, 8192, 1); flip_test_progress_indicator();
       RUN_TEST_IN_TASK("statistics_diagnostics", test_uart_statistics_diagnostics, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("printf_support", test_uart_printf_support, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("error_handling", test_uart_error_handling, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_ESP_SPECIFIC_TESTS, "UART ESP-SPECIFIC TESTS",
@@ -2009,8 +2002,7 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("performance", test_uart_performance, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("callback_verification", test_uart_callback_verification, 8192, 1);
-      flip_test_progress_indicator();
-);
+      flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_EVENT_TESTS, "UART EVENT TESTS",
@@ -2023,17 +2015,15 @@ extern "C" void app_main(void) {
       ESP_LOGI(TAG, "Running comprehensive event-driven pattern detection test...");
       ESP_LOGI(TAG, "This test runs with 5-second timeout and comprehensive event monitoring");
       ESP_LOGI(TAG, "It will test the complete event queue behavior for pattern detection");
-      RUN_TEST_IN_TASK("event_driven_pattern_detection", test_uart_event_driven_pattern_detection, 8192, 1);
-      flip_test_progress_indicator();
-);
+      RUN_TEST_IN_TASK("event_driven_pattern_detection", test_uart_event_driven_pattern_detection,
+                       8192, 1);
+      flip_test_progress_indicator(););
 
-  RUN_TEST_SECTION_IF_ENABLED(
-      ENABLE_CLEANUP_TESTS, "UART CLEANUP TESTS",
-      // Cleanup Tests
-      ESP_LOGI(TAG, "Running cleanup tests...");
-      RUN_TEST_IN_TASK("cleanup", test_uart_cleanup, 8192, 1);
-      flip_test_progress_indicator();
-);
+  RUN_TEST_SECTION_IF_ENABLED(ENABLE_CLEANUP_TESTS, "UART CLEANUP TESTS",
+                              // Cleanup Tests
+                              ESP_LOGI(TAG, "Running cleanup tests...");
+                              RUN_TEST_IN_TASK("cleanup", test_uart_cleanup, 8192, 1);
+                              flip_test_progress_indicator(););
 
   print_test_summary(g_test_results, "UART", TAG);
 

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -1946,15 +1946,17 @@ extern "C" void app_main(void) {
       // Constructor/Destructor Tests
       ESP_LOGI(TAG, "Running constructor/destructor tests...");
       RUN_TEST_IN_TASK("uart_construction", test_uart_construction, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("uart_initialization", test_uart_initialization, 8192, 1);
+      flip_test_progress_indicator();
 
 
       // Basic Communication Tests
       ESP_LOGI(TAG, "Running basic communication tests...");
       RUN_TEST_IN_TASK("basic_communication", test_uart_basic_communication, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("baud_rate_configuration", test_uart_baud_rate_configuration, 8192, 1);
+      flip_test_progress_indicator();
 
       // Temporarily skip flow control test due to ESP32-C6 compatibility issues
       // RUN_TEST_IN_TASK("flow_control", test_uart_flow_control, 8192, 1);
@@ -1965,6 +1967,7 @@ extern "C" void app_main(void) {
       // Buffer Operations Tests
       ESP_LOGI(TAG, "Running buffer operations tests...");
       RUN_TEST_IN_TASK("buffer_operations", test_uart_buffer_operations, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -1973,12 +1976,13 @@ extern "C" void app_main(void) {
       ESP_LOGI(TAG, "Running advanced feature tests...");
       // Run pattern detection test in a separate task with larger stack for event processing
       RUN_TEST_IN_TASK("pattern_detection", test_uart_pattern_detection, 8192, 5);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("advanced_features", test_uart_advanced_features, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("communication_modes", test_uart_communication_modes, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("async_operations", test_uart_async_operations, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -1986,12 +1990,13 @@ extern "C" void app_main(void) {
       // Callback and Support Tests
       ESP_LOGI(TAG, "Running callback and support tests...");
       RUN_TEST_IN_TASK("callbacks", test_uart_callbacks, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("statistics_diagnostics", test_uart_statistics_diagnostics, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("printf_support", test_uart_printf_support, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("error_handling", test_uart_error_handling, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -1999,10 +2004,11 @@ extern "C" void app_main(void) {
       // ESP32-C6 specific tests
       ESP_LOGI(TAG, "Running ESP32-C6 specific tests...");
       RUN_TEST_IN_TASK("esp32c6_features", test_uart_esp32c6_features, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("performance", test_uart_performance, 8192, 1);
-
+      flip_test_progress_indicator();
       RUN_TEST_IN_TASK("callback_verification", test_uart_callback_verification, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2010,13 +2016,14 @@ extern "C" void app_main(void) {
       // User Event Task Test
       ESP_LOGI(TAG, "Running user event task tests...");
       RUN_TEST_IN_TASK("user_event_task", test_uart_user_event_task, 8192, 1);
-
+      flip_test_progress_indicator();
 
       // Comprehensive Event-Driven Pattern Detection Test
       ESP_LOGI(TAG, "Running comprehensive event-driven pattern detection test...");
       ESP_LOGI(TAG, "This test runs with 5-second timeout and comprehensive event monitoring");
       ESP_LOGI(TAG, "It will test the complete event queue behavior for pattern detection");
       RUN_TEST_IN_TASK("event_driven_pattern_detection", test_uart_event_driven_pattern_detection, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   RUN_TEST_SECTION_IF_ENABLED(
@@ -2024,6 +2031,7 @@ extern "C" void app_main(void) {
       // Cleanup Tests
       ESP_LOGI(TAG, "Running cleanup tests...");
       RUN_TEST_IN_TASK("cleanup", test_uart_cleanup, 8192, 1);
+      flip_test_progress_indicator();
 );
 
   print_test_summary(g_test_results, "UART", TAG);

--- a/examples/esp32/main/UartComprehensiveTest.cpp
+++ b/examples/esp32/main/UartComprehensiveTest.cpp
@@ -1961,6 +1961,7 @@ extern "C" void app_main(void) {
       // Temporarily skip flow control test due to ESP32-C6 compatibility issues
       // RUN_TEST_IN_TASK("flow_control", test_uart_flow_control, 8192, 1);
       // );
+);
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_BASIC_TESTS, "UART BASIC TESTS",

--- a/examples/esp32/main/UtilsComprehensiveTest.cpp
+++ b/examples/esp32/main/UtilsComprehensiveTest.cpp
@@ -40,13 +40,13 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core utilities functionality tests
-static constexpr bool ENABLE_ASCII_ART_TESTS = true;      // AsciiArtGenerator functionality
-static constexpr bool ENABLE_RTOS_MUTEX_TESTS = true;     // RtosMutex basic functionality
-static constexpr bool ENABLE_SHARED_MUTEX_TESTS = true;   // RtosSharedMutex functionality
-static constexpr bool ENABLE_CONCURRENT_TESTS = true;      // Concurrent access testing
-static constexpr bool ENABLE_EDGE_CASE_TESTS = true;      // Edge cases and error conditions
-static constexpr bool ENABLE_TIME_UTILITY_TESTS = true;   // RtosTime utility functions
-static constexpr bool ENABLE_PERFORMANCE_TESTS = true;     // Performance and stress testing
+static constexpr bool ENABLE_ASCII_ART_TESTS = true;    // AsciiArtGenerator functionality
+static constexpr bool ENABLE_RTOS_MUTEX_TESTS = true;   // RtosMutex basic functionality
+static constexpr bool ENABLE_SHARED_MUTEX_TESTS = true; // RtosSharedMutex functionality
+static constexpr bool ENABLE_CONCURRENT_TESTS = true;   // Concurrent access testing
+static constexpr bool ENABLE_EDGE_CASE_TESTS = true;    // Edge cases and error conditions
+static constexpr bool ENABLE_TIME_UTILITY_TESTS = true; // RtosTime utility functions
+static constexpr bool ENABLE_PERFORMANCE_TESTS = true;  // Performance and stress testing
 
 //==============================================================================
 // ASCII ART GENERATOR TESTS
@@ -1151,9 +1151,10 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("empty_string", test_ascii_art_empty_string, 8192, 1);
       RUN_TEST_IN_TASK("mixed_case", test_ascii_art_mixed_case, 8192, 1);
       RUN_TEST_IN_TASK("special_characters", test_ascii_art_special_characters, 8192, 1);
-      RUN_TEST_IN_TASK("long_text", test_ascii_art_long_text, 8192, 1);
-      RUN_TEST_IN_TASK("custom_character_management", test_ascii_art_custom_character_management, 8192, 1);
-      RUN_TEST_IN_TASK("supported_characters_list", test_ascii_art_supported_characters_list, 8192, 1););
+      RUN_TEST_IN_TASK("long_text", test_ascii_art_long_text, 8192, 1); RUN_TEST_IN_TASK(
+          "custom_character_management", test_ascii_art_custom_character_management, 8192, 1);
+      RUN_TEST_IN_TASK("supported_characters_list", test_ascii_art_supported_characters_list, 8192,
+                       1););
 
   RUN_TEST_SECTION_IF_ENABLED(
       ENABLE_RTOS_MUTEX_TESTS, "UTILS RTOS MUTEX TESTS",
@@ -1188,7 +1189,8 @@ extern "C" void app_main(void) {
       // Edge Cases and Error Condition Tests
       ESP_LOGI(TAG, "Running edge case and error condition tests...");
       RUN_TEST_IN_TASK("mutex_move_semantics", test_rtos_mutex_move_semantics, 8192, 1);
-      RUN_TEST_IN_TASK("shared_mutex_move_semantics", test_rtos_shared_mutex_move_semantics, 8192, 1);
+      RUN_TEST_IN_TASK("shared_mutex_move_semantics", test_rtos_shared_mutex_move_semantics, 8192,
+                       1);
       RUN_TEST_IN_TASK("mutex_edge_cases", test_rtos_mutex_edge_cases, 8192, 1);
       RUN_TEST_IN_TASK("lock_guard_edge_cases", test_rtos_lock_guard_edge_cases, 8192, 1););
 
@@ -1205,8 +1207,10 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("ascii_art_performance", test_ascii_art_performance, 8192, 1);
       RUN_TEST_IN_TASK("ascii_art_stress", test_ascii_art_stress, 8192, 1);
       RUN_TEST_IN_TASK("rtos_mutex_performance", test_rtos_mutex_performance, 8192, 1);
-      RUN_TEST_IN_TASK("rtos_mutex_recursive_performance", test_rtos_mutex_recursive_performance, 8192, 1);
-      RUN_TEST_IN_TASK("rtos_shared_mutex_performance", test_rtos_shared_mutex_performance, 8192, 1););
+      RUN_TEST_IN_TASK("rtos_mutex_recursive_performance", test_rtos_mutex_recursive_performance,
+                       8192, 1);
+      RUN_TEST_IN_TASK("rtos_shared_mutex_performance", test_rtos_shared_mutex_performance, 8192,
+                       1););
 
   // Print final summary
   print_test_summary(g_test_results, "UTILS", TAG);

--- a/examples/esp32/main/WifiComprehensiveTest.cpp
+++ b/examples/esp32/main/WifiComprehensiveTest.cpp
@@ -24,9 +24,9 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core WiFi interface tests
-static constexpr bool ENABLE_CORE_TESTS = true;           // Data structures, enums, error codes
-static constexpr bool ENABLE_INTERFACE_TESTS = true;      // Interface validation, integration
-static constexpr bool ENABLE_PERFORMANCE_TESTS = true;    // Performance, stress testing
+static constexpr bool ENABLE_CORE_TESTS = true;        // Data structures, enums, error codes
+static constexpr bool ENABLE_INTERFACE_TESTS = true;   // Interface validation, integration
+static constexpr bool ENABLE_PERFORMANCE_TESTS = true; // Performance, stress testing
 
 //==============================================================================
 // WIFI INTERFACE AND DATA STRUCTURE TESTS

--- a/inc/mcu/esp32/EspSpi.h
+++ b/inc/mcu/esp32/EspSpi.h
@@ -176,7 +176,7 @@ public:
    * @brief Destructor. Automatically deinitializes the bus if needed.
    */
   ~EspSpiBus() noexcept;
-  
+
   /**
    * @brief Initialize the SPI bus.
    * @return true if successful, false otherwise

--- a/inc/mcu/esp32/utils/EspTypes_SPI.h
+++ b/inc/mcu/esp32/utils/EspTypes_SPI.h
@@ -232,19 +232,19 @@ struct hf_spi_device_config_t {
         post_cb(nullptr), user_ctx(nullptr),
         clock_source(static_cast<hf_spi_clock_source_t>(SPI_CLK_SRC_DEFAULT)),
 #ifdef HF_MCU_ESP32C6
-        sampling_point(static_cast<hf_spi_sampling_point_t>(SPI_SAMPLING_POINT_PHASE_0)) {
+        sampling_point(static_cast<hf_spi_sampling_point_t>(SPI_SAMPLING_POINT_PHASE_0)){
 #else
         sampling_point(static_cast<hf_spi_sampling_point_t>(SPI_SAMPLING_POINT_PHASE_1)) {
 #endif
-  }
+        }
 };
 
 // ESP-IDF SPI device flags (matching ESP-IDF example patterns)
-#define HF_SPI_DEVICE_HALFDUPLEX     (1 << 0)  // Half-duplex mode
-#define HF_SPI_DEVICE_POSITIVE_CS    (1 << 1)  // CS active high
-#define HF_SPI_DEVICE_CLK_AS_CS      (1 << 2)  // Clock idle state
-#define HF_SPI_DEVICE_NO_DUMMY       (1 << 3)  // No dummy bits
-#define HF_SPI_DEVICE_DDRCLK         (1 << 4)  // DDR clock mode
+#define HF_SPI_DEVICE_HALFDUPLEX (1 << 0)  // Half-duplex mode
+#define HF_SPI_DEVICE_POSITIVE_CS (1 << 1) // CS active high
+#define HF_SPI_DEVICE_CLK_AS_CS (1 << 2)   // Clock idle state
+#define HF_SPI_DEVICE_NO_DUMMY (1 << 3)    // No dummy bits
+#define HF_SPI_DEVICE_DDRCLK (1 << 4)      // DDR clock mode
 
 //==============================================================================
 // END OF ESPSPI TYPES - MINIMAL AND ESSENTIAL ONLY


### PR DESCRIPTION
Remove custom EspGpio implementations from comprehensive tests to use the framework's centralized progress indicator.