### PR TITLE
Verify EspCan and Can documentation is up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ See [LICENSE](LICENSE) for full details.
 
 ### **Development**
 - 🚀 [Examples](examples/esp32/) - Test applications and usage examples
+- 🧪 [Test Documentation](examples/esp32/docs/README.md) - Comprehensive test documentation
 - 🔧 [Scripts](examples/esp32/scripts/) - Build, flash, and development tools
 - 📊 [Configuration](examples/esp32/app_config.yml) - Application and build settings
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -301,7 +301,7 @@ Our comprehensive documentation is organized into logical sections for easy navi
 | **`EspI2c`** | BaseI2c | Clock stretching, multi-master | ✅ Complete |
 | **`EspSpi`** | BaseSpi | Full-duplex, DMA support | ✅ Complete |
 | **`EspUart`** | BaseUart | Hardware flow control | ✅ Complete |
-| **`EspCan`** | BaseCan | TWAI controller | ✅ Complete |
+| **`EspCan`** | BaseCan | TWAI controller, SN65 transceiver, no CAN-FD | ✅ Complete |
 | **`EspWifi`** | BaseWifi | 802.11n, WPA3, mesh | ✅ Complete |
 | **`EspBluetooth`** | BaseBluetooth | BLE/Classic, NimBLE optimized | ✅ Complete |
 | **`EspNvs`** | BaseNvs | Encrypted storage, wear leveling | ✅ Complete |

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -28,7 +28,7 @@ The `BaseCan` class provides a comprehensive CAN bus abstraction that serves as 
 
 ### ✨ **Key Features**
 
-- 🚌 **CAN & CAN-FD Support** - Both classic CAN and CAN-FD protocols
+- 🚌 **CAN 2.0A/2.0B Support** - Classic CAN protocols (CAN-FD support varies by hardware)
 - 📨 **Message Filtering** - Hardware-based acceptance filtering
 - 🔄 **Error Recovery** - Automatic bus recovery and error handling
 - 📊 **Statistics & Diagnostics** - Comprehensive monitoring and reporting
@@ -41,7 +41,7 @@ The `BaseCan` class provides a comprehensive CAN bus abstraction that serves as 
 
 | Implementation | Hardware Type | Protocol | Speed | Features |
 |----------------|---------------|----------|-------|----------|
-| `EspCan` | ESP32-C6 Internal | CAN 2.0A/B | Up to 1 Mbps | Built-in error handling |
+| `EspCan` | ESP32-C6 Internal | CAN 2.0A/B | Up to 1 Mbps | Built-in error handling, no CAN-FD |
 
 ---
 
@@ -379,7 +379,8 @@ virtual void ClearReceiveCallback() noexcept;
  * @return hf_can_err_t error code
  * 
  * 📞 Sets callback for CAN-FD messages with enhanced information.
- * Only available if CAN-FD is supported.
+ * Only available if CAN-FD is supported by the hardware.
+ * ESP32-C6 TWAI controller does not support CAN-FD.
  */
 virtual hf_can_err_t SetReceiveCallbackFD(hf_can_fd_receive_callback_t callback) noexcept;
 ```
@@ -392,6 +393,7 @@ virtual hf_can_err_t SetReceiveCallbackFD(hf_can_fd_receive_callback_t callback)
  * @return true if supported, false otherwise
  * 
  * ✅ Checks if the hardware supports CAN-FD protocol.
+ * ESP32-C6 TWAI controller returns false (no CAN-FD support).
  */
 virtual bool SupportsCanFD() const noexcept;
 
@@ -402,6 +404,7 @@ virtual bool SupportsCanFD() const noexcept;
  * @return true if successful, false otherwise
  * 
  * 🚀 Configures CAN-FD mode if supported.
+ * ESP32-C6 TWAI controller does not support CAN-FD - returns false.
  * Requires re-initialization to take effect.
  */
 virtual bool SetCanFDMode(bool enable, uint32_t data_baudrate = 2000000,

--- a/docs/esp_api/EspCan.md
+++ b/docs/esp_api/EspCan.md
@@ -7,7 +7,7 @@
 ## Features
 
 - **ESP32-C6 TWAI Controller** - Full support for ESP32-C6 TWAI (Two-Wire Automotive Interface) capabilities
-- **CAN 2.0A/2.0B Support** - Standard and extended frame formats
+- **CAN 2.0A/2.0B Support** - Standard and extended frame formats (no CAN-FD support)
 - **High-Speed Operation** - Up to 1 Mbps CAN bus speeds
 - **DMA Integration** - High-performance DMA transfers
 - **Filter Support** - Hardware message filtering
@@ -134,7 +134,7 @@ if (err == HF_CAN_ERR_OK) {
 
 ### TWAI Controller
 
-The ESP32-C6 uses the TWAI (Two-Wire Automotive Interface) controller, which is fully compatible with CAN 2.0A and CAN 2.0B standards.
+The ESP32-C6 uses the TWAI (Two-Wire Automotive Interface) controller, which is fully compatible with CAN 2.0A and CAN 2.0B standards. **Note: CAN-FD is not supported by the ESP32-C6 TWAI controller.**
 
 ### Hardware Filtering
 
@@ -169,3 +169,4 @@ The `EspCan` class provides comprehensive error handling with specific error cod
 - [BaseCan API Reference](../api/BaseCan.md) - Base class interface
 - [HardwareTypes Reference](../api/HardwareTypes.md) - Platform-agnostic type definitions
 - [ESP-IDF TWAI Driver](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/peripherals/twai.html) - ESP-IDF documentation
+- [CAN Comprehensive Tests](../../examples/esp32/docs/README_CAN_TEST.md) - Complete CAN validation suite

--- a/examples/esp32/README.md
+++ b/examples/esp32/README.md
@@ -781,6 +781,23 @@ cat build-*/.ninja_log
 - **ASCII Art** - Text-based graphics
 - **Utils** - Common utility functions
 
+### **Test Documentation**
+
+Each application includes comprehensive test documentation:
+
+- **[Test Documentation](docs/README.md)** - Complete test documentation index
+- **[CAN Test Documentation](docs/README_CAN_TEST.md)** - CAN bus testing with SN65 transceiver
+- **[GPIO Test Documentation](docs/README_GPIO_TEST.md)** - GPIO testing and validation
+- **[ADC Test Documentation](docs/README_ADC_TEST.md)** - ADC testing and calibration
+- **[PWM Test Documentation](docs/README_PWM_TEST.md)** - PWM testing and frequency control
+- **[UART Test Documentation](docs/README_UART_TESTING.md)** - UART communication testing
+- **[SPI Test Documentation](docs/README_SPI_TEST.md)** - SPI interface testing
+- **[I2C Test Documentation](docs/README_I2C_TEST.md)** - I2C device testing
+- **[PIO Test Documentation](docs/README_PIO_TEST.md)** - Programmable I/O testing
+- **[Temperature Test Documentation](docs/README_TEMPERATURE_TEST.md)** - Temperature sensor testing
+- **[NVS Test Documentation](docs/README_NVS_TEST.md)** - Non-volatile storage testing
+- **[Logger Test Documentation](docs/README_LOGGER_TEST.md)** - Logging system testing
+
 ---
 
 ## 🤝 **Contributing**
@@ -837,6 +854,7 @@ This project is licensed under the GPL-3.0 License - see the [LICENSE](../LICENS
 
 - [Main Project README](../README.md) - Project overview and architecture
 - [API Documentation](../docs/) - Interface API documentation
+- [Test Documentation](docs/README.md) - Comprehensive test documentation and examples
 - [CI/CD Workflows](../.github/workflows/) - GitHub Actions workflows
 - [ESP-IDF Documentation](https://docs.espressif.com/projects/esp-idf/) - ESP-IDF reference
 

--- a/examples/esp32/docs/README.md
+++ b/examples/esp32/docs/README.md
@@ -1,0 +1,167 @@
+# 🧪 ESP32 Test Documentation
+
+<div align="center">
+
+![ESP32 Tests](https://img.shields.io/badge/ESP32-Test%20Documentation-blue?style=for-the-badge&logo=espressif)
+![Test Coverage](https://img.shields.io/badge/Coverage-Comprehensive-green?style=for-the-badge&logo=testing-library)
+![ESP-IDF](https://img.shields.io/badge/ESP--IDF-v5.5-orange?style=for-the-badge&logo=espressif)
+
+**🎯 Comprehensive Test Documentation for HardFOC ESP32 Interface Wrapper**
+
+*Complete test documentation covering all peripheral interfaces with hardware validation*
+
+</div>
+
+---
+
+## 📚 **Table of Contents**
+
+- [🎯 **Overview**](#-overview)
+- [🔧 **Test Categories**](#-test-categories)
+- [📋 **Test Documentation**](#-test-documentation)
+- [🚀 **Quick Start**](#-quick-start)
+- [🔗 **Related Documentation**](#-related-documentation)
+
+---
+
+## 🎯 **Overview**
+
+This directory contains comprehensive test documentation for all HardFOC ESP32 interface wrapper implementations. Each test suite validates hardware functionality, error handling, and performance characteristics of the respective peripheral interfaces.
+
+### 🏆 **Key Features**
+
+- **🔧 Hardware Validation** - Real hardware testing with proper connections
+- **📊 Performance Testing** - Throughput, latency, and reliability metrics
+- **🛡️ Error Handling** - Comprehensive error detection and recovery testing
+- **📈 Stress Testing** - High-load and edge case validation
+- **🔍 Signal Quality** - Electrical signal integrity verification
+
+---
+
+## 🔧 **Test Categories**
+
+### **Core Peripherals**
+- **[GPIO Testing](README_GPIO_TEST.md)** - Digital I/O, interrupts, pull resistors
+- **[ADC Testing](README_ADC_TEST.md)** - Analog-to-digital conversion, calibration
+- **[PWM Testing](README_PWM_TEST.md)** - Pulse-width modulation, frequency control
+- **[PIO Testing](README_PIO_TEST.md)** - Programmable I/O, custom protocols
+
+### **Communication Interfaces**
+- **[UART Testing](README_UART_TESTING.md)** - Serial communication, flow control
+- **[SPI Testing](README_SPI_TEST.md)** - Serial peripheral interface, DMA
+- **[I2C Testing](README_I2C_TEST.md)** - Inter-integrated circuit, device scanning
+- **[CAN Testing](README_CAN_TEST.md)** - Controller area network, SN65 transceiver
+
+### **Wireless Technologies**
+- **[WiFi Testing](README_WIFI_TEST.md)** - Wireless networking, connectivity
+- **[Bluetooth Testing](README_BLUETOOTH_TEST.md)** - Short-range communication
+
+### **System Features**
+- **[NVS Testing](README_NVS_TEST.md)** - Non-volatile storage, data persistence
+- **[Timer Testing](README_TIMER_TEST.md)** - Hardware timers, periodic events
+- **[Temperature Testing](README_TEMPERATURE_TEST.md)** - Thermal monitoring
+- **[Logger Testing](README_LOGGER_TEST.md)** - Logging system, debug output
+
+### **Utilities**
+- **[ASCII Art Testing](README_ASCII_ART_TEST.md)** - ASCII art generation
+- **[DOG Testing](README_DOG_TEST.md)** - Display on Glass testing
+
+---
+
+## 📋 **Test Documentation**
+
+| **Test Suite** | **Hardware** | **Key Features** | **Status** |
+|----------------|--------------|------------------|------------|
+| [**GPIO Test**](README_GPIO_TEST.md) | ESP32-C6 GPIO | Digital I/O, interrupts, pull resistors | ✅ Complete |
+| [**ADC Test**](README_ADC_TEST.md) | ESP32-C6 ADC | Multi-channel, calibration, voltage conversion | ✅ Complete |
+| [**PWM Test**](README_PWM_TEST.md) | ESP32-C6 LEDC | Multi-channel, frequency control, duty cycle | ✅ Complete |
+| [**PIO Test**](README_PIO_TEST.md) | ESP32-C6 PIO | Custom protocols, precise timing, encoding | ✅ Complete |
+| [**UART Test**](README_UART_TESTING.md) | ESP32-C6 UART | Async I/O, flow control, configurable parameters | ✅ Complete |
+| [**SPI Test**](README_SPI_TEST.md) | ESP32-C6 SPI | Full-duplex, configurable modes, DMA support | ✅ Complete |
+| [**I2C Test**](README_I2C_TEST.md) | ESP32-C6 I2C | Master mode, device scanning, error recovery | ✅ Complete |
+| [**CAN Test**](README_CAN_TEST.md) | ESP32-C6 + SN65 | Standard/Extended frames, filtering, error handling | ✅ Complete |
+| [**WiFi Test**](README_WIFI_TEST.md) | ESP32-C6 WiFi | Wireless networking, connectivity, security | ✅ Complete |
+| [**Bluetooth Test**](README_BLUETOOTH_TEST.md) | ESP32-C6 BT | Short-range communication, device discovery | ✅ Complete |
+| [**NVS Test**](README_NVS_TEST.md) | ESP32-C6 NVS | Non-volatile storage, data persistence | ✅ Complete |
+| [**Timer Test**](README_TIMER_TEST.md) | ESP32-C6 Timer | Hardware timers, periodic events, precision | ✅ Complete |
+| [**Temperature Test**](README_TEMPERATURE_TEST.md) | ESP32-C6 Temp | Thermal monitoring, calibration | ✅ Complete |
+| [**Logger Test**](README_LOGGER_TEST.md) | ESP32-C6 Logger | Logging system, debug output, levels | ✅ Complete |
+| [**ASCII Art Test**](README_ASCII_ART_TEST.md) | ESP32-C6 | ASCII art generation, display testing | ✅ Complete |
+| [**DOG Test**](README_DOG_TEST.md) | ESP32-C6 + Display | Display on Glass testing, graphics | ✅ Complete |
+
+---
+
+## 🚀 **Quick Start**
+
+### **Running Tests**
+
+1. **Navigate to ESP32 examples directory**:
+   ```bash
+   cd examples/esp32
+   ```
+
+2. **Build and run specific test**:
+   ```bash
+   # Build CAN test
+   idf.py -DAPP_NAME=can_test build flash monitor
+   
+   # Build GPIO test
+   idf.py -DAPP_NAME=gpio_test build flash monitor
+   ```
+
+3. **Run all tests**:
+   ```bash
+   # Build all test applications
+   ./scripts/build_all_tests.sh
+   ```
+
+### **Test Configuration**
+
+Each test can be configured by modifying the respective test file:
+- **Test sections**: Enable/disable specific test categories
+- **Hardware pins**: Configure GPIO pins for testing
+- **Performance parameters**: Adjust timing and throughput settings
+- **Error thresholds**: Set acceptable error rates
+
+### **Hardware Requirements**
+
+Most tests require minimal hardware:
+- **ESP32-C6 DevKit** - Primary development board
+- **Jumper wires** - For connections
+- **Basic components** - Resistors, LEDs, sensors (test-specific)
+
+**Special Requirements**:
+- **CAN Test**: SN65HVD230/232 transceiver, 120Ω termination
+- **SPI Test**: SPI device or loopback connections
+- **I2C Test**: I2C device or pull-up resistors
+- **Display Tests**: Compatible display hardware
+
+---
+
+## 🔗 **Related Documentation**
+
+### **API Documentation**
+- [📋 Base Interfaces](../../docs/api/README.md) - Abstract base classes
+- [🔧 ESP32 Implementations](../../docs/esp_api/README.md) - Hardware-specific implementations
+- [🛠️ Utility Classes](../../docs/utils/README.md) - Helper classes and utilities
+
+### **Specific Interface Documentation**
+- [BaseCan API](../../docs/api/BaseCan.md) - CAN bus interface
+- [EspCan Implementation](../../docs/esp_api/EspCan.md) - ESP32-C6 CAN implementation
+- [BaseGpio API](../../docs/api/BaseGpio.md) - GPIO interface
+- [BaseAdc API](../../docs/api/BaseAdc.md) - ADC interface
+
+### **Project Documentation**
+- [Main Project README](../../README.md) - Project overview
+- [ESP32 Examples README](../README.md) - Build system and examples
+- [ESP-IDF Documentation](https://docs.espressif.com/projects/esp-idf/) - ESP-IDF reference
+
+---
+
+<div align="center">
+
+**🧪 Comprehensive Testing for HardFOC ESP32 Interface Wrapper**
+
+*Professional-grade test documentation with hardware validation*
+
+</div>

--- a/examples/esp32/docs/README_CAN_TEST.md
+++ b/examples/esp32/docs/README_CAN_TEST.md
@@ -1,0 +1,206 @@
+# CAN Comprehensive Test Documentation
+
+## Overview
+
+This document describes the comprehensive CAN testing suite for ESP32-C6 with ESP-IDF v5.5 TWAI API and SN65 transceiver integration. The test suite validates all EspCan functionality including hardware integration, error handling, and performance characteristics.
+
+## Hardware Requirements
+
+### Required Components
+- **ESP32-C6 DevKit** - Primary microcontroller
+- **SN65HVD230/SN65HVD232** - CAN transceiver
+- **120Ω termination resistors** - CAN bus termination
+- **Jumper wires** - For connections
+
+### Optional Components
+- **Second CAN node** - For full bus testing
+- **Oscilloscope** - For signal quality analysis
+
+## Wiring Configuration
+
+### ESP32-C6 + SN65 Transceiver
+```
+ESP32-C6    SN65HVD230/232
+GPIO4   →   CTX (TX)
+GPIO5   →   CRX (RX)
+3.3V    →   VCC
+GND     →   GND
+```
+
+### CAN Bus Connections
+```
+SN65 CANH  →  CAN Bus High
+SN65 CANL  →  CAN Bus Low
+120Ω       →  Between CANH and CANL (termination)
+```
+
+### External Loopback Testing
+```
+SN65 CANH  →  120Ω resistor  →  SN65 CANL
+```
+
+## Test Configuration
+
+### Pin Configuration
+- **TX Pin**: GPIO4 (configurable)
+- **RX Pin**: GPIO5 (configurable)
+- **Baud Rate**: 500 kbps (configurable)
+- **Progress Indicator**: GPIO14 (toggles after each test)
+
+### Test Sections
+The test suite is organized into configurable sections:
+
+```cpp
+// Core functionality tests
+static constexpr bool ENABLE_CORE_TESTS = true;
+
+// Advanced feature tests  
+static constexpr bool ENABLE_ADVANCED_TESTS = true;
+
+// Error handling tests
+static constexpr bool ENABLE_ERROR_TESTS = true;
+
+// Performance tests
+static constexpr bool ENABLE_PERFORMANCE_TESTS = true;
+
+// SN65 transceiver tests
+static constexpr bool ENABLE_TRANSCEIVER_TESTS = true;
+```
+
+## Test Categories
+
+### 1. Core Tests
+- **Initialization Test**: Validates CAN controller startup
+- **Self-Test Mode**: Tests internal loopback functionality
+- **Message Transmission**: Basic send/receive operations
+
+### 2. Advanced Tests
+- **Acceptance Filtering**: Hardware message filtering
+- **Advanced Timing**: Bit timing configuration
+
+### 3. Error Tests
+- **Error Handling**: Comprehensive error detection
+- **Bus Recovery**: Recovery from bus-off state
+
+### 4. Performance Tests
+- **Batch Transmission**: Multiple message handling
+- **High Throughput**: Maximum performance testing
+
+### 5. Transceiver Tests
+- **Loopback Comparison**: Internal vs external loopback
+- **Physical Loopback**: Real CAN bus testing
+- **SN65 Integration**: Transceiver-specific tests
+- **Signal Quality**: Communication reliability
+
+## Loopback Modes
+
+### Internal Loopback
+- **Configuration**: `enable_loopback = true`
+- **Hardware**: TX and RX on same pin (GPIO4)
+- **Use Case**: Basic functionality testing
+- **Limitations**: No real CAN bus signaling
+
+### External Loopback
+- **Configuration**: `enable_loopback = false`
+- **Hardware**: CANH → 120Ω → CANL (after transceiver)
+- **Use Case**: Real CAN bus testing
+- **Advantages**: Tests actual differential signaling
+
+## Test Execution
+
+### Running Tests
+```bash
+# Build and flash the test
+idf.py build flash monitor
+
+# Enable specific test sections in CanComprehensiveTest.cpp
+# Modify the ENABLE_*_TESTS constants as needed
+```
+
+### Monitoring Progress
+- **Serial Output**: Detailed test results via UART
+- **GPIO14 Indicator**: Toggles after each test completion
+- **Test Sections**: 5 blinks indicate test section completion
+
+### Expected Results
+- **Success Rate**: >98% for signal quality tests
+- **Error Handling**: Proper error detection and recovery
+- **Performance**: Meets timing requirements
+- **Hardware Integration**: SN65 transceiver functionality
+
+## Troubleshooting
+
+### Common Issues
+
+#### Initialization Failures
+- Check GPIO pin configuration
+- Verify SN65 power supply (3.3V)
+- Ensure proper grounding
+
+#### Message Transmission Errors
+- Verify CAN bus termination (120Ω)
+- Check transceiver connections
+- Monitor error counters
+
+#### Signal Quality Issues
+- Check bus termination
+- Verify cable quality
+- Monitor for electrical interference
+
+### Error Codes
+The test suite uses comprehensive error reporting:
+- `CAN_SUCCESS`: Operation completed successfully
+- `CAN_ERR_BUS_OFF`: Bus-off state detected
+- `CAN_ERR_TIMEOUT`: Operation timeout
+- `CAN_ERR_HARDWARE_FAULT`: Hardware issue detected
+
+## Performance Metrics
+
+### Expected Performance
+- **Message Rate**: Up to 1000 messages/second
+- **Latency**: <1ms for single messages
+- **Success Rate**: >99% under normal conditions
+- **Error Recovery**: <100ms from bus-off
+
+### Monitoring
+- **Statistics**: Message counts, error rates
+- **Diagnostics**: Bus load, error counters
+- **Timing**: Message timestamps, latencies
+
+## Integration Notes
+
+### ESP-IDF v5.5 Compatibility
+- Uses modern TWAI node-based API
+- Supports advanced timing configuration
+- Implements proper error handling
+
+### SN65 Transceiver Features
+- 3.3V/5V compatible
+- High-speed operation (up to 1 Mbps)
+- Built-in protection features
+- Low power consumption
+
+## Related Documentation
+
+- [EspCan API Reference](../../../docs/esp_api/EspCan.md)
+- [BaseCan API Reference](../../../docs/api/BaseCan.md)
+- [ESP-IDF TWAI Driver](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/peripherals/twai.html)
+- [SN65HVD230 Datasheet](https://www.ti.com/lit/ds/symlink/sn65hvd230.pdf)
+
+## Test Results Interpretation
+
+### Success Criteria
+- All test sections complete without critical failures
+- Error rates within acceptable limits
+- Performance metrics meet requirements
+- Hardware integration functions correctly
+
+### Failure Analysis
+- Check hardware connections
+- Verify configuration parameters
+- Monitor error counters and statistics
+- Review test logs for specific error codes
+
+---
+
+*This documentation reflects the current state of the CAN testing suite as of 2025.*

--- a/examples/esp32/main/CanComprehensiveTest.cpp
+++ b/examples/esp32/main/CanComprehensiveTest.cpp
@@ -26,21 +26,21 @@
  * - 3.3V -> SN65 VCC
  * - GND -> SN65 GND
  * - SN65 CANH/CANL -> CAN bus
- * 
+ *
  * For External Loopback Testing:
  * - Connect: SN65 CANH -> 120Ω resistor -> SN65 CANL
  * - DO NOT short TWAI TX/RX lines directly!
  *
  * IMPORTANT: Two loopback modes are tested:
- * 
+ *
  * 1. INTERNAL LOOPBACK (enable_loopback=true):
  *    - Uses ESP32's internal hardware loopback
  *    - TX and RX on same pin (GPIO4)
  *    - No external hardware required
  *    - Interrupt callbacks work correctly
- *    - Used for: message_transmission, acceptance_filtering, batch_transmission, 
+ *    - Used for: message_transmission, acceptance_filtering, batch_transmission,
  *               high_throughput, bus_recovery, self_test_mode
- * 
+ *
  * 2. EXTERNAL LOOPBACK (enable_loopback=false):
  *    - Requires proper CAN bus loopback AFTER the transceiver
  *    - Connect: SN65 CANH -> 120Ω termination resistor -> SN65 CANL
@@ -48,7 +48,7 @@
  *    - Tests actual CAN bus communication with differential signaling
  *    - Used for: external_physical_loopback (in SN65 transceiver section)
  *    - NOTE: Shorting TWAI TX/RX lines directly does NOT work!
- * 
+ *
  * ## Test Progression Indicator:
  * GPIO14 toggles HIGH/LOW after each test completion for visual feedback.
  * Test sections are indicated by 5 blinks on GPIO14 (like SpiComprehensiveTest).
@@ -96,7 +96,7 @@ static constexpr hf_pin_num_t TEST_TX_PIN = 4; // ESP32-C6 + SN65
 static constexpr hf_pin_num_t TEST_RX_PIN = 5; // ESP32-C6 + SN65
 
 // Event bits for synchronization
-  static constexpr int MESSAGE_RECEIVED_BIT = BIT0;
+static constexpr int MESSAGE_RECEIVED_BIT = BIT0;
 static constexpr int ERROR_OCCURRED_BIT = BIT1;
 static constexpr int STATE_CHANGED_BIT = BIT2;
 
@@ -128,7 +128,7 @@ static constexpr bool ENABLE_TRANSCEIVER_TESTS =
  */
 void verify_can_pin_states() {
   ESP_LOGI(TAG, "Verifying CAN pin states...");
-  
+
   // Note: We can't directly read GPIO states in this context,
   // but we can log the expected behavior
   ESP_LOGI(TAG, "Expected CAN pin behavior:");
@@ -144,10 +144,10 @@ void verify_can_pin_states() {
  */
 void test_receive_callback_enhanced(const hf_can_message_t& message, void* user_data) {
   (void)user_data; // Unused in basic tests
-  
+
   last_received_message = message;
   messages_received.fetch_add(1);
-  
+
   // Signal that a message was received (for test synchronization)
   if (test_event_group) {
     BaseType_t higher_priority_task_woken = pdFALSE;
@@ -192,22 +192,22 @@ bool wait_for_event(EventBits_t bits, uint32_t timeout_ms) {
  */
 bool test_basic_initialization() noexcept {
   ESP_LOGI(TAG, "Feature 1: Basic Initialization and State Management");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_RX_PIN;
   config.baud_rate = TEST_BAUD_RATE;
   config.enable_self_test = true;
   config.enable_loopback = false;
-  
+
   EspCan can(config);
-  
+
   // Test lazy initialization
   if (can.IsInitialized()) {
     ESP_LOGE(TAG, "❌ Lazy initialization failed - should not be initialized");
     return false;
   }
-  
+
   // Test initialization
   if (can.Initialize() != hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGE(TAG, "❌ Initialization failed");
@@ -218,7 +218,7 @@ bool test_basic_initialization() noexcept {
   } else {
     ESP_LOGI(TAG, "✅ Initialization and state management - PASSED");
   }
-  
+
   // Test deinitialization
   if (can.Deinitialize() != hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGE(TAG, "❌ Deinitialization failed");
@@ -227,7 +227,7 @@ bool test_basic_initialization() noexcept {
     ESP_LOGE(TAG, "❌ IsInitialized() should return false after Deinitialize()");
     return false;
   }
-  
+
   return true;
 }
 
@@ -236,18 +236,18 @@ bool test_basic_initialization() noexcept {
  */
 bool test_message_transmission() noexcept {
   ESP_LOGI(TAG, "Feature 2: Message Transmission and Reception");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_TX_PIN; // Use same pin for internal loopback
   config.baud_rate = TEST_BAUD_RATE;
   config.enable_self_test = true;
   config.enable_loopback = true; // Enable internal loopback
-  
+
   EspCan can(config);
   can.Initialize();
   can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-  
+
   // Test standard frame
   messages_received.store(0);
   auto std_msg = create_test_message(0x123, false, 8);
@@ -258,7 +258,7 @@ bool test_message_transmission() noexcept {
     ESP_LOGE(TAG, "❌ Standard frame transmission - FAILED");
     return false;
   }
-  
+
   // Test extended frame
   messages_received.store(0);
   auto ext_msg = create_test_message(0x12345678, true, 6);
@@ -269,7 +269,7 @@ bool test_message_transmission() noexcept {
     ESP_LOGE(TAG, "❌ Extended frame transmission - FAILED");
     return false;
   }
-  
+
   // Test RTR frame
   messages_received.store(0);
   hf_can_message_t rtr_msg = create_test_message(0x456, false, 4);
@@ -281,7 +281,7 @@ bool test_message_transmission() noexcept {
     ESP_LOGE(TAG, "❌ RTR frame transmission - FAILED");
     return false;
   }
-  
+
   return true;
 }
 
@@ -290,18 +290,18 @@ bool test_message_transmission() noexcept {
  */
 bool test_acceptance_filtering() noexcept {
   ESP_LOGI(TAG, "Feature 3: Acceptance Filtering");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_TX_PIN; // Use same pin for internal loopback
   config.baud_rate = TEST_BAUD_RATE;
   config.enable_self_test = true;
   config.enable_loopback = true; // Enable internal loopback
-  
+
   EspCan can(config);
   can.Initialize();
   can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-  
+
   // Set filter to accept only 0x100-0x10F
   if (can.SetAcceptanceFilter(0x100, 0x7F0, false) == hf_can_err_t::CAN_SUCCESS) {
     // Test accepted message
@@ -314,7 +314,7 @@ bool test_acceptance_filtering() noexcept {
       ESP_LOGE(TAG, "❌ Filter acceptance - FAILED");
       return false;
     }
-    
+
     // Test rejected message
     messages_received.store(0);
     auto rejected_msg = create_test_message(0x200, false, 4);
@@ -329,7 +329,7 @@ bool test_acceptance_filtering() noexcept {
     ESP_LOGE(TAG, "❌ Filter configuration - FAILED");
     return false;
   }
-  
+
   return true;
 }
 
@@ -338,24 +338,24 @@ bool test_acceptance_filtering() noexcept {
  */
 bool test_advanced_timing() noexcept {
   ESP_LOGI(TAG, "Feature 4: Advanced Timing Configuration");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_RX_PIN;
   config.baud_rate = 250000; // Different baud rate
   config.enable_self_test = true;
   config.enable_loopback = false;
-  
+
   EspCan can(config);
   can.Initialize();
-  
+
   hf_esp_can_timing_config_t timing{};
   timing.brp = 16;
   timing.prop_seg = 5;
   timing.tseg_1 = 8;
   timing.tseg_2 = 3;
   timing.sjw = 2;
-  
+
   if (can.ConfigureAdvancedTiming(timing) == hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGI(TAG, "✅ Advanced timing configuration - PASSED");
     return true;
@@ -370,24 +370,24 @@ bool test_advanced_timing() noexcept {
  */
 bool test_statistics_diagnostics() noexcept {
   ESP_LOGI(TAG, "Feature 5: Statistics and Diagnostics");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_RX_PIN;
   config.baud_rate = TEST_BAUD_RATE;
   config.enable_self_test = true;
   config.enable_loopback = false;
-  
+
   EspCan can(config);
   can.Initialize();
   can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-  
+
   // Reset statistics
   if (can.ResetStatistics() != hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGE(TAG, "❌ Reset statistics - FAILED");
     return false;
   }
-  
+
   // Send some messages to generate statistics
   messages_received.store(0);
   for (int i = 0; i < 5; i++) {
@@ -400,11 +400,12 @@ bool test_statistics_diagnostics() noexcept {
     vTaskDelay(pdMS_TO_TICKS(50)); // Small delay between messages
   }
   vTaskDelay(pdMS_TO_TICKS(200));
-  
+
   // Get statistics
   hf_can_statistics_t stats{};
   if (can.GetStatistics(stats) == hf_can_err_t::CAN_SUCCESS) {
-    ESP_LOGI(TAG, "Statistics: sent=%llu, received=%llu", stats.messages_sent.load(), stats.messages_received.load());
+    ESP_LOGI(TAG, "Statistics: sent=%llu, received=%llu", stats.messages_sent.load(),
+             stats.messages_received.load());
     if (stats.messages_sent.load() > 0) {
       ESP_LOGI(TAG, "✅ Statistics collection - PASSED");
     } else {
@@ -415,7 +416,7 @@ bool test_statistics_diagnostics() noexcept {
     ESP_LOGE(TAG, "❌ Get statistics - FAILED");
     return false;
   }
-  
+
   // Get diagnostics
   hf_can_diagnostics_t diagnostics{};
   if (can.GetDiagnostics(diagnostics) == hf_can_err_t::CAN_SUCCESS) {
@@ -424,7 +425,7 @@ bool test_statistics_diagnostics() noexcept {
     ESP_LOGE(TAG, "❌ Diagnostics retrieval - FAILED");
     return false;
   }
-  
+
   return true;
 }
 
@@ -433,7 +434,7 @@ bool test_statistics_diagnostics() noexcept {
  */
 bool test_batch_transmission() noexcept {
   ESP_LOGI(TAG, "Feature 6: Batch Message Transmission");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_TX_PIN; // Use same pin for internal loopback
@@ -441,27 +442,29 @@ bool test_batch_transmission() noexcept {
   config.enable_self_test = true;
   config.enable_loopback = true; // Enable internal loopback
   config.tx_queue_depth = 20;
-  
+
   EspCan can(config);
   can.Initialize();
   can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-  
+
   // Create batch of messages (smaller batch to avoid memory issues)
   const int BATCH_SIZE = 3;
   hf_can_message_t batch_messages[BATCH_SIZE]; // Use stack array instead of vector
   for (int i = 0; i < BATCH_SIZE; i++) {
     batch_messages[i] = create_test_message(0x300 + i, false, 8);
   }
-  
+
   messages_received.store(0);
   uint32_t sent_count = can.SendMessageBatch(batch_messages, BATCH_SIZE, 500);
   vTaskDelay(pdMS_TO_TICKS(500));
-  
+
   if (sent_count >= BATCH_SIZE * 0.9f && messages_received.load() >= sent_count * 0.9f) {
-    ESP_LOGI(TAG, "✅ Batch transmission - PASSED (sent: %d, received: %d)", sent_count, messages_received.load());
+    ESP_LOGI(TAG, "✅ Batch transmission - PASSED (sent: %d, received: %d)", sent_count,
+             messages_received.load());
     return true;
   } else {
-    ESP_LOGE(TAG, "❌ Batch transmission - FAILED (sent: %d, received: %d)", sent_count, messages_received.load());
+    ESP_LOGE(TAG, "❌ Batch transmission - FAILED (sent: %d, received: %d)", sent_count,
+             messages_received.load());
     return false;
   }
 }
@@ -471,17 +474,17 @@ bool test_batch_transmission() noexcept {
  */
 bool test_error_handling() noexcept {
   ESP_LOGI(TAG, "Feature 7: Error Handling and Recovery");
-  
+
   hf_esp_can_config_t config{};
   config.tx_pin = TEST_TX_PIN;
   config.rx_pin = TEST_RX_PIN;
   config.baud_rate = TEST_BAUD_RATE;
   config.enable_self_test = true;
   config.enable_alerts = true;
-  
+
   EspCan can(config);
   can.Initialize();
-  
+
   // Test status retrieval
   hf_can_status_t status{};
   if (can.GetStatus(status) == hf_can_err_t::CAN_SUCCESS) {
@@ -490,7 +493,7 @@ bool test_error_handling() noexcept {
     ESP_LOGE(TAG, "❌ Status retrieval - FAILED");
     return false;
   }
-  
+
   // Test reset functionality
   if (can.Reset() == hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGI(TAG, "✅ Reset functionality - PASSED");
@@ -498,7 +501,7 @@ bool test_error_handling() noexcept {
     ESP_LOGE(TAG, "❌ Reset functionality - FAILED");
     return false;
   }
-  
+
   // Test bus recovery
   if (can.InitiateBusRecovery() == hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGI(TAG, "✅ Bus recovery - PASSED");
@@ -506,7 +509,7 @@ bool test_error_handling() noexcept {
     ESP_LOGE(TAG, "❌ Bus recovery - FAILED");
     return false;
   }
-  
+
   return true;
 }
 
@@ -518,38 +521,38 @@ bool test_espcan_comprehensive_functionality() noexcept {
   ESP_LOGI(TAG, "🔍 COMPREHENSIVE EspCan Functionality Validation");
   ESP_LOGI(TAG, "This test validates ALL EspCan features systematically");
   ESP_LOGI(TAG, "*** USING: Internal hardware loopback (TX and RX on GPIO%d) ***", TEST_TX_PIN);
-  
+
   bool all_features_passed = true;
-  
+
   // Run individual feature tests
   if (!test_basic_initialization()) {
     all_features_passed = false;
   }
-  
+
   if (!test_message_transmission()) {
     all_features_passed = false;
   }
-  
+
   if (!test_acceptance_filtering()) {
     all_features_passed = false;
   }
-  
+
   if (!test_advanced_timing()) {
     all_features_passed = false;
   }
-  
+
   if (!test_statistics_diagnostics()) {
     all_features_passed = false;
   }
-  
+
   if (!test_batch_transmission()) {
     all_features_passed = false;
   }
-  
+
   if (!test_error_handling()) {
     all_features_passed = false;
   }
-  
+
   // ============================================================================
   // SUMMARY
   // ============================================================================
@@ -560,7 +563,7 @@ bool test_espcan_comprehensive_functionality() noexcept {
     ESP_LOGE(TAG, "💥 [FAILED] ❌ Some EspCan features failed validation!");
     ESP_LOGE(TAG, "Review the failed features above and address the issues.");
   }
-  
+
   return all_features_passed;
 }
 
@@ -625,40 +628,41 @@ bool test_can_initialization() noexcept {
 
 bool test_can_self_test_mode() noexcept {
   ESP_LOGI(TAG, "Testing comprehensive TWAI self-test modes for ESP32-C6...");
-  
+
   bool all_tests_passed = true;
-  
+
   // ============================================================================
   // TEST 1: Pure Internal Hardware Loopback (ESP-IDF v5.5 Style)
   // ============================================================================
   ESP_LOGI(TAG, "Test 1: Internal hardware loopback (enable_loopback=true)");
-  
+
   {
     hf_esp_can_config_t internal_config{};
     internal_config.tx_pin = TEST_TX_PIN;
     internal_config.rx_pin = TEST_RX_PIN;
     internal_config.baud_rate = TEST_BAUD_RATE;
-    internal_config.enable_self_test = true;  // No ACK required
-    internal_config.enable_loopback = true;   // Internal hardware loopback
-    
+    internal_config.enable_self_test = true; // No ACK required
+    internal_config.enable_loopback = true;  // Internal hardware loopback
+
     EspCan internal_can(internal_config);
-    
+
     if (internal_can.Initialize() != hf_can_err_t::CAN_SUCCESS) {
       ESP_LOGE(TAG, "Failed to initialize internal loopback CAN");
       all_tests_passed = false;
     } else {
       internal_can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-      
+
       // Test with self-reception request (like ESP-IDF example)
       auto test_msg = create_test_message(TEST_CAN_ID_STANDARD, false, 4);
-      test_msg.is_self = true;  // Self-reception request flag
-      
+      test_msg.is_self = true; // Self-reception request flag
+
       messages_received.store(0);
       if (internal_can.SendMessage(test_msg, 1000) == hf_can_err_t::CAN_SUCCESS) {
         if (wait_for_event(MESSAGE_RECEIVED_BIT, 1000)) {
           ESP_LOGI(TAG, "✅ Internal loopback test PASSED");
         } else {
-          ESP_LOGW(TAG, "⚠️  Internal loopback: No message received (may be ESP-IDF v5.5 limitation)");
+          ESP_LOGW(TAG,
+                   "⚠️  Internal loopback: No message received (may be ESP-IDF v5.5 limitation)");
         }
       } else {
         ESP_LOGE(TAG, "❌ Internal loopback: Failed to send message");
@@ -666,31 +670,31 @@ bool test_can_self_test_mode() noexcept {
       }
     }
   }
-  
+
   // ============================================================================
   // TEST 2: Performance Test with Internal Loopback
   // ============================================================================
   ESP_LOGI(TAG, "Test 2: Performance test with internal loopback");
-  
+
   {
     hf_esp_can_config_t perf_config{};
     perf_config.tx_pin = TEST_TX_PIN;
     perf_config.rx_pin = TEST_TX_PIN; // Use same pin for internal loopback
     perf_config.baud_rate = TEST_BAUD_RATE;
-    perf_config.enable_self_test = true;  // No ACK required for internal loopback
-    perf_config.enable_loopback = true; // Enable internal loopback
-    perf_config.tx_queue_depth = 20; // Larger queue for performance test
-    
+    perf_config.enable_self_test = true; // No ACK required for internal loopback
+    perf_config.enable_loopback = true;  // Enable internal loopback
+    perf_config.tx_queue_depth = 20;     // Larger queue for performance test
+
     EspCan perf_can(perf_config);
-    
+
     if (perf_can.Initialize() == hf_can_err_t::CAN_SUCCESS) {
       perf_can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-      
+
       const int PERF_MESSAGE_COUNT = 50;
       messages_received.store(0);
-      
+
       uint64_t start_time = esp_timer_get_time();
-      
+
       // Send burst of messages
       int sent_count = 0;
       for (int i = 0; i < PERF_MESSAGE_COUNT; i++) {
@@ -699,20 +703,20 @@ bool test_can_self_test_mode() noexcept {
           sent_count++;
         }
       }
-      
+
       // Wait for all messages to be received
       vTaskDelay(pdMS_TO_TICKS(2000));
-      
+
       uint64_t end_time = esp_timer_get_time();
       uint32_t duration_ms = (uint32_t)((end_time - start_time) / 1000);
       uint32_t received_count = messages_received.load();
-      
+
       ESP_LOGI(TAG, "Performance results:");
       ESP_LOGI(TAG, "  Messages sent: %d/%d", sent_count, PERF_MESSAGE_COUNT);
       ESP_LOGI(TAG, "  Messages received: %d", received_count);
       ESP_LOGI(TAG, "  Duration: %d ms", duration_ms);
       ESP_LOGI(TAG, "  Success rate: %.1f%%", (float)received_count / sent_count * 100.0f);
-      
+
       if (received_count >= sent_count * 0.95f) { // 95% success rate
         ESP_LOGI(TAG, "✅ Performance test PASSED");
       } else {
@@ -721,14 +725,17 @@ bool test_can_self_test_mode() noexcept {
       }
     }
   }
-  
+
   if (all_tests_passed) {
     ESP_LOGI(TAG, "[SUCCESS] ✅ Comprehensive CAN self-test mode PASSED");
-    ESP_LOGI(TAG, "NOTE: For best results, ensure GPIO%d (TX) is connected to GPIO%d (RX) with a jumper wire", TEST_TX_PIN, TEST_RX_PIN);
+    ESP_LOGI(
+        TAG,
+        "NOTE: For best results, ensure GPIO%d (TX) is connected to GPIO%d (RX) with a jumper wire",
+        TEST_TX_PIN, TEST_RX_PIN);
   } else {
     ESP_LOGE(TAG, "[FAILED] ❌ Some CAN self-test modes FAILED");
   }
-  
+
   return all_tests_passed;
 }
 
@@ -740,8 +747,8 @@ bool test_can_message_transmission() noexcept {
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_TX_PIN; // Same pin for internal loopback (like ESP-IDF example)
   can_config.baud_rate = TEST_BAUD_RATE;
-  can_config.enable_self_test = true;  // No ACK required (like ESP-IDF example)
-  can_config.enable_loopback = true;   // Enable internal loopback (like ESP-IDF example)
+  can_config.enable_self_test = true; // No ACK required (like ESP-IDF example)
+  can_config.enable_loopback = true;  // Enable internal loopback (like ESP-IDF example)
 
   EspCan test_can(can_config);
 
@@ -827,8 +834,8 @@ bool test_can_acceptance_filtering() noexcept {
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_TX_PIN; // Same pin for internal loopback (like ESP-IDF example)
   can_config.baud_rate = TEST_BAUD_RATE;
-  can_config.enable_self_test = true;  // No ACK required (like ESP-IDF example)
-  can_config.enable_loopback = true;   // Enable internal loopback (like ESP-IDF example)
+  can_config.enable_self_test = true; // No ACK required (like ESP-IDF example)
+  can_config.enable_loopback = true;  // Enable internal loopback (like ESP-IDF example)
 
   EspCan test_can(can_config);
 
@@ -905,7 +912,8 @@ bool test_can_acceptance_filtering() noexcept {
   // Wait for both messages
   vTaskDelay(pdMS_TO_TICKS(1000));
 
-  ESP_LOGI(TAG, "Dual filter test: received %d messages (expected 0-2 in loopback mode)", messages_received.load());
+  ESP_LOGI(TAG, "Dual filter test: received %d messages (expected 0-2 in loopback mode)",
+           messages_received.load());
 
   // Clear filter (accept all)
   if (test_can.ClearAcceptanceFilter() != hf_can_err_t::CAN_SUCCESS) {
@@ -928,8 +936,8 @@ bool test_can_advanced_timing() noexcept {
   hf_esp_can_config_t can_config{};
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_RX_PIN;
-  can_config.baud_rate = 250000; // Start with 250kbps
-  can_config.enable_self_test = true;  // No external ACK required
+  can_config.baud_rate = 250000;      // Start with 250kbps
+  can_config.enable_self_test = true; // No external ACK required
   can_config.enable_loopback = false; // Using physical wire loopback
 
   EspCan test_can(can_config);
@@ -1051,8 +1059,8 @@ bool test_can_bus_recovery() noexcept {
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_TX_PIN; // Use same pin for internal loopback
   can_config.baud_rate = TEST_BAUD_RATE;
-  can_config.enable_self_test = true;  // No ACK required for internal loopback
-  can_config.enable_loopback = true; // Enable internal loopback
+  can_config.enable_self_test = true; // No ACK required for internal loopback
+  can_config.enable_loopback = true;  // Enable internal loopback
   can_config.enable_alerts = true;
 
   EspCan test_can(can_config);
@@ -1104,9 +1112,9 @@ bool test_can_batch_transmission() noexcept {
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_TX_PIN; // Same pin for internal loopback (like ESP-IDF example)
   can_config.baud_rate = TEST_BAUD_RATE;
-  can_config.enable_self_test = true;  // No ACK required (like ESP-IDF example)
-  can_config.enable_loopback = true;   // Enable internal loopback (like ESP-IDF example)
-  can_config.tx_queue_depth = 20; // Larger queue for batch testing
+  can_config.enable_self_test = true; // No ACK required (like ESP-IDF example)
+  can_config.enable_loopback = true;  // Enable internal loopback (like ESP-IDF example)
+  can_config.tx_queue_depth = 20;     // Larger queue for batch testing
 
   EspCan test_can(can_config);
 
@@ -1164,10 +1172,10 @@ bool test_can_high_throughput() noexcept {
 
   hf_esp_can_config_t can_config{};
   can_config.tx_pin = TEST_TX_PIN;
-  can_config.rx_pin = TEST_TX_PIN; // Use same pin for internal loopback
-  can_config.baud_rate = 1000000; // 1 Mbps for high throughput
-  can_config.enable_self_test = true;  // No ACK required for internal loopback
-  can_config.enable_loopback = true; // Enable internal loopback
+  can_config.rx_pin = TEST_TX_PIN;    // Use same pin for internal loopback
+  can_config.baud_rate = 1000000;     // 1 Mbps for high throughput
+  can_config.enable_self_test = true; // No ACK required for internal loopback
+  can_config.enable_loopback = true;  // Enable internal loopback
   can_config.tx_queue_depth = 50;
   can_config.sample_point_permill = 800; // 80% for high speed
 
@@ -1243,45 +1251,43 @@ bool test_external_physical_loopback() noexcept {
   ESP_LOGI(TAG, "*** REQUIRES: CAN bus loopback AFTER transceiver ***");
   ESP_LOGI(TAG, "*** Connect: SN65 CANH -> 120Ω resistor -> SN65 CANL ***");
   ESP_LOGI(TAG, "*** DO NOT short TWAI TX/RX lines directly - this will NOT work! ***");
-  
+
   hf_esp_can_config_t can_config{};
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_RX_PIN;
   can_config.baud_rate = TEST_BAUD_RATE;
-  can_config.enable_self_test = true;  // Enable self-test (no ACK required)
+  can_config.enable_self_test = true; // Enable self-test (no ACK required)
   can_config.enable_loopback = false; // Disable internal loopback - using external wire
-  can_config.tx_queue_depth = 20; // Larger queue for external loopback
-  
+  can_config.tx_queue_depth = 20;     // Larger queue for external loopback
+
   EspCan test_can(can_config);
-  
+
   if (test_can.Initialize() != hf_can_err_t::CAN_SUCCESS) {
     ESP_LOGE(TAG, "Failed to initialize CAN for external loopback test");
     return false;
   }
-  
+
   test_can.SetReceiveCallbackEx(test_receive_callback_enhanced);
-  
+
   // Test multiple message formats
   std::vector<std::pair<std::string, hf_can_message_t>> test_cases = {
-    {"Standard 11-bit ID", create_test_message(0x123, false, 8)},
-    {"Extended 29-bit ID", create_test_message(0x12345678, true, 6)},
-    {"Short message (2 bytes)", create_test_message(0x456, false, 2)},
-    {"RTR frame", [](){
-      auto rtr_msg = create_test_message(0x789, false, 4);
-      rtr_msg.is_rtr = true;
-      return rtr_msg;
-    }()}
-  };
-  
-  ESP_LOGI(TAG, "Configuration: TX=GPIO%d, RX=GPIO%d, Self-test=%s, Loopback=%s", 
-           can_config.tx_pin, can_config.rx_pin, 
-           can_config.enable_self_test ? "true" : "false",
+      {"Standard 11-bit ID", create_test_message(0x123, false, 8)},
+      {"Extended 29-bit ID", create_test_message(0x12345678, true, 6)},
+      {"Short message (2 bytes)", create_test_message(0x456, false, 2)},
+      {"RTR frame", []() {
+         auto rtr_msg = create_test_message(0x789, false, 4);
+         rtr_msg.is_rtr = true;
+         return rtr_msg;
+       }()}};
+
+  ESP_LOGI(TAG, "Configuration: TX=GPIO%d, RX=GPIO%d, Self-test=%s, Loopback=%s", can_config.tx_pin,
+           can_config.rx_pin, can_config.enable_self_test ? "true" : "false",
            can_config.enable_loopback ? "true" : "false");
-  
+
   bool all_tests_passed = true;
   for (const auto& test_case : test_cases) {
     ESP_LOGI(TAG, "Testing: %s", test_case.first.c_str());
-    
+
     messages_received.store(0);
     if (test_can.SendMessage(test_case.second, 1000) == hf_can_err_t::CAN_SUCCESS) {
       if (wait_for_event(MESSAGE_RECEIVED_BIT, 2000)) {
@@ -1302,10 +1308,10 @@ bool test_external_physical_loopback() noexcept {
       ESP_LOGE(TAG, "❌ %s - Failed to send", test_case.first.c_str());
       all_tests_passed = false;
     }
-    
+
     vTaskDelay(pdMS_TO_TICKS(100)); // Brief delay between tests
   }
-  
+
   if (all_tests_passed) {
     ESP_LOGI(TAG, "✅ External physical loopback test PASSED");
   } else {
@@ -1313,13 +1319,13 @@ bool test_external_physical_loopback() noexcept {
     ESP_LOGE(TAG, "Note: This test requires CANH->120Ω->CANL loopback AFTER transceiver");
     ESP_LOGE(TAG, "DO NOT short TWAI TX/RX lines directly - this will NOT work!");
   }
-  
+
   return all_tests_passed;
 }
 
 bool test_loopback_comparison() noexcept {
   ESP_LOGI(TAG, "Testing internal vs external loopback comparison...");
-  
+
   // Test 1: Internal loopback (should work)
   ESP_LOGI(TAG, "Test 1: Internal loopback (TX=GPIO%d, RX=GPIO%d)", TEST_TX_PIN, TEST_TX_PIN);
   {
@@ -1329,12 +1335,12 @@ bool test_loopback_comparison() noexcept {
     internal_config.baud_rate = TEST_BAUD_RATE;
     internal_config.enable_self_test = true;
     internal_config.enable_loopback = true; // Internal loopback
-    
+
     EspCan internal_can(internal_config);
     if (internal_can.Initialize() == hf_can_err_t::CAN_SUCCESS) {
       internal_can.SetReceiveCallbackEx(test_receive_callback_enhanced);
       messages_received.store(0);
-      
+
       auto test_msg = create_test_message(0x100, false, 4);
       if (internal_can.SendMessage(test_msg, 1000) == hf_can_err_t::CAN_SUCCESS) {
         if (wait_for_event(MESSAGE_RECEIVED_BIT, 1000)) {
@@ -1347,7 +1353,7 @@ bool test_loopback_comparison() noexcept {
       }
     }
   }
-  
+
   // Test 2: External loopback (with proper CAN bus loopback)
   ESP_LOGI(TAG, "Test 2: External loopback (TX=GPIO%d, RX=GPIO%d)", TEST_TX_PIN, TEST_RX_PIN);
   ESP_LOGI(TAG, "Note: This requires CANH->120Ω->CANL loopback AFTER transceiver");
@@ -1358,25 +1364,27 @@ bool test_loopback_comparison() noexcept {
     external_config.baud_rate = TEST_BAUD_RATE;
     external_config.enable_self_test = true;
     external_config.enable_loopback = false; // External loopback
-    
+
     EspCan external_can(external_config);
     if (external_can.Initialize() == hf_can_err_t::CAN_SUCCESS) {
       external_can.SetReceiveCallbackEx(test_receive_callback_enhanced);
       messages_received.store(0);
-      
+
       auto test_msg = create_test_message(0x200, false, 4);
       if (external_can.SendMessage(test_msg, 1000) == hf_can_err_t::CAN_SUCCESS) {
         if (wait_for_event(MESSAGE_RECEIVED_BIT, 1000)) {
           ESP_LOGI(TAG, "✅ External loopback: Message received successfully");
         } else {
-          ESP_LOGW(TAG, "⚠️  External loopback: No message received (requires CANH->120Ω->CANL loopback)");
+          ESP_LOGW(
+              TAG,
+              "⚠️  External loopback: No message received (requires CANH->120Ω->CANL loopback)");
         }
       } else {
         ESP_LOGE(TAG, "❌ External loopback: Failed to send message");
       }
     }
   }
-  
+
   ESP_LOGI(TAG, "Loopback comparison test completed");
   return true;
 }
@@ -1444,7 +1452,7 @@ bool test_can_signal_quality() noexcept {
   can_config.tx_pin = TEST_TX_PIN;
   can_config.rx_pin = TEST_RX_PIN;
   can_config.baud_rate = TEST_BAUD_RATE;
-  can_config.enable_self_test = true;  // No external ACK required
+  can_config.enable_self_test = true; // No external ACK required
   can_config.enable_loopback = false; // Using physical wire loopback
   can_config.enable_alerts = true;
 
@@ -1562,7 +1570,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after self-test mode test
       RUN_TEST_IN_TASK("message_transmission", test_can_message_transmission, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after message transmission test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_ADVANCED_TESTS, "CAN ADVANCED TESTS", 5,
@@ -1572,7 +1580,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after acceptance filtering test
       RUN_TEST_IN_TASK("advanced_timing", test_can_advanced_timing, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after advanced timing test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_ERROR_TESTS, "CAN ERROR TESTS", 5,
@@ -1582,7 +1590,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after error handling test
       RUN_TEST_IN_TASK("bus_recovery", test_can_bus_recovery, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after bus recovery test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_PERFORMANCE_TESTS, "CAN PERFORMANCE TESTS", 5,
@@ -1592,7 +1600,7 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after batch transmission test
       RUN_TEST_IN_TASK("high_throughput", test_can_high_throughput, 12288, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after high throughput test
-      );
+  );
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_TRANSCEIVER_TESTS, "CAN TRANSCEIVER TESTS", 5,
@@ -1606,14 +1614,14 @@ extern "C" void app_main(void) {
       flip_test_progress_indicator(); // Toggle GPIO14 after SN65 transceiver integration test
       RUN_TEST_IN_TASK("can_signal_quality", test_can_signal_quality, 8192, 1);
       flip_test_progress_indicator(); // Toggle GPIO14 after signal quality test
-      );
+  );
 
   print_test_summary(g_test_results, "ESP32-C6 CAN (ESP-IDF v5.5 + SN65)", TAG);
 
   // Cleanup
   vEventGroupDelete(test_event_group);
 
-  ESP_LOGI(TAG,"\n");
+  ESP_LOGI(TAG, "\n");
   ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
   ESP_LOGI(TAG, "║                      TEST SUITE COMPLETED                                    ║");
   ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");

--- a/examples/esp32/main/DigitalOutputGuardComprehensiveTest.cpp
+++ b/examples/esp32/main/DigitalOutputGuardComprehensiveTest.cpp
@@ -23,60 +23,60 @@
  *
  * PERFORMANCE TESTING AND EXPECTED OUTPUTS:
  * ==========================================
- * 
+ *
  * The performance tests measure critical timing characteristics of the DigitalOutputGuard:
- * 
+ *
  * 1. GUARD CREATION/DESTRUCTION PERFORMANCE:
  *    - Tests: 1000 iterations of guard creation and destruction
  *    - Measures: Complete RAII lifecycle timing
  *    - Expected: < 100 μs per cycle (typically 2-5 μs on ESP32-C6)
  *    - Output: "Guard creation/destruction: 1000 iterations in X.XX ms (avg: X.XX us per cycle)"
  *    - Significance: Validates efficient object lifecycle management
- * 
+ *
  * 2. STATE TRANSITION PERFORMANCE:
  *    - Tests: 1000 iterations of SetActive()/SetInactive() operations
  *    - Measures: GPIO state change timing
  *    - Expected: < 50 μs per operation (typically 1-3 μs on ESP32-C6)
  *    - Output: "State transitions: 1000 iterations in X.XX ms (avg: X.XX us per operation)"
  *    - Significance: Validates fast GPIO control without overhead
- * 
+ *
  * 3. STRESS TEST PERFORMANCE:
  *    - Tests: 2000 iterations with 5 state changes per iteration across 3 GPIO pins
  *    - Measures: Complex multi-GPIO scenario timing
  *    - Expected: < 200 μs per iteration (typically 5-15 μs on ESP32-C6)
  *    - Output: "Stress test: 2000 iterations in X.XX ms (avg: X.XX us per iteration)"
  *    - Significance: Validates performance under realistic usage patterns
- * 
+ *
  * 4. CONCURRENT ACCESS PERFORMANCE:
  *    - Tests: 3 concurrent tasks performing 100 operations each (300 total)
  *    - Measures: Multi-threaded access timing and thread safety
  *    - Expected: All operations complete successfully without race conditions
  *    - Output: "DigitalOutputGuard concurrent access test successful: 300 operations"
  *    - Significance: Validates thread-safe operation under concurrent load
- * 
+ *
  * PERFORMANCE INTERPRETATION:
  * ===========================
- * 
+ *
  * Excellent Performance Indicators:
  * - Guard creation/destruction < 5 μs: Minimal RAII overhead
  * - State transitions < 3 μs: Direct GPIO control efficiency
  * - Stress test < 15 μs: Good scalability under load
  * - 100% concurrent test success: Robust thread safety
- * 
+ *
  * Performance Degradation Warnings:
  * - Guard creation/destruction > 50 μs: Potential memory allocation issues
  * - State transitions > 20 μs: GPIO driver inefficiency
  * - Stress test > 100 μs: Resource contention or memory fragmentation
  * - Concurrent test failures: Thread safety violations
- * 
+ *
  * @author Nebiyu Tadesse
  * @date 2025
  * @copyright HardFOC
  */
 
 #include "TestFramework.h"
-#include "utils/DigitalOutputGuard.h"
 #include "mcu/esp32/EspGpio.h"
+#include "utils/DigitalOutputGuard.h"
 
 static const char* TAG = "DIGITAL_OUTPUT_GUARD_Test";
 
@@ -88,13 +88,13 @@ static TestResults g_test_results;
 // Enable/disable specific test categories by setting to true or false
 
 // Core DigitalOutputGuard functionality tests
-static constexpr bool ENABLE_BASIC_TESTS = true;        // Basic RAII and state management
-static constexpr bool ENABLE_CONSTRUCTOR_TESTS = true;  // Constructor variants and error handling
-static constexpr bool ENABLE_STATE_TESTS = true;        // State transitions and GPIO control
+static constexpr bool ENABLE_BASIC_TESTS = true;          // Basic RAII and state management
+static constexpr bool ENABLE_CONSTRUCTOR_TESTS = true;    // Constructor variants and error handling
+static constexpr bool ENABLE_STATE_TESTS = true;          // State transitions and GPIO control
 static constexpr bool ENABLE_MOVE_SEMANTICS_TESTS = true; // Move operations and resource management
-static constexpr bool ENABLE_EDGE_CASE_TESTS = true;    // Edge cases and error conditions
-static constexpr bool ENABLE_CONCURRENT_TESTS = true;   // Concurrent access testing
-static constexpr bool ENABLE_PERFORMANCE_TESTS = true;  // Performance and stress testing
+static constexpr bool ENABLE_EDGE_CASE_TESTS = true;      // Edge cases and error conditions
+static constexpr bool ENABLE_CONCURRENT_TESTS = true;     // Concurrent access testing
+static constexpr bool ENABLE_PERFORMANCE_TESTS = true;    // Performance and stress testing
 
 // Test GPIO pins - using only 3 pins for all tests
 static constexpr hf_pin_num_t TEST_GPIO_PIN_1 = 2;
@@ -293,7 +293,7 @@ bool test_digital_output_guard_null_pointer_handling() noexcept {
   }
 
   if (guard.GetLastError() != hf_gpio_err_t::GPIO_ERR_NULL_POINTER) {
-    ESP_LOGE(TAG, "Expected GPIO_ERR_NULL_POINTER, got: %d", 
+    ESP_LOGE(TAG, "Expected GPIO_ERR_NULL_POINTER, got: %d",
              static_cast<int>(guard.GetLastError()));
     return false;
   }
@@ -358,12 +358,14 @@ bool test_digital_output_guard_no_ensure_output_mode() noexcept {
   DigitalOutputGuard guard(test_gpio, false);
 
   if (guard.IsValid()) {
-    ESP_LOGE(TAG, "DigitalOutputGuard should not be valid with input mode GPIO and ensure_output_mode=false");
+    ESP_LOGE(
+        TAG,
+        "DigitalOutputGuard should not be valid with input mode GPIO and ensure_output_mode=false");
     return false;
   }
 
   if (guard.GetLastError() != hf_gpio_err_t::GPIO_ERR_DIRECTION_MISMATCH) {
-    ESP_LOGE(TAG, "Expected GPIO_ERR_DIRECTION_MISMATCH, got: %d", 
+    ESP_LOGE(TAG, "Expected GPIO_ERR_DIRECTION_MISMATCH, got: %d",
              static_cast<int>(guard.GetLastError()));
     return false;
   }
@@ -637,8 +639,8 @@ bool test_digital_output_guard_multiple_guards_same_gpio() noexcept {
   hf_gpio_err_t result2 = guard2.SetActive();
 
   if (result1 != hf_gpio_err_t::GPIO_SUCCESS || result2 != hf_gpio_err_t::GPIO_SUCCESS) {
-    ESP_LOGE(TAG, "Multiple guards failed to control same GPIO: %d, %d", 
-             static_cast<int>(result1), static_cast<int>(result2));
+    ESP_LOGE(TAG, "Multiple guards failed to control same GPIO: %d, %d", static_cast<int>(result1),
+             static_cast<int>(result2));
     return false;
   }
 
@@ -708,16 +710,17 @@ bool test_digital_output_guard_concurrent_access() noexcept {
   // - Measures thread safety and race condition prevention
   // Expected: All 300 operations complete successfully without race conditions
   // Significance: Validates thread-safe operation under concurrent load
-  // 
+  //
   // Test Pattern: 3 tasks × 100 operations = 300 total concurrent operations
   const int num_tasks = 3;
   const int expected_total = num_tasks * 100;
 
   // Create shared GPIO for concurrent testing
-  g_concurrent_test_gpio = new EspGpio(TEST_GPIO_PIN_1, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
-                                       hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
-                                       hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
-                                       hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_DOWN);
+  g_concurrent_test_gpio =
+      new EspGpio(TEST_GPIO_PIN_1, hf_gpio_direction_t::HF_GPIO_DIRECTION_OUTPUT,
+                  hf_gpio_active_state_t::HF_GPIO_ACTIVE_HIGH,
+                  hf_gpio_output_mode_t::HF_GPIO_OUTPUT_MODE_PUSH_PULL,
+                  hf_gpio_pull_mode_t::HF_GPIO_PULL_MODE_DOWN);
 
   if (!g_concurrent_test_gpio->EnsureInitialized()) {
     ESP_LOGE(TAG, "Failed to initialize concurrent test GPIO");
@@ -752,8 +755,8 @@ bool test_digital_output_guard_concurrent_access() noexcept {
 
   // Check results
   if (g_concurrent_guard_counter != expected_total) {
-    ESP_LOGE(TAG, "Concurrent guard access test failed: expected %d, got %d", 
-             expected_total, g_concurrent_guard_counter);
+    ESP_LOGE(TAG, "Concurrent guard access test failed: expected %d, got %d", expected_total,
+             g_concurrent_guard_counter);
     delete g_concurrent_test_gpio;
     return false;
   }
@@ -834,7 +837,7 @@ bool test_digital_output_guard_performance() noexcept {
 
   for (int i = 0; i < iterations; i++) {
     if (i % 2 == 0) {
-      guard.SetActive();   // Measures GPIO HIGH setting time
+      guard.SetActive(); // Measures GPIO HIGH setting time
     } else {
       guard.SetInactive(); // Measures GPIO LOW setting time
     }
@@ -869,7 +872,7 @@ bool test_digital_output_guard_stress() noexcept {
   // - Memory allocation/deallocation stress
   // Expected: < 200 μs per iteration (typically 5-15 μs on ESP32-C6)
   // Significance: Validates performance under realistic usage patterns
-  // 
+  //
   // Test Pattern: 2000 iterations × 3 GPIOs × 5 state changes = 30,000 operations
   const int num_gpios = 3;
   const hf_pin_num_t test_pins[num_gpios] = {TEST_GPIO_PIN_1, TEST_GPIO_PIN_2, TEST_GPIO_PIN_3};
@@ -896,11 +899,11 @@ bool test_digital_output_guard_stress() noexcept {
   uint64_t start_time = esp_timer_get_time();
 
   for (int i = 0; i < stress_iterations; i++) {
-    int gpio_index = i % num_gpios;  // Rotate through GPIO pins
-    
+    int gpio_index = i % num_gpios; // Rotate through GPIO pins
+
     // Create guard - measures RAII overhead under stress
     DigitalOutputGuard guard(*test_gpios[gpio_index]);
-    
+
     if (!guard.IsValid()) {
       ESP_LOGE(TAG, "Guard creation failed in stress test iteration %d", i);
       // Clean up
@@ -913,7 +916,7 @@ bool test_digital_output_guard_stress() noexcept {
     // Perform multiple state changes - measures GPIO control efficiency
     for (int j = 0; j < 5; j++) {
       if (j % 2 == 0) {
-        guard.SetActive();   // 5 state changes per iteration
+        guard.SetActive(); // 5 state changes per iteration
       } else {
         guard.SetInactive();
       }
@@ -970,21 +973,22 @@ extern "C" void app_main(void) {
       RUN_TEST_IN_TASK("creation", test_digital_output_guard_creation, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("raii_cleanup", test_digital_output_guard_raii_cleanup, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("manual_state_control", test_digital_output_guard_manual_state_control, 8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "manual_state_control", test_digital_output_guard_manual_state_control, 8192, 1);
       flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
       ENABLE_CONSTRUCTOR_TESTS, "DIGITAL OUTPUT GUARD CONSTRUCTOR TESTS", 5,
       // Constructor Variants and Error Handling Tests
       ESP_LOGI(TAG, "Running DigitalOutputGuard constructor tests...");
-      RUN_TEST_IN_TASK("pointer_constructor", test_digital_output_guard_pointer_constructor, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("null_pointer_handling", test_digital_output_guard_null_pointer_handling, 8192, 1);
+      RUN_TEST_IN_TASK("pointer_constructor", test_digital_output_guard_pointer_constructor, 8192,
+                       1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "null_pointer_handling", test_digital_output_guard_null_pointer_handling, 8192, 1);
       flip_test_progress_indicator();
       RUN_TEST_IN_TASK("ensure_output_mode", test_digital_output_guard_ensure_output_mode, 8192, 1);
-      flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("no_ensure_output_mode", test_digital_output_guard_no_ensure_output_mode, 8192, 1);
+      flip_test_progress_indicator(); RUN_TEST_IN_TASK(
+          "no_ensure_output_mode", test_digital_output_guard_no_ensure_output_mode, 8192, 1);
       flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
@@ -1011,7 +1015,8 @@ extern "C" void app_main(void) {
       ESP_LOGI(TAG, "Running DigitalOutputGuard edge case tests...");
       RUN_TEST_IN_TASK("invalid_operations", test_digital_output_guard_invalid_operations, 8192, 1);
       flip_test_progress_indicator();
-      RUN_TEST_IN_TASK("multiple_guards_same_gpio", test_digital_output_guard_multiple_guards_same_gpio, 8192, 1);
+      RUN_TEST_IN_TASK("multiple_guards_same_gpio",
+                       test_digital_output_guard_multiple_guards_same_gpio, 8192, 1);
       flip_test_progress_indicator(););
 
   RUN_TEST_SECTION_IF_ENABLED_WITH_PATTERN(
@@ -1034,14 +1039,10 @@ extern "C" void app_main(void) {
   print_test_summary(g_test_results, "DIGITAL_OUTPUT_GUARD", TAG);
 
   ESP_LOGI(TAG, "\n");
-  ESP_LOGI(TAG,
-           "╔══════════════════════════════════════════════════════════════════════════════╗");
-  ESP_LOGI(TAG,
-           "║                DIGITAL OUTPUT GUARD COMPREHENSIVE TEST SUITE COMPLETE        ║");
-  ESP_LOGI(TAG,
-           "║                         HardFOC Internal Interface                           ║");
-  ESP_LOGI(TAG, 
-           "╚══════════════════════════════════════════════════════════════════════════════╝");
+  ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
+  ESP_LOGI(TAG, "║                DIGITAL OUTPUT GUARD COMPREHENSIVE TEST SUITE COMPLETE        ║");
+  ESP_LOGI(TAG, "║                         HardFOC Internal Interface                           ║");
+  ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
 
   // Keep the system running
   while (true) {

--- a/examples/esp32/main/TestFramework.h
+++ b/examples/esp32/main/TestFramework.h
@@ -381,8 +381,7 @@ inline void print_test_section_header(const char* tag, const char* section_name,
     ESP_LOGI(tag, "\n");
     ESP_LOGI(tag,
              "╔══════════════════════════════════════════════════════════════════════════════╗");
-    ESP_LOGI(tag,
-             "║                              %s                                              ",
+    ESP_LOGI(tag, "║                              %s                                              ",
              section_name);
     ESP_LOGI(tag,
              "╠══════════════════════════════════════════════════════════════════════════════╣");
@@ -390,8 +389,7 @@ inline void print_test_section_header(const char* tag, const char* section_name,
     ESP_LOGI(tag, "\n");
     ESP_LOGI(tag,
              "╔══════════════════════════════════════════════════════════════════════════════╗");
-    ESP_LOGI(tag, 
-             "║                         %s (DISABLED)                                  ",
+    ESP_LOGI(tag, "║                         %s (DISABLED)                                  ",
              section_name);
     ESP_LOGI(tag,
              "╚══════════════════════════════════════════════════════════════════════════════╝");

--- a/examples/esp32/main/TimerComprehensiveTest.cpp
+++ b/examples/esp32/main/TimerComprehensiveTest.cpp
@@ -54,7 +54,8 @@ struct CallbackTestData {
 
   CallbackTestData()
       : call_count(0), last_call_time_us(0), min_interval_us(UINT64_MAX), max_interval_us(0),
-        total_interval_us(0), callback_executed(false), user_data_mismatch(false), expected_user_data(nullptr) {}
+        total_interval_us(0), callback_executed(false), user_data_mismatch(false),
+        expected_user_data(nullptr) {}
 
   void reset() {
     call_count = 0;
@@ -852,8 +853,7 @@ extern "C" void app_main(void) {
       ENABLE_STRESS_TESTS, "TIMER STRESS TESTS", 5,
       // Stress and resource management tests
       ESP_LOGI(TAG, "Running timer stress tests...");
-      RUN_TEST_IN_TASK("stress", test_timer_stress, 8192, 1);
-      flip_test_progress_indicator();
+      RUN_TEST_IN_TASK("stress", test_timer_stress, 8192, 1); flip_test_progress_indicator();
       RUN_TEST_IN_TASK("resource_management", test_timer_resource_management, 8192, 1);
       flip_test_progress_indicator(););
 
@@ -861,14 +861,10 @@ extern "C" void app_main(void) {
   print_test_summary(g_test_results, "TIMER", TAG);
 
   ESP_LOGI(TAG, "\n");
-  ESP_LOGI(TAG,
-            "╔══════════════════════════════════════════════════════════════════════════════╗");
-  ESP_LOGI(TAG,
-            "║                TIMER COMPREHENSIVE TEST SUITE COMPLETE                       ║");
-  ESP_LOGI(TAG,
-            "║                         HardFOC Internal Interface                           ║");
-  ESP_LOGI(TAG, 
-            "╚══════════════════════════════════════════════════════════════════════════════╝");
+  ESP_LOGI(TAG, "╔══════════════════════════════════════════════════════════════════════════════╗");
+  ESP_LOGI(TAG, "║                TIMER COMPREHENSIVE TEST SUITE COMPLETE                       ║");
+  ESP_LOGI(TAG, "║                         HardFOC Internal Interface                           ║");
+  ESP_LOGI(TAG, "╚══════════════════════════════════════════════════════════════════════════════╝");
 
   // Keep the system running
 

--- a/inc/base/BaseCan.h
+++ b/inc/base/BaseCan.h
@@ -24,10 +24,10 @@
 #pragma once
 
 #include "HardwareTypes.h"
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <string_view>
-#include <atomic>
 
 //--------------------------------------
 //  HardFOC CAN Error Codes (Table)
@@ -362,8 +362,8 @@ struct hf_can_statistics_t {
   std::atomic<hf_u32_t> error_warning_events{0};   ///< Error warning events
 
   // Performance metrics (atomic for ISR safety)
-  std::atomic<hf_u64_t> uptime_seconds{0};          ///< Total uptime in seconds
-  std::atomic<hf_u32_t> last_activity_timestamp{0}; ///< Last activity timestamp
+  std::atomic<hf_u64_t> uptime_seconds{0};                         ///< Total uptime in seconds
+  std::atomic<hf_u32_t> last_activity_timestamp{0};                ///< Last activity timestamp
   std::atomic<hf_can_err_t> last_error{hf_can_err_t::CAN_SUCCESS}; ///< Last error encountered
 
   // Queue statistics (atomic for ISR safety)

--- a/inc/mcu/esp32/EspCan.h
+++ b/inc/mcu/esp32/EspCan.h
@@ -510,8 +510,8 @@ private:
   const hf_esp_can_config_t config_; ///< TWAI node configuration
 
   // State flags (atomic)
-  std::atomic<bool> is_enabled_;     ///< Node enabled state
-  std::atomic<bool> is_recovering_;  ///< Bus recovery state
+  std::atomic<bool> is_enabled_;    ///< Node enabled state
+  std::atomic<bool> is_recovering_; ///< Bus recovery state
 
   // Thread safety (RtosMutex)
   mutable RtosMutex config_mutex_;   ///< Configuration mutex
@@ -545,4 +545,3 @@ private:
 };
 
 //==============================================//
-

--- a/src/mcu/esp32/EspPeriodicTimer.cpp
+++ b/src/mcu/esp32/EspPeriodicTimer.cpp
@@ -219,7 +219,7 @@ hf_u64_t EspPeriodicTimer::GetMinPeriod() const noexcept {
 hf_u64_t EspPeriodicTimer::GetMaxPeriod() const noexcept {
   // ESP32 timer practical maximum: UINT64_MAX/10 to avoid watchdog timeouts
   // UINT64_MAX/2 causes system to appear unresponsive and triggers watchdog
-  return UINT64_MAX / 10;  // ~58,494 years - practical maximum
+  return UINT64_MAX / 10; // ~58,494 years - practical maximum
 }
 
 hf_u64_t EspPeriodicTimer::GetResolution() const noexcept {
@@ -256,7 +256,7 @@ bool EspPeriodicTimer::CreateTimerHandle() noexcept {
 
   esp_timer_create_args_t timer_args = {};
   timer_args.callback = InternalTimerCallback; // Use static C bridge function
-  timer_args.arg = this; // Pass this pointer as user data
+  timer_args.arg = this;                       // Pass this pointer as user data
   timer_args.dispatch_method = ESP_TIMER_TASK;
   timer_args.name = "HardFOC_Timer";
 
@@ -313,7 +313,7 @@ void EspPeriodicTimer::InternalTimerCallback(void* arg) {
   // ISR-safe operations only - no logging, no complex operations
   // Just increment callback count and execute user callback
   timer->stats_.callback_count++;
-  
+
   // Execute user callback if valid (this is ISR-safe as it's just a function call)
   if (timer->HasValidCallback()) {
     timer->ExecuteCallback();


### PR DESCRIPTION
Add comprehensive CAN test documentation and clarify ESP32-C6 CAN-FD limitations to ensure all documentation reflects current capabilities.