### PR TITLE
Check markdown for dead links

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,11 +17,11 @@
 ## 📋 Table of Contents
 
 - [🎯 Overview](#-overview)
-- [🏗️ Workflow Architecture](#️-workflow-architecture)
+- [🏗️ Workflow Architecture](#-workflow-architecture)
 - [🚀 Available Workflows](#-available-workflows)
 - [🔧 Configuration](#-configuration)
 - [📊 Workflow Selection Guide](#-workflow-selection-guide)
-- [🛡️ Security Features](#️-security-features)
+- [🛡️ Security Features](#-security-features)
 - [⚡ Performance Optimization](#-performance-optimization)
 - [🔍 Troubleshooting](#-troubleshooting)
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Architecture**](#️-architecture)
+- [🏗️ **Architecture**](#-architecture)
 - [🔌 **Peripheral Interfaces**](#-peripheral-interfaces)
-- [🖥️ **MCU Support**](#️-mcu-support)
+- [🖥️ **MCU Support**](#-mcu-support)
 - [🚀 **Quick Start**](#-quick-start)
 - [📖 **API Documentation**](#-api-documentation)
 - [🔧 **Building**](#-building)
@@ -224,7 +224,7 @@ public:
 
 ### **1. Clone Repository**
 ```bash
-git clone https://github.com/your-repo/hf-internal-interface-wrap.git
+git clone <repository-url>
 cd hf-internal-interface-wrap
 ```
 
@@ -780,7 +780,7 @@ See [LICENSE](LICENSE) for full details.
 - 📚 [API Reference](docs/api/) - Complete interface documentation
 - 🔧 [ESP32 Implementations](docs/esp_api/) - Hardware-specific implementations
 - 🛠️ [Utility Classes](docs/utils/) - Advanced utility classes and helpers
-- 🔧 [Build System](examples/esp32/scripts/docs/) - Build and deployment guides
+- 🔧 [Build System](examples/esp32/) - Build and deployment guides
 - 🛡️ [CI/CD Pipeline](.github/workflows/) - Advanced automated workflows and testing
 
 ### **Development**
@@ -790,8 +790,6 @@ See [LICENSE](LICENSE) for full details.
 - 📊 [Configuration](examples/esp32/app_config.yml) - Application and build settings
 
 ### **Community**
-- 🐛 [Issues](https://github.com/your-repo/hf-internal-interface-wrap/issues) - Bug reports and feature requests
-- 💬 [Discussions](https://github.com/your-repo/hf-internal-interface-wrap/discussions) - Community support
 - 🤝 [Contributing](CONTRIBUTING.md) - Development guidelines
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,11 +18,11 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Architecture**](#️-architecture)
+- [🏗️ **Architecture**](#-architecture)
 - [🔧 **Type System**](#-type-system)
 - [✨ **Key Features**](#-key-features)
 - [🔌 **Supported Hardware**](#-supported-hardware)
-- [🏛️ **Design Principles**](#️-design-principles)
+- [🏛️ **Design Principles**](#-design-principles)
 - [📋 **API Reference**](#-api-reference)
 - [🚀 **Quick Start**](#-quick-start)
 - [📊 **Examples**](#-examples)
@@ -504,6 +504,6 @@ The GPL-3.0 license ensures that improvements to the HardFOC wrapper remain open
 
 **📞 Support**
 
-[💬 GitHub Discussions](../../discussions) | [🐛 Issue Tracker](../../issues) | [📧 HardFOC Support](mailto:support@hardfoc.com)
+[📧 HardFOC Support](mailto:support@hardfoc.com)
 
 </div>

--- a/docs/api/BaseBluetooth.md
+++ b/docs/api/BaseBluetooth.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/BaseLogger.md
+++ b/docs/api/BaseLogger.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/BaseNvs.md
+++ b/docs/api/BaseNvs.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/BasePeriodicTimer.md
+++ b/docs/api/BasePeriodicTimer.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/BasePio.md
+++ b/docs/api/BasePio.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)
@@ -828,7 +828,7 @@ spi.ConfigureDevice(99, config);  // Invalid device
 - **[📋 API Interfaces](README.md)** - Base classes and interfaces overview
 - **[🔧 ESP32 Implementations](../esp_api/README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](../security/README.md)** - Security implementation
+- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Related Documentation**
 

--- a/docs/api/BaseTemperature.md
+++ b/docs/api/BaseTemperature.md
@@ -17,11 +17,11 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)
-- [🌡️ **Temperature Units**](#️-temperature-units)
+- [🌡️ **Temperature Units**](#-temperature-units)
 - [📊 **Usage Examples**](#-usage-examples)
 - [🧪 **Best Practices**](#-best-practices)
 

--- a/docs/api/BaseUart.md
+++ b/docs/api/BaseUart.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Class Hierarchy**](#️-class-hierarchy)
+- [🏗️ **Class Hierarchy**](#-class-hierarchy)
 - [📋 **Error Codes**](#-error-codes)
 - [🔧 **Core API**](#-core-api)
 - [📊 **Data Structures**](#-data-structures)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,7 +15,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Architecture**](#️-architecture)
+- [🏗️ **Architecture**](#-architecture)
 - [📋 **Base Classes**](#-base-classes)
 - [🔧 **ESP32 Implementations**](#-esp32-implementations)
 - [🎯 **Type System**](#-type-system)
@@ -315,7 +315,7 @@ Comprehensive test suites for validating hardware interface implementations:
 - **[🔧 ESP32 Implementations](../esp_api/README.md)** - Hardware-specific implementations
 - **[🛠️ Utility Classes](../utils/README.md)** - Advanced utility classes and helpers
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](../security/README.md)** - Security implementation
+- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Base Class Documentation**
 

--- a/docs/esp_api/EspSpi.md
+++ b/docs/esp_api/EspSpi.md
@@ -17,7 +17,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Architecture**](#️-architecture)
+- [🏗️ **Architecture**](#-architecture)
 - [🔧 **Core Classes**](#-core-classes)
 - [📋 **Configuration**](#-configuration)
 - [📊 **Data Structures**](#-data-structures)
@@ -382,7 +382,7 @@ ESP_LOGI(TAG, "Transfer %zu bytes in %llu μs", length, transfer_time);
 - **[📋 API Interfaces](../api/README.md)** - Base classes and interfaces
 - **[🔧 ESP32 Implementations](README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](../security/README.md)** - Security implementation
+- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Related Documentation**
 

--- a/docs/esp_api/README.md
+++ b/docs/esp_api/README.md
@@ -16,7 +16,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Architecture**](#️-architecture)
+- [🏗️ **Architecture**](#-architecture)
 - [🔧 **Implementation Status**](#-implementation-status)
 - [📋 **Core Implementations**](#-core-implementations)
 - [⚡ **ESP32-C6 Features**](#-esp32-c6-features)
@@ -378,7 +378,7 @@ The ESP32-C6 implementations provide hardware-optimized versions of the HardFOC 
 - **[📋 API Interfaces](../api/README.md)** - Base classes and interfaces
 - **[🛠️ Utility Classes](../utils/README.md)** - Advanced utility classes and helpers
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](../security/README.md)** - Security implementation
+- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Related Documentation**
 

--- a/docs/utils/README.md
+++ b/docs/utils/README.md
@@ -15,7 +15,7 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Architecture**](#️-architecture)
+- [🏗️ **Architecture**](#-architecture)
 - [📋 **Utility Classes**](#-utility-classes)
 - [🔗 **Integration**](#-integration)
 - [📊 **Getting Started**](#-getting-started)
@@ -355,7 +355,7 @@ void setup_led_tasks() {
 - **[📋 API Reference](../api/README.md)** - Core interface documentation
 - **[🔧 ESP32 Implementations](../esp_api/README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](../security/README.md)** - Security implementation
+- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Utility Class Documentation**
 

--- a/examples/esp32/README.md
+++ b/examples/esp32/README.md
@@ -17,14 +17,14 @@
 ## 📚 **Table of Contents**
 
 - [🎯 **Overview**](#-overview)
-- [🏗️ **Build System Architecture**](#️-build-system-architecture)
+- [🏗️ **Build System Architecture**](#-build-system-architecture)
 - [🚀 **ESP-IDF Management**](#-esp-idf-management)
 - [📁 **Project Structure**](#-project-structure)
 - [🔧 **Quick Start**](#-quick-start)
 - [📖 **Detailed Usage**](#-detailed-usage)
-- [⚙️ **Configuration**](#️-configuration)
+- [⚙️ **Configuration**](#-configuration)
 - [📦 **Build Artifacts**](#-build-artifacts)
-- [🔄 **CI/CD Integration**](#️-cicd-integration)
+- [🔄 **CI/CD Integration**](#-cicd-integration)
 - [🔍 **Troubleshooting**](#-troubleshooting)
 - [📋 **Examples List**](#-examples-list)
 
@@ -852,7 +852,7 @@ This project is licensed under the GPL-3.0 License - see the [LICENSE](../LICENS
 
 ## 🔗 **Related Documentation**
 
-- [Main Project README](../README.md) - Project overview and architecture
+- [Main Project README](../../README.md) - Project overview and architecture
 - [API Documentation](../docs/) - Interface API documentation
 - [Test Documentation](docs/README.md) - Comprehensive test documentation and examples
 - [CI/CD Workflows](../.github/workflows/) - GitHub Actions workflows

--- a/examples/esp32/docs/README.md
+++ b/examples/esp32/docs/README.md
@@ -54,11 +54,9 @@ This directory contains comprehensive test documentation for all HardFOC ESP32 i
 
 ### **Wireless Technologies**
 - **[WiFi Testing](README_WIFI_TEST.md)** - Wireless networking, connectivity
-- **[Bluetooth Testing](README_BLUETOOTH_TEST.md)** - Short-range communication
 
 ### **System Features**
 - **[NVS Testing](README_NVS_TEST.md)** - Non-volatile storage, data persistence
-- **[Timer Testing](README_TIMER_TEST.md)** - Hardware timers, periodic events
 - **[Temperature Testing](README_TEMPERATURE_TEST.md)** - Thermal monitoring
 - **[Logger Testing](README_LOGGER_TEST.md)** - Logging system, debug output
 
@@ -81,9 +79,7 @@ This directory contains comprehensive test documentation for all HardFOC ESP32 i
 | [**I2C Test**](README_I2C_TEST.md) | ESP32-C6 I2C | Master mode, device scanning, error recovery | ✅ Complete |
 | [**CAN Test**](README_CAN_TEST.md) | ESP32-C6 + SN65 | Standard/Extended frames, filtering, error handling | ✅ Complete |
 | [**WiFi Test**](README_WIFI_TEST.md) | ESP32-C6 WiFi | Wireless networking, connectivity, security | ✅ Complete |
-| [**Bluetooth Test**](README_BLUETOOTH_TEST.md) | ESP32-C6 BT | Short-range communication, device discovery | ✅ Complete |
 | [**NVS Test**](README_NVS_TEST.md) | ESP32-C6 NVS | Non-volatile storage, data persistence | ✅ Complete |
-| [**Timer Test**](README_TIMER_TEST.md) | ESP32-C6 Timer | Hardware timers, periodic events, precision | ✅ Complete |
 | [**Temperature Test**](README_TEMPERATURE_TEST.md) | ESP32-C6 Temp | Thermal monitoring, calibration | ✅ Complete |
 | [**Logger Test**](README_LOGGER_TEST.md) | ESP32-C6 Logger | Logging system, debug output, levels | ✅ Complete |
 | [**ASCII Art Test**](README_ASCII_ART_TEST.md) | ESP32-C6 | ASCII art generation, display testing | ✅ Complete |
@@ -141,18 +137,18 @@ Most tests require minimal hardware:
 ## 🔗 **Related Documentation**
 
 ### **API Documentation**
-- [📋 Base Interfaces](../../docs/api/README.md) - Abstract base classes
-- [🔧 ESP32 Implementations](../../docs/esp_api/README.md) - Hardware-specific implementations
-- [🛠️ Utility Classes](../../docs/utils/README.md) - Helper classes and utilities
+- [📋 Base Interfaces](../../../docs/api/README.md) - Abstract base classes
+- [🔧 ESP32 Implementations](../../../docs/esp_api/README.md) - Hardware-specific implementations
+- [🛠️ Utility Classes](../../../docs/utils/README.md) - Helper classes and utilities
 
 ### **Specific Interface Documentation**
-- [BaseCan API](../../docs/api/BaseCan.md) - CAN bus interface
-- [EspCan Implementation](../../docs/esp_api/EspCan.md) - ESP32-C6 CAN implementation
-- [BaseGpio API](../../docs/api/BaseGpio.md) - GPIO interface
-- [BaseAdc API](../../docs/api/BaseAdc.md) - ADC interface
+- [BaseCan API](../../../docs/api/BaseCan.md) - CAN bus interface
+- [EspCan Implementation](../../../docs/esp_api/EspCan.md) - ESP32-C6 CAN implementation
+- [BaseGpio API](../../../docs/api/BaseGpio.md) - GPIO interface
+- [BaseAdc API](../../../docs/api/BaseAdc.md) - ADC interface
 
 ### **Project Documentation**
-- [Main Project README](../../README.md) - Project overview
+- [Main Project README](../../../README.md) - Project overview
 - [ESP32 Examples README](../README.md) - Build system and examples
 - [ESP-IDF Documentation](https://docs.espressif.com/projects/esp-idf/) - ESP-IDF reference
 

--- a/examples/esp32/docs/README_ASCII_ART_TEST.md
+++ b/examples/esp32/docs/README_ASCII_ART_TEST.md
@@ -521,4 +521,3 @@ matrix:
 - [ESP32-C6 Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf)
 - [ESP-IDF v5.5 Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/)
 - [ASCII Art Design Guidelines](https://textart.io/art)
-- [HardFOC ASCII Art Generator API Documentation](../../docs/api/ascii_art.md)

--- a/examples/esp32/docs/README_I2C_TEST.md
+++ b/examples/esp32/docs/README_I2C_TEST.md
@@ -4,7 +4,7 @@
 
 This directory contains the comprehensive I2C test suite (`I2cComprehensiveTest.cpp`) for the ESP32 implementation. For complete documentation including test details, API reference, and usage examples, see:
 
-**📖 [Complete I2C Documentation](../../../docs/esp_api/README_I2C_COMPREHENSIVE.md)**
+**📖 Complete I2C Documentation**
 
 ## Quick Test Information
 
@@ -112,7 +112,7 @@ static constexpr uint32_t FAST_PLUS_FREQ = 1000000;  // 1MHz
 
 ## For Complete Documentation
 
-**📖 See [README_I2C_COMPREHENSIVE.md](../../../docs/esp_api/README_I2C_COMPREHENSIVE.md) for:**
+**📖 See Complete I2C Documentation for:**
 
 - Complete API reference
 - Detailed test descriptions  

--- a/examples/esp32/docs/README_LOGGER_TEST.md
+++ b/examples/esp32/docs/README_LOGGER_TEST.md
@@ -441,4 +441,3 @@ matrix:
 - [ESP-IDF Logging Documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/system/log.html)
 - [ESP32-C6 Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf)
 - [ESP-IDF v5.5 Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/)
-- [HardFOC Logger API Documentation](../../docs/api/logger.md)

--- a/examples/esp32/docs/README_SPI_TEST.md
+++ b/examples/esp32/docs/README_SPI_TEST.md
@@ -338,7 +338,6 @@ The test suite provides comprehensive debug output:
 - **[📋 API Interfaces](../../../docs/api/README.md)** - Base classes and interfaces
 - **[🔧 ESP32 Implementations](../../../docs/esp_api/README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](README.md)** - Testing and validation overview
-- **[🔒 Security Features](../../../docs/security/README.md)** - Security implementation
 
 ### **Related Documentation**
 

--- a/examples/esp32/docs/README_TEMPERATURE_TEST.md
+++ b/examples/esp32/docs/README_TEMPERATURE_TEST.md
@@ -548,4 +548,3 @@ matrix:
 - [ESP32-C6 Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf)
 - [ESP-IDF v5.5 Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/)
 - [Temperature Sensor Calibration Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-guides/temp_sensor.html)
-- [HardFOC Temperature API Documentation](../../docs/api/temperature.md)

--- a/examples/esp32/docs/README_WIFI_TEST.md
+++ b/examples/esp32/docs/README_WIFI_TEST.md
@@ -209,5 +209,4 @@ The test suite is designed to be integrated into continuous integration pipeline
 
 - [EspWifi API Reference](../../../docs/esp_api/EspWifi.md)
 - [BaseWifi API Reference](../../../docs/api/BaseWifi.md)
-- [Test Framework Documentation](../TestFramework.h)
 - [ESP-IDF WiFi Driver](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/network/esp_wifi.html)


### PR DESCRIPTION
Fix 60 dead links in markdown documentation to ensure all links are valid and CI/CD checks pass.

The dead links were caused by incorrect anchor generation (due to emojis and formatting in headers), incorrect relative file paths, and references to non-existent files or placeholder external URLs. This PR corrects these issues across various documentation files.