### PR TITLE
Check documentation for dead links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -254,7 +254,7 @@ Our comprehensive documentation is organized into logical sections for easy navi
 | **[📋 API Interfaces](api/README.md)** | Base classes and abstract interfaces | Complete API reference with examples |
 | **[🔧 ESP32 Implementations](esp_api/README.md)** | ESP32-C6 specific implementations | Hardware-specific optimizations and features |
 | **[🛠️ Utility Classes](utils/README.md)** | Advanced utility classes and helpers | RAII patterns, safety mechanisms, and convenience wrappers |
-| **[🧪 Test Suites](../../examples/esp32/docs/README.md)** | Test documentation and examples | Test suites and examples |
+| **[🧪 Test Suites](../examples/esp32/docs/README.md)** | Test documentation and examples | Test suites and examples |
 
 
 ### 🏛️ **Core Interfaces for HardFOC Boards**
@@ -500,7 +500,7 @@ The GPL-3.0 license ensures that improvements to the HardFOC wrapper remain open
 
 **📚 Documentation Navigation**
 
-[📋 API Interfaces](api/README.md) | [🔧 ESP32 Implementations](esp_api/README.md) | [🛠️ Utility Classes](utils/README.md) | [🧪 Test Suites](../../examples/esp32/docs/README.md)
+[📋 API Interfaces](api/README.md) | [🔧 ESP32 Implementations](esp_api/README.md) | [🛠️ Utility Classes](utils/README.md) | [🧪 Test Suites](../examples/esp32/docs/README.md)
 
 **📞 Support**
 

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -828,7 +828,6 @@ spi.ConfigureDevice(99, config);  // Invalid device
 - **[📋 API Interfaces](README.md)** - Base classes and interfaces overview
 - **[🔧 ESP32 Implementations](../esp_api/README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Related Documentation**
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -315,7 +315,6 @@ Comprehensive test suites for validating hardware interface implementations:
 - **[🔧 ESP32 Implementations](../esp_api/README.md)** - Hardware-specific implementations
 - **[🛠️ Utility Classes](../utils/README.md)** - Advanced utility classes and helpers
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Base Class Documentation**
 

--- a/docs/esp_api/EspSpi.md
+++ b/docs/esp_api/EspSpi.md
@@ -20,7 +20,6 @@
 - [🏗️ **Architecture**](#-architecture)
 - [🔧 **Core Classes**](#-core-classes)
 - [📋 **Configuration**](#-configuration)
-- [📊 **Data Structures**](#-data-structures)
 - [📊 **Usage Examples**](#-usage-examples)
 - [🧪 **Best Practices**](#-best-practices)
 - [🔍 **Troubleshooting**](#-troubleshooting)
@@ -382,7 +381,6 @@ ESP_LOGI(TAG, "Transfer %zu bytes in %llu μs", length, transfer_time);
 - **[📋 API Interfaces](../api/README.md)** - Base classes and interfaces
 - **[🔧 ESP32 Implementations](README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Related Documentation**
 

--- a/docs/esp_api/README.md
+++ b/docs/esp_api/README.md
@@ -20,7 +20,6 @@
 - [🔧 **Implementation Status**](#-implementation-status)
 - [📋 **Core Implementations**](#-core-implementations)
 - [⚡ **ESP32-C6 Features**](#-esp32-c6-features)
-- [🧪 **Testing & Validation**](#-testing--validation)
 - [📊 **Performance Benchmarks**](#-performance-benchmarks)
 - [🔍 **Troubleshooting**](#-troubleshooting)
 
@@ -378,7 +377,6 @@ The ESP32-C6 implementations provide hardware-optimized versions of the HardFOC 
 - **[📋 API Interfaces](../api/README.md)** - Base classes and interfaces
 - **[🛠️ Utility Classes](../utils/README.md)** - Advanced utility classes and helpers
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Related Documentation**
 

--- a/docs/utils/README.md
+++ b/docs/utils/README.md
@@ -355,7 +355,6 @@ void setup_led_tasks() {
 - **[📋 API Reference](../api/README.md)** - Core interface documentation
 - **[🔧 ESP32 Implementations](../esp_api/README.md)** - Hardware-specific implementations
 - **[🧪 Test Suites](../../examples/esp32/docs/README.md)** - Testing and validation
-- **[🔒 Security Features](#security)** - Security implementation
 
 ### **Utility Class Documentation**
 

--- a/examples/esp32/README.md
+++ b/examples/esp32/README.md
@@ -846,16 +846,16 @@ Each application includes comprehensive test documentation:
 
 ## 📄 **License**
 
-This project is licensed under the GPL-3.0 License - see the [LICENSE](../LICENSE) file for details.
+This project is licensed under the GPL-3.0 License - see the [LICENSE](../../LICENSE) file for details.
 
 ---
 
 ## 🔗 **Related Documentation**
 
 - [Main Project README](../../README.md) - Project overview and architecture
-- [API Documentation](../docs/) - Interface API documentation
+- [API Documentation](../../docs/) - Interface API documentation
 - [Test Documentation](docs/README.md) - Comprehensive test documentation and examples
-- [CI/CD Workflows](../.github/workflows/) - GitHub Actions workflows
+- [CI/CD Workflows](../../.github/workflows/) - GitHub Actions workflows
 - [ESP-IDF Documentation](https://docs.espressif.com/projects/esp-idf/) - ESP-IDF reference
 
 ---


### PR DESCRIPTION
Fix 12 dead links in documentation by correcting relative paths and removing non-existent fragment links.
