### PR TITLE
Check recursive repo clone

### DIFF
--- a/.github/workflows/esp32-release-ci.yml
+++ b/.github/workflows/esp32-release-ci.yml
@@ -73,6 +73,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Add recursive submodule cloning to the release CI workflow to ensure submodules are available for release creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc965a5b-a00e-4dd3-bc84-63d7be3da289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc965a5b-a00e-4dd3-bc84-63d7be3da289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

