### PR TITLE
Organize and structure documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🤝 Contributing"
+description: "Guidelines and information for contributing to the HardFOC Internal Interface Wrapper"
+nav_order: 5
+parent: "🔧 HardFOC Internal Interface Layer"
+permalink: /CONTRIBUTING/
+---
+
 # 🤝 Contributing to HardFOC Internal Interface Wrapper
 
 Thank you for your interest in contributing to the HardFOC Internal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔧 HardFOC Internal Interface Layer"
+description: "Multi-MCU Peripheral Interface - Universal hardware abstraction layer enabling seamless MCU portability through unified peripheral APIs"
+nav_order: 1
+permalink: /
+has_children: true
+---
+
 # 🔧 HardFOC Internal Interface Layer: **Multi-MCU Peripheral Interface**
 
 <div align="center">

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: "📚 Documentation"
+description: "Complete documentation for the HardFOC Interface Wrapper - API reference, implementations, and utilities"
+nav_order: 2
+parent: "🔧 HardFOC Internal Interface Layer"
+permalink: /docs/
+has_children: true
+---
+
 # 🚀 HardFOC Internal Interface Wrapper
 
 <div align="center">

--- a/docs/api/BaseAdc.md
+++ b/docs/api/BaseAdc.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📊 BaseAdc"
+description: "Analog-to-Digital Conversion base class for multi-channel ADC operations"
+nav_order: 2
+parent: "📋 API Reference"
+permalink: /docs/api/BaseAdc/
+---
+
 # 📊 BaseAdc API Reference
 
 ## 📋 Navigation

--- a/docs/api/BaseBluetooth.md
+++ b/docs/api/BaseBluetooth.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📲 BaseBluetooth"
+description: "Bluetooth base class for Classic and BLE wireless communication"
+nav_order: 9
+parent: "📋 API Reference"
+permalink: /docs/api/BaseBluetooth/
+---
+
 # 📲 BaseBluetooth API Reference
 
 ## 🎯 Unified Bluetooth abstraction for Classic and BLE wireless communication

--- a/docs/api/BaseCan.md
+++ b/docs/api/BaseCan.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🚌 BaseCan"
+description: "Controller Area Network base class for automotive and industrial communication"
+nav_order: 7
+parent: "📋 API Reference"
+permalink: /docs/api/BaseCan/
+---
+
 # 🚌 BaseCan API Reference
 
 <div align="center">

--- a/docs/api/BaseGpio.md
+++ b/docs/api/BaseGpio.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔌 BaseGpio"
+description: "Unified GPIO base class for all digital GPIO implementations in the HardFOC system"
+nav_order: 1
+parent: "📋 API Reference"
+permalink: /docs/api/BaseGpio/
+---
+
 # 🔌 BaseGpio API Reference
 
 <div align="center">

--- a/docs/api/BaseI2c.md
+++ b/docs/api/BaseI2c.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔗 BaseI2c"
+description: "Inter-Integrated Circuit base class for I2C bus communication"
+nav_order: 4
+parent: "📋 API Reference"
+permalink: /docs/api/BaseI2c/
+---
+
 # 🚌 BaseI2c API Reference
 
 <div align="center">

--- a/docs/api/BaseLogger.md
+++ b/docs/api/BaseLogger.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📝 BaseLogger"
+description: "Logging system base class for multi-level logging and diagnostics"
+nav_order: 11
+parent: "📋 API Reference"
+permalink: /docs/api/BaseLogger/
+---
+
 # 📝 BaseLogger API Reference
 
 <div align="center">

--- a/docs/api/BaseNvs.md
+++ b/docs/api/BaseNvs.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "💾 BaseNvs"
+description: "Non-Volatile Storage base class for configuration and data persistence"
+nav_order: 10
+parent: "📋 API Reference"
+permalink: /docs/api/BaseNvs/
+---
+
 # 💾 BaseNvs API Reference
 
 <div align="center">

--- a/docs/api/BasePeriodicTimer.md
+++ b/docs/api/BasePeriodicTimer.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "⏰ BasePeriodicTimer"
+description: "High-precision timing base class for periodic operations and callbacks"
+nav_order: 12
+parent: "📋 API Reference"
+permalink: /docs/api/BasePeriodicTimer/
+---
+
 # ⏰ BasePeriodicTimer API Reference
 
 <div align="center">

--- a/docs/api/BasePio.md
+++ b/docs/api/BasePio.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🎛️ BasePio"
+description: "Programmable I/O base class for custom protocols and precise timing"
+nav_order: 13
+parent: "📋 API Reference"
+permalink: /docs/api/BasePio/
+---
+
 # 🎛️ BasePio API Reference
 
 <div align="center">

--- a/docs/api/BasePwm.md
+++ b/docs/api/BasePwm.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🎛️ BasePwm"
+description: "Pulse Width Modulation base class for motor control and servo operations"
+nav_order: 3
+parent: "📋 API Reference"
+permalink: /docs/api/BasePwm/
+---
+
 # 🎛️ BasePwm API Reference
 
 <div align="center">

--- a/docs/api/BaseSpi.md
+++ b/docs/api/BaseSpi.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔄 BaseSpi"
+description: "Serial Peripheral Interface base class for high-speed SPI communication"
+nav_order: 5
+parent: "📋 API Reference"
+permalink: /docs/api/BaseSpi/
+---
+
 # 🔌 BaseSpi API Reference
 
 <div align="center">

--- a/docs/api/BaseTemperature.md
+++ b/docs/api/BaseTemperature.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🌡️ BaseTemperature"
+description: "Temperature sensing base class for thermal monitoring and protection"
+nav_order: 14
+parent: "📋 API Reference"
+permalink: /docs/api/BaseTemperature/
+---
+
 # 🌡️ BaseTemperature API Reference
 
 <div align="center">

--- a/docs/api/BaseUart.md
+++ b/docs/api/BaseUart.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📡 BaseUart"
+description: "Universal Asynchronous Receiver-Transmitter base class for serial communication"
+nav_order: 6
+parent: "📋 API Reference"
+permalink: /docs/api/BaseUart/
+---
+
 # 📡 BaseUart API Reference
 
 <div align="center">

--- a/docs/api/BaseWifi.md
+++ b/docs/api/BaseWifi.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📶 BaseWifi"
+description: "WiFi base class for wireless network connectivity and IoT integration"
+nav_order: 8
+parent: "📋 API Reference"
+permalink: /docs/api/BaseWifi/
+---
+
 # 📶 BaseWifi API Reference
 
 <div align="center">

--- a/docs/api/HardwareTypes.md
+++ b/docs/api/HardwareTypes.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔧 HardwareTypes"
+description: "Platform-agnostic type definitions and validation functions for hardware abstraction"
+nav_order: 15
+parent: "📋 API Reference"
+permalink: /docs/api/HardwareTypes/
+---
+
 # HardwareTypes API Reference
 
 <div align="center">

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: "📋 API Reference"
+description: "Complete API reference for the HardFOC Interface Wrapper base classes and abstract interfaces"
+nav_order: 1
+parent: "📚 Documentation"
+permalink: /docs/api/
+has_children: true
+---
+
 # 🚀 HardFOC Interface Wrapper API Reference
 
 <div align="center">

--- a/docs/esp_api/EspAdc.md
+++ b/docs/esp_api/EspAdc.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📊 EspAdc"
+description: "ESP32-C6 ADC implementation with 12-bit resolution and hardware calibration"
+nav_order: 2
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspAdc/
+---
+
 # 📊 EspAdc API Reference
 
 <div align="center">

--- a/docs/esp_api/EspBluetooth.md
+++ b/docs/esp_api/EspBluetooth.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📲 EspBluetooth"
+description: "ESP32-C6 Bluetooth implementation with NimBLE stack for Classic and BLE support"
+nav_order: 9
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspBluetooth/
+---
+
 # ESP32C6 NimBLE Bluetooth Implementation
 
 <div align="center">

--- a/docs/esp_api/EspCan.md
+++ b/docs/esp_api/EspCan.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🚌 EspCan"
+description: "ESP32-C6 CAN implementation with TWAI controller for automotive communication"
+nav_order: 7
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspCan/
+---
+
 # EspCan API Reference
 
 <div align="center">

--- a/docs/esp_api/EspGpio.md
+++ b/docs/esp_api/EspGpio.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔌 EspGpio"
+description: "ESP32-C6 GPIO implementation with hardware-optimized features and advanced configuration"
+nav_order: 1
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspGpio/
+---
+
 # EspGpio API Reference
 
 <div align="center">

--- a/docs/esp_api/EspI2c.md
+++ b/docs/esp_api/EspI2c.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔗 EspI2c"
+description: "ESP32-C6 I2C implementation with bus-device architecture and multi-master support"
+nav_order: 4
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspI2c/
+---
+
 # EspI2c API Reference
 
 <div align="center">

--- a/docs/esp_api/EspLogger.md
+++ b/docs/esp_api/EspLogger.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📝 EspLogger"
+description: "ESP32-C6 Logger implementation with multi-output support and ESP-IDF integration"
+nav_order: 11
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspLogger/
+---
+
 # 📝 EspLogger API Reference
 
 <div align="center">

--- a/docs/esp_api/EspNvs.md
+++ b/docs/esp_api/EspNvs.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "💾 EspNvs"
+description: "ESP32-C6 NVS implementation with encryption and wear leveling support"
+nav_order: 10
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspNvs/
+---
+
 # EspNvs API Reference
 
 <div align="center">

--- a/docs/esp_api/EspPeriodicTimer.md
+++ b/docs/esp_api/EspPeriodicTimer.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "⏰ EspPeriodicTimer"
+description: "ESP32-C6 PeriodicTimer implementation with microsecond precision and hardware timers"
+nav_order: 12
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspPeriodicTimer/
+---
+
 # EspPeriodicTimer API Reference
 
 <div align="center">

--- a/docs/esp_api/EspPio.md
+++ b/docs/esp_api/EspPio.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🎛️ EspPio"
+description: "ESP32-C6 PIO implementation with RMT peripheral for custom protocols and precise timing"
+nav_order: 13
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspPio/
+---
+
 # EspPio Class API Reference
 
 ## Overview

--- a/docs/esp_api/EspPwm.md
+++ b/docs/esp_api/EspPwm.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🎛️ EspPwm"
+description: "ESP32-C6 PWM implementation with LEDC controller and hardware fade effects"
+nav_order: 3
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspPwm/
+---
+
 # EspPwm API Reference
 
 <div align="center">

--- a/docs/esp_api/EspSpi.md
+++ b/docs/esp_api/EspSpi.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🔄 EspSpi"
+description: "ESP32-C6 SPI implementation with full-duplex communication and DMA support"
+nav_order: 5
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspSpi/
+---
+
 # 🔌 EspSpi API Reference
 
 <div align="center">

--- a/docs/esp_api/EspTemperature.md
+++ b/docs/esp_api/EspTemperature.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🌡️ EspTemperature"
+description: "ESP32-C6 Temperature implementation with internal sensor and threshold monitoring"
+nav_order: 14
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspTemperature/
+---
+
 # 🌡️ EspTemperature API Reference
 
 <div align="center">

--- a/docs/esp_api/EspUart.md
+++ b/docs/esp_api/EspUart.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📡 EspUart"
+description: "ESP32-C6 UART implementation with hardware flow control and DMA integration"
+nav_order: 6
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspUart/
+---
+
 # EspUart API Reference
 
 <div align="center">

--- a/docs/esp_api/EspWifi.md
+++ b/docs/esp_api/EspWifi.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📶 EspWifi"
+description: "ESP32-C6 WiFi implementation with 802.11n support and WPA3 security"
+nav_order: 8
+parent: "🔧 ESP32 Implementations"
+permalink: /docs/esp_api/EspWifi/
+---
+
 # EspWifi API Reference
 
 <div align="center">

--- a/docs/esp_api/README.md
+++ b/docs/esp_api/README.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: "🔧 ESP32 Implementations"
+description: "ESP32-C6 specific implementations with ESP-IDF v5.5+ features and hardware optimizations"
+nav_order: 2
+parent: "📚 Documentation"
+permalink: /docs/esp_api/
+has_children: true
+---
+
 # 🔧 ESP32-C6 Implementations
 
 <div align="center">

--- a/docs/utils/AsciiArtGenerator.md
+++ b/docs/utils/AsciiArtGenerator.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🎨 AsciiArtGenerator"
+description: "ASCII art generation utility for console output and logging enhancement"
+nav_order: 2
+parent: "🛠️ Utilities"
+permalink: /docs/utils/AsciiArtGenerator/
+---
+
 # 🎨 AsciiArtGenerator API Reference
 
 <div align="center">

--- a/docs/utils/DigitalOutputGuard.md
+++ b/docs/utils/DigitalOutputGuard.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🛡️ DigitalOutputGuard"
+description: "RAII GPIO management utility for safe and automatic GPIO state control"
+nav_order: 1
+parent: "🛠️ Utilities"
+permalink: /docs/utils/DigitalOutputGuard/
+---
+
 # DigitalOutputGuard
 
 ## Overview

--- a/docs/utils/README.md
+++ b/docs/utils/README.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: "🛠️ Utilities"
+description: "Advanced utility classes and helper components that enhance the HardFOC Interface Wrapper ecosystem"
+nav_order: 3
+parent: "📚 Documentation"
+permalink: /docs/utils/
+has_children: true
+---
+
 # 🛠️ HardFOC Interface Wrapper - Utilities
 
 <div align="center">

--- a/examples/esp32/README.md
+++ b/examples/esp32/README.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: "🚀 ESP32 Examples"
+description: "Comprehensive examples with advanced build system for HardFOC ESP32 development"
+nav_order: 4
+parent: "🔧 HardFOC Internal Interface Layer"
+permalink: /examples/esp32/
+has_children: true
+---
+
 # 🚀 ESP32 Examples - HardFOC Internal Interface Wrapper
 
 <div align="center">

--- a/examples/esp32/docs/README.md
+++ b/examples/esp32/docs/README.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🧪 Test Documentation"
+description: "Comprehensive test documentation and validation for ESP32 implementations"
+nav_order: 1
+parent: "🚀 ESP32 Examples"
+permalink: /examples/esp32/docs/
+---
+
 # 🧪 ESP32 Test Documentation
 
 <div align="center">


### PR DESCRIPTION
Add Jekyll front matter to all markdown files to establish a proper documentation structure for CI publication.
