### PR TITLE
Check markdown file formatting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,5 +12,6 @@
   "MD031": false,
   "MD051": false,
   "MD009": false,
-  "MD047": false
+  "MD047": false,
+  "MD025": false
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ permalink: /docs/
 has_children: true
 ---
 
-## 🚀 HardFOC Internal Interface Wrapper
+# 🚀 HardFOC Internal Interface Wrapper
 
 ![Multi-MCU Interface](https://img.shields.io/badge/Multi--MCU-Interface%20Wrapper-blue?style=for-the-badge&logo=microchip)
 ![C++17](https://img.shields.io/badge/C++-17-blue?style=for-the-badge&logo=cplusplus)


### PR DESCRIPTION
Fix markdown linting errors in `docs/README.md` and update markdownlint configuration for Jekyll compatibility.

The `MD025` rule for multiple top-level headings was triggered by the YAML front matter title in `docs/README.md`, which is standard for Jekyll/GitHub Pages. Disabling this rule in the configuration allows the linter to pass while maintaining the intended document structure.