### PR TITLE
Fix doxygen examples for esp32

### DIFF
--- a/inc/base/BaseAdc.h
+++ b/inc/base/BaseAdc.h
@@ -14,6 +14,10 @@
  * controller types, making the system extensible and maintainable.
  *
  * @note This is a header-only abstract base class.
+ *
+ * @example AdcComprehensiveTest.cpp
+ * This example demonstrates comprehensive ADC testing including basic operations,
+ * calibration, continuous conversion, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/base/BaseGpio.h
+++ b/inc/base/BaseGpio.h
@@ -16,6 +16,10 @@
  *
  * @note This class is not thread-safe. Use appropriate synchronization if
  * accessed from multiple contexts.
+ *
+ * @example GpioComprehensiveTest.cpp
+ * This example demonstrates comprehensive GPIO testing including basic operations,
+ * advanced features, interrupts, power management, and hardware-specific capabilities.
  */
 
 #pragma once

--- a/inc/base/BaseI2c.h
+++ b/inc/base/BaseI2c.h
@@ -14,6 +14,10 @@
  * @note This is a header-only abstract base class following the same pattern as BaseCan.
  * @note Users should program against this interface, not specific implementations.
  * @note Each BaseI2c instance represents a specific I2C device, not the I2C bus itself.
+ *
+ * @example I2cComprehensiveTest.cpp
+ * This example demonstrates comprehensive I2C testing including device communication,
+ * error handling, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/base/BaseLogger.h
+++ b/inc/base/BaseLogger.h
@@ -14,6 +14,10 @@
  * @copyright HardFOC
  *
  * @note This class is thread-safe and designed for concurrent access.
+ *
+ * @example LoggerComprehensiveTest.cpp
+ * This example demonstrates comprehensive logging testing including multiple log levels,
+ * output destinations, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/base/BasePwm.h
+++ b/inc/base/BasePwm.h
@@ -12,6 +12,10 @@
  *
  * @note This is a header-only abstract base class following the same pattern as BaseCan/BaseAdc.
  * @note Users should program against this interface, not specific implementations.
+ *
+ * @example PwmComprehensiveTest.cpp
+ * This example demonstrates comprehensive PWM testing including signal generation,
+ * frequency control, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/base/BaseSpi.h
+++ b/inc/base/BaseSpi.h
@@ -15,6 +15,10 @@
  * @note This is a header-only abstract base class following the same pattern as BaseCan.
  * @note Users should program against this interface, not specific implementations.
  * @note Each BaseSpi instance represents a specific SPI device, not the SPI bus itself.
+ *
+ * @example SpiComprehensiveTest.cpp
+ * This example demonstrates comprehensive SPI testing including device communication,
+ * transfer management, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/base/BaseUart.h
+++ b/inc/base/BaseUart.h
@@ -13,6 +13,10 @@
  *
  * @note This is a header-only abstract base class following the same pattern as BaseCan.
  * @note Users should program against this interface, not specific implementations.
+ *
+ * @example UartComprehensiveTest.cpp
+ * This example demonstrates comprehensive UART testing including serial communication,
+ * flow control, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/base/BaseWifi.h
+++ b/inc/base/BaseWifi.h
@@ -15,6 +15,10 @@
  *
  * @note This class is not thread-safe. Use appropriate synchronization if
  * accessed from multiple contexts.
+ *
+ * @example WifiComprehensiveTest.cpp
+ * This example demonstrates comprehensive WiFi testing including station and access point modes,
+ * security configurations, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/mcu/esp32/EspAdc.h
+++ b/inc/mcu/esp32/EspAdc.h
@@ -21,6 +21,10 @@
  * @note Supports ESP32-C6, ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-H2
  * @note Each EspAdc instance represents a single ADC unit
  * @note Higher-level applications should instantiate multiple EspAdc objects for multi-unit boards
+ *
+ * @example AdcComprehensiveTest.cpp
+ * This example demonstrates comprehensive ADC testing including basic operations,
+ * calibration, continuous conversion, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/mcu/esp32/EspGpio.h
+++ b/inc/mcu/esp32/EspGpio.h
@@ -12,6 +12,10 @@
  * @author Nebiyu Tadesse
  * @date 2025
  * @copyright HardFOC
+ *
+ * @example GpioComprehensiveTest.cpp
+ * This example demonstrates comprehensive GPIO testing including basic operations,
+ * advanced features, interrupts, power management, and hardware-specific capabilities.
  */
 
 #pragma once

--- a/inc/mcu/esp32/EspI2c.h
+++ b/inc/mcu/esp32/EspI2c.h
@@ -22,6 +22,10 @@
  * - **Comprehensive Error Handling**: Proper error conversion and reporting
  * - **Resource Management**: Automatic cleanup and proper resource lifecycle
  *
+ * @example I2cComprehensiveTest.cpp
+ * This example demonstrates comprehensive I2C testing including device communication,
+ * error handling, and hardware-specific capabilities for ESP32-C6.
+ *
  * @section performance Performance Characteristics:
  * - Standard Mode: 100 kHz
  * - Fast Mode: 400 kHz

--- a/inc/mcu/esp32/EspSpi.h
+++ b/inc/mcu/esp32/EspSpi.h
@@ -25,6 +25,10 @@
  * @note This implementation fully complies with ESP-IDF v5.5 SPI Master driver API
  * @note Supports ESP32C6 hardware features including dual/quad/octal SPI modes
  * @note Thread-safe operations using RTOS mutex protection
+ *
+ * @example SpiComprehensiveTest.cpp
+ * This example demonstrates comprehensive SPI testing including device communication,
+ * transfer management, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once

--- a/inc/mcu/esp32/EspUart.h
+++ b/inc/mcu/esp32/EspUart.h
@@ -15,6 +15,10 @@
  * @note Supports ESP32-C6, ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-H2
  * @note Each EspUart instance represents a single UART port
  * @note Higher-level applications should instantiate multiple EspUart objects for multi-port boards
+ *
+ * @example UartComprehensiveTest.cpp
+ * This example demonstrates comprehensive UART testing including serial communication,
+ * flow control, and hardware-specific capabilities for ESP32-C6.
  */
 
 #pragma once


### PR DESCRIPTION
Add `@example` Doxygen commands to header files to link existing examples to class documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e37154a-809e-4663-a3fb-04454a26cfa3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e37154a-809e-4663-a3fb-04454a26cfa3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

