### PR TITLE
Organize and document bluetooth code with doxygen

### DIFF
--- a/inc/base/HardwareTypes.h
+++ b/inc/base/HardwareTypes.h
@@ -1,5 +1,6 @@
 /**
  * @file HardwareTypes.h
+ * @ingroup core
  * @brief Platform-agnostic hardware type definitions for the HardFOC system.
  *
  * This file defines platform-agnostic types used by base interface classes.
@@ -13,6 +14,14 @@
  *
  * @note These types are designed to be platform-independent and should not include
  *       any MCU-specific headers or definitions.
+ */
+
+/**
+ * @defgroup core Core Module
+ * @brief Core types and definitions for the HardFOC system.
+ * @details This module provides the fundamental types and definitions used throughout
+ *          the HardFOC system, including hardware types, platform detection, and
+ *          common data structures.
  */
 
 #pragma once

--- a/inc/mcu/esp32/EspAdc.h
+++ b/inc/mcu/esp32/EspAdc.h
@@ -1,5 +1,6 @@
 /**
  * @file EspAdc.h
+ * @ingroup adc
  * @brief ESP32 ADC implementation for the HardFOC system.
  *
  * This file contains the ESP32 ADC implementation that extends the BaseAdc

--- a/inc/mcu/esp32/EspCan.h
+++ b/inc/mcu/esp32/EspCan.h
@@ -1,5 +1,6 @@
 /**
  * @file EspCan.h
+ * @ingroup can
  * @brief ESP32 CAN (TWAI) implementation for the HardFOC system - ESP-IDF v5.5 Compatible.
  *
  * This file contains the ESP32 CAN (TWAI) implementation that extends the BaseCan

--- a/inc/mcu/esp32/EspGpio.h
+++ b/inc/mcu/esp32/EspGpio.h
@@ -1,5 +1,6 @@
 /**
  * @file EspGpio.h
+ * @ingroup gpio
  * @brief Advanced MCU-specific implementation of the unified BaseGpio class with ESP32C6/ESP-IDF
  * v5.5+ features.
  *

--- a/inc/mcu/esp32/EspI2c.h
+++ b/inc/mcu/esp32/EspI2c.h
@@ -3,6 +3,7 @@
 
 /**
  * @file EspI2c.h
+ * @ingroup i2c
  * @brief Advanced ESP32-integrated I2C controller for ESP-IDF v5.5+ with proper bus-device
  * architecture.
  *

--- a/inc/mcu/esp32/EspNvs.h
+++ b/inc/mcu/esp32/EspNvs.h
@@ -1,5 +1,6 @@
 /**
  * @file EspNvs.h
+ * @ingroup nvs
  * @brief World-class ESP32-C6 NVS storage implementation with ESP-IDF v5.5+ features.
  *
  * This header provides a production-ready NVS implementation for microcontrollers with

--- a/inc/mcu/esp32/EspPeriodicTimer.h
+++ b/inc/mcu/esp32/EspPeriodicTimer.h
@@ -1,5 +1,6 @@
 /**
  * @file EspPeriodicTimer.h
+ * @ingroup timer
  * @brief MCU-integrated periodic timer implementation.
  *
  * This header provides a periodic timer implementation for microcontrollers with

--- a/inc/mcu/esp32/EspPio.h
+++ b/inc/mcu/esp32/EspPio.h
@@ -1,5 +1,6 @@
 /**
  * @file EspPio.h
+ * @ingroup pio
  * @brief ESP32C6 RMT-based Programmable IO Channel implementation with ESP-IDF v5.5+ features.
  *
  * This header provides a comprehensive PIO implementation for ESP32C6 microcontrollers using

--- a/inc/mcu/esp32/EspPwm.h
+++ b/inc/mcu/esp32/EspPwm.h
@@ -1,5 +1,6 @@
 /**
  * @file EspPwm.h
+ * @ingroup pwm
  * @brief ESP32C6 LEDC (PWM) controller implementation for the HardFOC system.
  *
  * This header provides a comprehensive PWM implementation for ESP32C6 using the

--- a/inc/mcu/esp32/EspSpi.h
+++ b/inc/mcu/esp32/EspSpi.h
@@ -1,5 +1,6 @@
 /**
  * @file EspSpi.h
+ * @ingroup spi
  * @brief Advanced MCU-integrated SPI controller implementation with ESP32C6/ESP-IDF v5.5+ features.
  *
  * This header provides a comprehensive SPI implementation that utilizes all the advanced

--- a/inc/mcu/esp32/EspTemperature.h
+++ b/inc/mcu/esp32/EspTemperature.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTemperature.h
+ * @ingroup temperature
  * @brief ESP32-C6 internal temperature sensor implementation for the HardFOC system.
  *
  * This file contains the declaration of the EspTemperature class that extends the

--- a/inc/mcu/esp32/EspUart.h
+++ b/inc/mcu/esp32/EspUart.h
@@ -1,5 +1,6 @@
 /**
  * @file EspUart.h
+ * @ingroup uart
  * @brief ESP32 UART implementation for the HardFOC system.
  *
  * This file provides a comprehensive UART implementation for ESP32 variants using the

--- a/inc/mcu/esp32/EspWifi.h
+++ b/inc/mcu/esp32/EspWifi.h
@@ -1,5 +1,6 @@
 /**
  * @file EspWifi.h
+ * @ingroup wifi
  * @brief Advanced ESP32 implementation of the unified BaseWifi class with ESP-IDF v5.5+ features.
  *
  * This file provides concrete implementations of the unified BaseWifi class

--- a/inc/mcu/esp32/utils/EspTypes.h
+++ b/inc/mcu/esp32/utils/EspTypes.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes.h
+ * @ingroup esp32_types
  * @brief Consolidated MCU-specific type definitions for hardware abstraction (hf_* types).
  *
  * This header consolidates all MCU-specific types and constants by including
@@ -23,6 +24,14 @@
  * @note All interface classes (CAN, UART, I2C, SPI, GPIO, ADC, PWM, RMT) must use only these types.
  * @note This implementation is verified against ESP-IDF v5.5+ documentation and supports all latest
  * features.
+ */
+
+/**
+ * @defgroup esp32_types ESP32 Type Definitions
+ * @brief ESP32-specific type definitions and hardware abstraction types.
+ * @details This module provides ESP32-specific type definitions for all hardware peripherals
+ *          including ADC, Bluetooth, CAN, GPIO, I2C, NVS, PIO, PWM, SPI, Timer, UART, and WiFi.
+ *          These types provide a clean abstraction layer over ESP-IDF APIs.
  */
 
 #pragma once

--- a/inc/mcu/esp32/utils/EspTypes_ADC.h
+++ b/inc/mcu/esp32/utils/EspTypes_ADC.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_ADC.h
+ * @ingroup esp32_types
  * @brief ESP32 ADC type definitions for hardware abstraction.
  *
  * This header defines only the essential ADC-specific types and constants used by

--- a/inc/mcu/esp32/utils/EspTypes_Base.h
+++ b/inc/mcu/esp32/utils/EspTypes_Base.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_Base.h
+ * @ingroup esp32_types
  * @brief ESP32 base type definitions for hardware abstraction.
  *
  * This header defines the common base types and includes that are shared across

--- a/inc/mcu/esp32/utils/EspTypes_CAN.h
+++ b/inc/mcu/esp32/utils/EspTypes_CAN.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_CAN.h
+ * @ingroup esp32_types
  * @brief ESP32 CAN type definitions for hardware abstraction.
  *
  * This header defines only the essential CAN-specific types and constants used by

--- a/inc/mcu/esp32/utils/EspTypes_GPIO.h
+++ b/inc/mcu/esp32/utils/EspTypes_GPIO.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_GPIO.h
+ * @ingroup esp32_types
  * @brief ESP32 GPIO type definitions for hardware abstraction.
  *
  * This header defines only the essential GPIO-specific types and constants used by

--- a/inc/mcu/esp32/utils/EspTypes_I2C.h
+++ b/inc/mcu/esp32/utils/EspTypes_I2C.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_I2C.h
+ * @ingroup esp32_types
  * @brief ESP32 I2C type definitions for hardware abstraction.
  *
  * This header defines only the essential I2C-specific types used by

--- a/inc/mcu/esp32/utils/EspTypes_NVS.h
+++ b/inc/mcu/esp32/utils/EspTypes_NVS.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_NVS.h
+ * @ingroup esp32_types
  * @brief ESP32 NVS type definitions for hardware abstraction.
  *
  * This header defines only the essential NVS-specific types used by

--- a/inc/mcu/esp32/utils/EspTypes_PIO.h
+++ b/inc/mcu/esp32/utils/EspTypes_PIO.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_PIO.h
+ * @ingroup esp32_types
  * @brief ESP32 PIO/RMT type definitions for hardware abstraction.
  *
  * This header defines only the essential PIO/RMT-specific types used by

--- a/inc/mcu/esp32/utils/EspTypes_PWM.h
+++ b/inc/mcu/esp32/utils/EspTypes_PWM.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_PWM.h
+ * @ingroup esp32_types
  * @brief ESP32 PWM type definitions for LEDC peripheral hardware abstraction.
  *
  * This header defines essential PWM-specific types and constants for the EspPwm

--- a/inc/mcu/esp32/utils/EspTypes_SPI.h
+++ b/inc/mcu/esp32/utils/EspTypes_SPI.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_SPI.h
+ * @ingroup esp32_types
  * @brief ESP32 SPI type definitions for hardware abstraction.
  *
  * This header defines only the essential SPI-specific types used by

--- a/inc/mcu/esp32/utils/EspTypes_Timer.h
+++ b/inc/mcu/esp32/utils/EspTypes_Timer.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_Timer.h
+ * @ingroup esp32_types
  * @brief ESP32 timer type definitions for hardware abstraction.
  *
  * This header defines only the essential timer-specific types used by

--- a/inc/mcu/esp32/utils/EspTypes_UART.h
+++ b/inc/mcu/esp32/utils/EspTypes_UART.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_UART.h
+ * @ingroup esp32_types
  * @brief ESP32 UART type definitions for hardware abstraction.
  *
  * This header defines only the essential UART-specific types used by

--- a/inc/mcu/esp32/utils/EspTypes_WiFi.h
+++ b/inc/mcu/esp32/utils/EspTypes_WiFi.h
@@ -1,5 +1,6 @@
 /**
  * @file EspTypes_WiFi.h
+ * @ingroup esp32_types
  * @brief ESP32 WiFi type definitions for hardware abstraction.
  *
  * This header defines the ESP32-specific types, constants, and utility functions

--- a/inc/utils/AsciiArtGenerator.h
+++ b/inc/utils/AsciiArtGenerator.h
@@ -1,5 +1,6 @@
 /**
  * @file AsciiArtGenerator.h
+ * @ingroup utils
  * @brief Simple ASCII art generator.
  *
  * This file provides a simple ASCII art generator that creates
@@ -10,6 +11,17 @@
  * @author Nebiyu Tadesse
  * @date 2025
  * @copyright HardFOC
+ */
+
+/**
+ * @defgroup utils Utility Module
+ * @brief Utility classes and helper functions for the HardFOC system.
+ * @details This module provides various utility classes and functions including:
+ *          - ASCII art generation
+ *          - GPIO output guards and RAII patterns
+ *          - MCU platform selection and configuration
+ *          - Memory management utilities
+ *          - RTOS synchronization primitives
  */
 
 #pragma once

--- a/inc/utils/DigitalOutputGuard.h
+++ b/inc/utils/DigitalOutputGuard.h
@@ -1,5 +1,6 @@
 /**
  * @file DigitalOutputGuard.h
+ * @ingroup utils
  * @brief Header file for the DigitalOutputGuard class.
  *
  * The DigitalOutputGuard class ensures that a DigitalGpio instance is set to

--- a/inc/utils/McuSelect.h
+++ b/inc/utils/McuSelect.h
@@ -1,5 +1,6 @@
 /**
  * @file McuSelect.h
+ * @ingroup utils
  * @brief Centralized MCU platform selection and configuration header.
  *
  * This header provides a SINGLE POINT OF CONTROL for MCU platform selection.

--- a/inc/utils/RtosMutex.h
+++ b/inc/utils/RtosMutex.h
@@ -1,5 +1,6 @@
 /**
  * @file RtosMutex.h
+ * @ingroup utils
  * @brief Cross-platform RTOS mutex and synchronization primitives.
  *
  * This header provides platform-agnostic mutex, lock guard, and timing utilities

--- a/inc/utils/memory_utils.h
+++ b/inc/utils/memory_utils.h
@@ -1,3 +1,9 @@
+/**
+ * @file memory_utils.h
+ * @ingroup utils
+ * @brief Memory management utilities for exception-free design.
+ */
+
 #pragma once
 
 #include <memory>


### PR DESCRIPTION
Organize Doxygen documentation with `@ingroup` and `@defgroup` tags to enhance content generation and code navigation.

This PR systematically groups related files (base classes, MCU implementations, and utility files) into logical modules, making the generated Doxygen documentation more structured and easier to explore.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a9b04af-c6d2-45f1-89aa-6a5820b84332">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a9b04af-c6d2-45f1-89aa-6a5820b84332">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

