### PR TITLE
Fix missing feature_list.html include

### DIFF
--- a/_config/_config.yml
+++ b/_config/_config.yml
@@ -14,8 +14,8 @@ author:
   url: "https://github.com/n3b3x"
 
 # Directory configuration
-layouts_dir: docs/_layouts
-includes_dir: docs/_includes
+layouts_dir: _config/_layouts
+includes_dir: _config/_includes
 # sass:
 #   sass_dir: _config/_sass
 


### PR DESCRIPTION
Update Jekyll `includes_dir` and `layouts_dir` in `_config.yml` to resolve Liquid file not found errors.

The previous configuration incorrectly pointed to `docs/_includes` and `docs/_layouts`, while the actual files were located in `_config/_includes` and `_config/_layouts`. This caused Jekyll to fail in locating included files like `feature_list.html`.
